### PR TITLE
Continued CLI design

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wcc"
+name = "wash"
 version = "0.1.0"
 authors = ["Brooks Townsend <brooks.townsend@capitalone.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ SUBCOMMANDS:
     watch    Watch events on the lattice
 ```
 
-### oci
+### reg
 
 ```
 USAGE:
-    wash oci <SUBCOMMAND> <artifact>
+    wash reg <SUBCOMMAND> <artifact> [FLAGS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -149,4 +149,18 @@ SUBCOMMANDS:
 
 ARGS:
     <artifact>       URI of the artifact
+```
+
+### up
+Starts an interactive REPL session for waSCC development
+```
+USAGE:
+    wash up [FLAGS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help        Prints this message or the help of the given subcommand(s)
 ```

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ OPTIONS:
     -c, --cap <capabilities>...         Add custom capabilities
     -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
                                         off, the token will never expire
-    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an issuer key at `$HOME/.wcc/issuer.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/issuer.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an issuer key at `$HOME/.wcc/keys/issuer.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/keys/issuer.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
     -n, --name <name>                   A human-readable, descriptive name for the token
     -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
                                         left off, the token will be valid immediately
     -r, --rev <rev>                     Revision number
-    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/keys/module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/keys/module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
     -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
     -v, --ver <ver>                     Human-readable version string
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# wcc
-waSCC Controller - A single CLI to handle all of your waSCC tooling needs
+# wash
+waSCC Shell - A single CLI to handle all of your waSCC tooling needs
 
-## Using wcc
+## Using wash
 ```
-wcc <subcommand> [args]
+wash <subcommand> [args]
 ```
 
 ## Subcommands
@@ -12,7 +12,7 @@ wcc <subcommand> [args]
 
 ```
 USAGE:
-    wcc claims inspect [FLAGS] <file>
+    wash claims inspect [FLAGS] <file>
 
 FLAGS:
     -h, --help    Prints help information
@@ -24,7 +24,7 @@ ARGS:
 
 ```
 USAGE:
-    wcc claims sign [FLAGS] [OPTIONS] <source> <output> --name <name>
+    wash claims sign [FLAGS] [OPTIONS] <module> <output> --name <name>
 
 FLAGS:
     -f, --blob_store     Enable access to the blob store capability
@@ -42,23 +42,23 @@ OPTIONS:
     -c, --cap <capabilities>...         Add custom capabilities
     -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
                                         off, the token will never expire
-    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an account key at `$HOME/.wcc/keys/<project_name>_account.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/keys/<project_name>_account.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate an account key at `$HOME/.wash/keys/<module>_account.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wash/keys/<module>_account.nk`. You can also override this directory by setting the `WCC_HOME` environment variable.
     -n, --name <name>                   A human-readable, descriptive name for the token
     -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
                                         left off, the token will be valid immediately
     -r, --rev <rev>                     Revision number
-    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/keys/<project_name>_module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/keys/<project_name>_module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate a module key at `$HOME/.wash/keys/<module>_module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wash/keys/<module>_module.nk`. You can also override this directory by setting the `WCC_HOME` environment variable.
     -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
     -v, --ver <ver>                     Human-readable version string
 
 ARGS:
-    <source>    File to read
-    <output>    Target output file. Defaults to `<source_file_location>/<source_file_name>_signed.wasm`
+    <module>    WASM to read
+    <output>    Target output file. Defaults to `<module_location>/<module>_signed.wasm`
 ```
 
 ```
 USAGE:
-    wcc claims token <tokentype>
+    wash claims token <tokentype>
 
 FLAGS:
     -h, --help    Prints help information
@@ -67,29 +67,11 @@ ARGS:
     <tokentype>    The type of jwt to generate. May be Account, Actor, or Operator.
 ```
 
-### gantry
-
-```
-USAGE:
-    wcc gantry <SUBCOMMAND>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
-    download    Downloads an actor module from the registry
-    get         Query the Gantry registry
-    help        Prints this message or the help of the given subcommand(s)
-    put         Puts a token in the registry
-    upload      Uploads an actor module to the registry
-```
-
 ### keys
 
 ```
 USAGE:
-    wcc keys gen <keytype>
+    wash keys gen <keytype>
 
 FLAGS:
     -h, --help    Prints help information
@@ -100,13 +82,13 @@ ARGS:
 
 ```
 USAGE:
-    wcc keys get [OPTIONS] <keyname>
+    wash keys get [OPTIONS] <keyname>
 
 FLAGS:
     -h, --help      Prints help information
 
 OPTIONS:
-    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wcc/keys`, and can be overwritten by setting the WCC_HOME environment variable.
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WCC_HOME environment variable.
 
 ARGS:
     <keyname>   The name of the key to output
@@ -114,20 +96,20 @@ ARGS:
 
 ```
 USAGE:
-    wcc keys list [OPTIONS]
+    wash keys list [OPTIONS]
 
 FLAGS:
     -h, --help          Prints help information
 
 OPTIONS:
-    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wcc/keys`, and can be overwritten by setting the WCC_HOME environment variable.
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WCC_HOME environment variable.
 ```
 
 ### lattice
 
 ```
 USAGE:
-    wcc lattice [FLAGS] [OPTIONS] <SUBCOMMAND>
+    wash lattice [FLAGS] [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
@@ -148,4 +130,23 @@ SUBCOMMANDS:
     start    Hold a lattice auction for a given actor and start it if a suitable host is found
     stop     Tell a given host to terminate the given actor
     watch    Watch events on the lattice
+```
+
+### oci
+
+```
+USAGE:
+    wash oci <SUBCOMMAND> <artifact>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help        Prints this message or the help of the given subcommand(s)
+    pull        Downloads a blob from an OCI compliant registry
+    push        Uploads a blob to an OCI compliant registry
+
+ARGS:
+    <artifact>       URI of the artifact
 ```

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ OPTIONS:
     -c, --cap <capabilities>...         Add custom capabilities
     -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
                                         off, the token will never expire
-    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an issuer key at `$HOME/.wcc/keys/issuer.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/keys/issuer.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an account key at `$HOME/.wcc/keys/<project_name>_account.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/keys/<project_name>_account.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
     -n, --name <name>                   A human-readable, descriptive name for the token
     -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
                                         left off, the token will be valid immediately
     -r, --rev <rev>                     Revision number
-    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/keys/module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/keys/module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/keys/<project_name>_module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/keys/<project_name>_module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
     -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
     -v, --ver <ver>                     Human-readable version string
 
@@ -96,6 +96,31 @@ FLAGS:
 
 ARGS:
     <keytype>    The type of key pair to generate. May be Account, User, Module (Actor), Server, Operator, Cluster, Service (Capability Provider)
+```
+
+```
+USAGE:
+    wcc keys get [OPTIONS] <keyname>
+
+FLAGS:
+    -h, --help      Prints help information
+
+OPTIONS:
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wcc/keys`, and can be overwritten by setting the WCC_HOME environment variable.
+
+ARGS:
+    <keyname>   The name of the key to output
+```
+
+```
+USAGE:
+    wcc keys list [OPTIONS]
+
+FLAGS:
+    -h, --help          Prints help information
+
+OPTIONS:
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wcc/keys`, and can be overwritten by setting the WCC_HOME environment variable.
 ```
 
 ### lattice

--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ wcc <subcommand> [args]
 
 ```
 USAGE:
-    wcc claims token <keytype>
-
-FLAGS:
-    -h, --help    Prints help information
-
-ARGS:
-    <tokentype>    The type of jwt to generate. May be Account, Actor, or Operator.
-```
-
-```
-USAGE:
     wcc claims inspect [FLAGS] <file>
 
 FLAGS:
@@ -31,6 +20,51 @@ FLAGS:
 
 ARGS:
     <file>    The WASM file to inspect
+```
+
+```
+USAGE:
+    wcc claims sign [FLAGS] [OPTIONS] <source> <output> --name <name>
+
+FLAGS:
+    -f, --blob_store     Enable access to the blob store capability
+    -e, --events         Enable access to an append-only event stream provider
+    -z, --extras         Enable access to the extras functionality (random nos, guids, etc)
+        --help           Prints help information
+    -h, --http_client    Enable the HTTP client standard capability
+    -s, --http_server    Enable the HTTP server standard capability
+    -k, --keyvalue       Enable the Key/Value Store standard capability
+    -l, --logging        Enable access to logging capability
+    -g, --msg            Enable the Message broker standard capability
+    -p, --prov           Indicates whether the signed module is a capability provider instead of an actor (the default is actor)
+
+OPTIONS:
+    -c, --cap <capabilities>...         Add custom capabilities
+    -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
+                                        off, the token will never expire
+    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate an issuer key at `$HOME/.wcc/issuer.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wcc/issuer.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -n, --name <name>                   A human-readable, descriptive name for the token
+    -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
+                                        left off, the token will be valid immediately
+    -r, --rev <rev>                     Revision number
+    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wcc` will attempt to locate a module key at `$HOME/.wcc/module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wcc/module.nk`. You can override this directory by setting the `WCC_HOME` environment variable.
+    -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
+    -v, --ver <ver>                     Human-readable version string
+
+ARGS:
+    <source>    File to read
+    <output>    Target output file. Defaults to `<source_file_location>/<source_file_name>_signed.wasm`
+```
+
+```
+USAGE:
+    wcc claims token <tokentype>
+
+FLAGS:
+    -h, --help    Prints help information
+
+ARGS:
+    <tokentype>    The type of jwt to generate. May be Account, Actor, or Operator.
 ```
 
 ### gantry
@@ -89,41 +123,4 @@ SUBCOMMANDS:
     start    Hold a lattice auction for a given actor and start it if a suitable host is found
     stop     Tell a given host to terminate the given actor
     watch    Watch events on the lattice
-```
-
-### sign
-
-```
-USAGE:
-    wcc sign [FLAGS] [OPTIONS] <source> <output> --issuer <issuer-key-path> --name <name> --subject <subject-key-path>
-
-FLAGS:
-    -f, --blob_store     Enable access to the blob store capability
-    -e, --events         Enable access to an append-only event stream provider
-    -z, --extras         Enable access to the extras functionality (random nos, guids, etc)
-        --help           Prints help information
-    -h, --http_client    Enable the HTTP client standard capability
-    -s, --http_server    Enable the HTTP server standard capability
-    -k, --keyvalue       Enable the Key/Value Store standard capability
-    -l, --logging        Enable access to logging capability
-    -g, --msg            Enable the Message broker standard capability
-    -p, --prov           Indicates whether the signed module is a capability provider instead of an actor (the default
-                         is actor)
-
-OPTIONS:
-    -c, --cap <capabilities>...         Add custom capabilities
-    -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
-                                        off, the token will never expire
-    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file)
-    -n, --name <name>                   A human-readable, descriptive name for the token
-    -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
-                                        left off, the token will be valid immediately
-    -r, --rev <rev>                     Revision number
-    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file)
-    -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
-    -v, --ver <ver>                     Human-readable version string
-
-ARGS:
-    <source>    File to read
-    <output>    Target output file
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,19 @@
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+/// This renders appropriately with escape characters
 const ASCII: &str = "
- ___       __   ________  ________     
-|\\  \\     |\\  \\|\\   ____\\|\\   ____\\    
-\\ \\  \\    \\ \\  \\ \\  \\___|\\ \\  \\___|    
- \\ \\  \\  __\\ \\  \\ \\  \\    \\ \\  \\       
-  \\ \\  \\|\\__\\_\\  \\ \\  \\____\\ \\  \\____  
-   \\ \\____________\\ \\_______\\ \\_______\\
-    \\|____________|\\|_______|\\|_______|
+               __    ___   ___   __ _          _ _ 
+__      ____ _/ _\\  / __\\ / __\\ / _\\ |__   ___| | |
+\\ \\ /\\ / / _` \\ \\  / /   / /    \\ \\| '_ \\ / _ \\ | |
+ \\ V  V / (_| |\\ \\/ /___/ /___  _\\ \\ | | |  __/ | |
+  \\_/\\_/ \\__,_\\__/\\____/\\____/  \\__/_| |_|\\___|_|_|
 
 A single CLI to handle all of your waSCC tooling needs
 ";
 
 #[derive(Debug, Clone, StructOpt)]
-#[structopt(name = "wcc", about = ASCII)]
+#[structopt(name = "wash", about = ASCII)]
 struct Cli {
     #[structopt(flatten)]
     command: CliCommand,
@@ -22,32 +21,22 @@ struct Cli {
 
 #[derive(Debug, Clone, StructOpt)]
 enum CliCommand {
-    /// caps
-    #[structopt(name = "caps")]
-    Caps(CapsCommand),
-    /// gantry
-    #[structopt(name = "gantry")]
-    Gantry(GantryCommand),
+    /// claims
+    #[structopt(name = "claims")]
+    Claims(ClaimsCommand),
     /// keys
     #[structopt(name = "keys")]
     Keys(KeysCommand),
+    /// oci
+    #[structopt(name = "oci")]
+    OCI(OCICommand),
     /// lattice
     #[structopt(name = "lattice")]
     Lattice(LatticeCommand),
-    /// sign
-    #[structopt(name = "sign")]
-    Sign(SignCommand),
 }
 
 #[derive(Debug, Clone, StructOpt)]
-struct CapsCommand {
-    /// Sample path
-    #[structopt(short = "p", long = "path")]
-    path: PathBuf,
-}
-
-#[derive(Debug, Clone, StructOpt)]
-struct GantryCommand {
+struct ClaimsCommand {
     /// Sample path
     #[structopt(short = "p", long = "path")]
     path: PathBuf,
@@ -68,7 +57,7 @@ struct LatticeCommand {
 }
 
 #[derive(Debug, Clone, StructOpt)]
-struct SignCommand {
+struct OCICommand {
     /// Sample path
     #[structopt(short = "p", long = "path")]
     path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,9 @@ enum CliCommand {
     /// keys
     #[structopt(name = "keys")]
     Keys(KeysCommand),
-    /// oci
-    #[structopt(name = "oci")]
-    OCI(OCICommand),
+    /// reg
+    #[structopt(name = "reg")]
+    Reg(RegCommand),
     /// lattice
     #[structopt(name = "lattice")]
     Lattice(LatticeCommand),
@@ -57,7 +57,7 @@ struct LatticeCommand {
 }
 
 #[derive(Debug, Clone, StructOpt)]
-struct OCICommand {
+struct RegCommand {
     /// Sample path
     #[structopt(short = "p", long = "path")]
     path: PathBuf,


### PR DESCRIPTION
This PR moves the `sign` subcommand under `wcc claims`, as well as specifies more defaults for `wcc claims sign` to enable an easier initial onboarding to signing `wasm` files in wascc projects.