### PR TITLE
Migrate functionality from existing CLIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,12 @@ edition = "2018"
 
 [dependencies]
 structopt = "0.3.18"
-nkeys = "0.0.9" # TODO: Update to 0.0.11 after updating gantryclient
-wascap = "0.5.0"
-gantryclient = "0.1.0"
-latticeclient = "0.3.1"
+env_logger = "0.7.1"
+serde_json = "1.0.59"
+serde = { version = "1.0.117", features = ["derive"] }
+crossbeam = "0.7.3"
+
+nkeys = "0.0.11"
+latticeclient = { git = "https://github.com/wascc/lattice-client" } #TODO: Change to 0.4.0 once crate is published
+wascap = "0.5.1"
+term-table = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ OPTIONS:
     -c, --cap <capabilities>...         Add custom capabilities
     -x, --expires <expires-in-days>     Indicates the token expires in the given amount of days. If this option is left
                                         off, the token will never expire
-    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate an account key at `$HOME/.wash/keys/<module>_account.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wash/keys/<module>_account.nk`. You can also override this directory by setting the `WCC_HOME` environment variable.
+    -i, --issuer <issuer-key-path>      Issuer seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate an account key at `$HOME/.wash/keys/<module>_account.nk`, and if it is not found then an issuer key will be generated and placed in `$HOME/.wash/keys/<module>_account.nk`. You can also override this directory by setting the `WASH_HOME` environment variable.
     -n, --name <name>                   A human-readable, descriptive name for the token
     -b, --nbf <not-before-days>         Period in days that must elapse before this token is valid. If this option is
                                         left off, the token will be valid immediately
     -r, --rev <rev>                     Revision number
-    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate a module key at `$HOME/.wash/keys/<module>_module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wash/keys/<module>_module.nk`. You can also override this directory by setting the `WCC_HOME` environment variable.
+    -u, --subject <subject-key-path>    Subject seed key path (usually a .nk file). If this option is left off, `wash` will attempt to locate a module key at `$HOME/.wash/keys/<module>_module.nk`, and if it is not found then a module key will be generated and placed in `$HOME/.wash/keys/<module>_module.nk`. You can also override this directory by setting the `WASH_HOME` environment variable.
     -t, --tag <tags>...                 A list of arbitrary tags to be embedded in the token
     -v, --ver <ver>                     Human-readable version string
 
@@ -63,8 +63,11 @@ USAGE:
 FLAGS:
     -h, --help    Prints help information
 
-ARGS:
-    <tokentype>    The type of jwt to generate. May be Account, Actor, or Operator.
+SUBCOMMANDS:
+    account     Generate a signed JWT for an account
+    actor       Generate a signed JWT for an actor module
+    help        Prints this message or the help of the given subcommand(s)
+    operator    Generate a signed JWT for an operator
 ```
 
 ### keys
@@ -77,7 +80,7 @@ FLAGS:
     -h, --help    Prints help information
 
 ARGS:
-    <keytype>    The type of key pair to generate. May be Account, User, Module (Actor), Server, Operator, Cluster, Service (Capability Provider)
+    <keytype>    The type of keypair to generate. May be Account, User, Module (Actor), Server, Operator, Cluster, Service (Capability Provider)
 ```
 
 ```
@@ -88,7 +91,7 @@ FLAGS:
     -h, --help      Prints help information
 
 OPTIONS:
-    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WCC_HOME environment variable.
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WASH_HOME environment variable.
 
 ARGS:
     <keyname>   The name of the key to output
@@ -102,7 +105,7 @@ FLAGS:
     -h, --help          Prints help information
 
 OPTIONS:
-    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WCC_HOME environment variable.
+    -d, --directory <keysdirectory>     The directory where keys are stored for listing. Defaults to `$HOME/.wash/keys`, and can also be overwritten by setting the WASH_HOME environment variable.
 ```
 
 ### lattice

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,0 +1,540 @@
+// Copyright 2015-2018 Capital One Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// extern crate serde_derive;
+
+use serde::{Serialize, Deserialize};
+use nkeys::KeyPair;
+use std::fs::{read_to_string, File};
+use std::io::Read;
+use std::io::Write;
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+use wascap::jwt::{Account, Actor, Claims, Operator, TokenValidation, WascapEntity, };
+use wascap::wasm::{days_from_now_to_jwt_time, sign_buffer_with_claims};
+use wascap::caps::*;
+use serde::de::DeserializeOwned;
+use term_table::{
+    row::Row,
+    table_cell::{Alignment, TableCell},
+    Table, TableStyle,
+};
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(
+    global_settings(&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]),
+    name = "wascap",
+    about = "A command line utility for viewing, manipulating, and verifying capability claims in WebAssembly modules")]
+pub struct ClaimsCli {
+    #[structopt(flatten)]
+    command: ClaimsCliCommand,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+enum ClaimsCliCommand {
+    /// Examine the capabilities of a WebAssembly module
+    #[structopt(name = "inspect")]
+    Inspect {
+        /// The file to read
+        file: String,
+        /// Extract the raw JWT from the file and print to stdout
+        #[structopt(name = "raw", short = "r", long = "raw")]
+        raw: bool,
+    },
+    /// Sign a WebAssembly module, specifying capabilities and other claims
+    /// including expiration, tags, and additional metadata
+    #[structopt(name = "sign")]
+    Sign(SignCommand),
+    /// Generate a signed JWT by supplying basic token information, a signing seed key, and metadata
+    #[structopt(name = "token")]
+    Token(TokenCommand),
+}
+
+#[derive(Debug, Clone, StructOpt)]
+enum TokenCommand {
+    /// Generate a signed JWT for an actor module
+    #[structopt(name = "actor")]
+    Actor(ActorMetadata),
+    /// Generate a signed JWT for an operator
+    #[structopt(name = "operator")]
+    Operator(OperatorMetadata),
+    /// Generate a signed JWT for an account
+    #[structopt(name = "account")]
+    Account(AccountMetadata),
+}
+
+#[derive(Debug, Clone, StructOpt, Serialize, Deserialize)]
+struct GenerateCommon {
+    /// Issuer seed key path (usually a .nk file)
+    #[structopt(short = "i", long = "issuer")]
+    issuer_key_path: String,
+
+    /// Subject seed key path (usually a .nk file)
+    #[structopt(short = "u", long = "subject")]
+    subject_key_path: String,
+
+    /// Indicates the token expires in the given amount of days. If this option is left off, the token will never expire
+    #[structopt(short = "x", long = "expires")]
+    expires_in_days: Option<u64>,
+    /// Period in days that must elapse before this token is valid. If this option is left off, the token will be valid immediately
+    #[structopt(short = "b", long = "nbf")]
+    not_before_days: Option<u64>,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+struct OperatorMetadata {
+    /// A descriptive name for the operator
+    #[structopt(short = "n", long = "name")]
+    name: String,
+
+    /// Seed key paths (first seed establishes self-signed identity, others are used for optional valid signers list)
+    #[structopt(short = "s", long = "seed", name = "seed-path")]
+    key_paths: Vec<String>,
+
+    /// Indicates the token expires in the given amount of days. If this option is left off, the token will never expire
+    #[structopt(short = "x", long = "expires")]
+    expires_in_days: Option<u64>,
+
+    /// Period in days that must elapse before this token is valid. If this option is left off, the token will be valid immediately
+    #[structopt(short = "b", long = "nbf")]
+    not_before_days: Option<u64>,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+struct AccountMetadata {
+    /// A descriptive name for the account
+    #[structopt(short = "n", long = "name")]
+    name: String,
+
+    /// Seed key paths (first seed is the issuer[operator], second is the subject[account], any additional seeds are used for the valid signers list)
+    #[structopt(short = "s", long = "seed", name = "seed-path")]
+    key_paths: Vec<String>,
+
+    /// Indicates the token expires in the given amount of days. If this option is left off, the token will never expire
+    #[structopt(short = "x", long = "expires")]
+    expires_in_days: Option<u64>,
+
+    /// Period in days that must elapse before this token is valid. If this option is left off, the token will be valid immediately
+    #[structopt(short = "b", long = "nbf")]
+    not_before_days: Option<u64>,
+}
+
+#[derive(StructOpt, Debug, Clone, Serialize, Deserialize)]
+struct ActorMetadata {
+    /// Enable the Key/Value Store standard capability
+    #[structopt(short = "k", long = "keyvalue")]
+    keyvalue: bool,
+    /// Enable the Message broker standard capability
+    #[structopt(short = "g", long = "msg")]
+    msg_broker: bool,
+    /// Enable the HTTP server standard capability
+    #[structopt(short = "s", long = "http_server")]
+    http_server: bool,
+    /// Enable the HTTP client standard capability
+    #[structopt(short = "h", long = "http_client")]
+    http_client: bool,
+    /// Enable access to the blob store capability
+    #[structopt(short = "f", long = "blob_store")]
+    blob_store: bool,
+    /// Enable access to the extras functionality (random nos, guids, etc)
+    #[structopt(short = "z", long = "extras")]
+    extras: bool,
+    /// Enable access to logging capability
+    #[structopt(short = "l", long = "logging")]
+    logging: bool,
+    /// Enable access to an append-only event stream provider
+    #[structopt(short = "e", long = "events")]
+    eventstream: bool,
+    /// A human-readable, descriptive name for the token
+    #[structopt(short = "n", long = "name")]
+    name: String,
+    /// Add custom capabilities
+    #[structopt(short = "c", long = "cap", name = "capabilities")]
+    custom_caps: Vec<String>,
+    /// A list of arbitrary tags to be embedded in the token
+    #[structopt(short = "t", long = "tag")]
+    tags: Vec<String>,
+    /// Indicates whether the signed module is a capability provider instead of an actor (the default is actor)
+    #[structopt(short = "p", long = "prov")]
+    provider: bool,
+    /// Revision number
+    #[structopt(short = "r", long = "rev")]
+    rev: Option<i32>,
+    /// Human-readable version string
+    #[structopt(short = "v", long = "ver")]
+    ver: Option<String>,
+
+    #[structopt(flatten)]
+    common: GenerateCommon,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+struct SignCommand {
+    /// File to read
+    source: String,
+    /// Target output file
+    output: String,
+
+    #[structopt(flatten)]
+    metadata: ActorMetadata,
+}
+
+pub fn handle_command(cli: ClaimsCli) -> Result<(), Box<dyn ::std::error::Error>> {
+    match cli.command {
+        ClaimsCliCommand::Inspect { file, raw } => render_caps(&file, raw),
+        ClaimsCliCommand::Sign(signcmd) => sign_file(&signcmd),
+        ClaimsCliCommand::Token (gencmd) => generate_token(&gencmd),
+    }
+}
+
+fn generate_token(cmd: &TokenCommand) -> Result<(), Box<dyn ::std::error::Error>> {
+    match cmd {
+        TokenCommand::Actor(actor) => generate_actor(actor),
+        TokenCommand::Operator(operator) => generate_operator(operator),
+        TokenCommand::Account(account) => generate_account(account),
+    }
+}
+
+fn get_keypair_vec(paths: &[String]) -> Result<Vec<KeyPair>, Box<dyn ::std::error::Error>> {
+    Ok(paths
+        .iter()
+        .map(|p| {
+            let key = read_to_string(p).unwrap();
+            let pair = KeyPair::from_seed(key.trim_end()).unwrap();
+            pair
+        })
+        .collect())
+}
+
+fn get_keypairs(
+    common: &GenerateCommon,
+) -> Result<(KeyPair, KeyPair), Box<dyn ::std::error::Error>> {
+    if common.issuer_key_path.is_empty() {
+        return Err("Must specify an issuer key path".into());
+    }
+    if common.subject_key_path.is_empty() {
+        return Err("Must specify a subject key path".into());
+    }
+    let iss_key = read_to_string(&common.issuer_key_path)?;
+    let sub_key = read_to_string(&common.subject_key_path)?;
+    let issuer = KeyPair::from_seed(iss_key.trim_end())?;
+    let subject = KeyPair::from_seed(sub_key.trim_end())?;
+
+    Ok((issuer, subject))
+}
+
+fn generate_actor(actor: &ActorMetadata) -> Result<(), Box<dyn ::std::error::Error>> {
+    let (issuer, subject) = get_keypairs(&actor.common)?;
+    let mut caps_list = vec![];
+    if actor.keyvalue {
+        caps_list.push(wascap::caps::KEY_VALUE.to_string());
+    }
+    if actor.msg_broker {
+        caps_list.push(wascap::caps::MESSAGING.to_string());
+    }
+    if actor.http_client {
+        caps_list.push(wascap::caps::HTTP_CLIENT.to_string());
+    }
+    if actor.http_server {
+        caps_list.push(wascap::caps::HTTP_SERVER.to_string());
+    }
+    if actor.blob_store {
+        caps_list.push(wascap::caps::BLOB.to_string());
+    }
+    if actor.logging {
+        caps_list.push(wascap::caps::LOGGING.to_string());
+    }
+    if actor.eventstream {
+        caps_list.push(wascap::caps::EVENTSTREAMS.to_string());
+    }
+    if actor.extras {
+        caps_list.push(wascap::caps::EXTRAS.to_string());
+    }
+    caps_list.extend(actor.custom_caps.iter().cloned());
+
+    if actor.provider && caps_list.len() > 1 {
+        return Err("Capability providers cannot provide multiple capabilities at once.".into());
+    }
+    let claims: Claims<Actor> = Claims::<Actor>::with_dates(
+        actor.name.clone(),
+        issuer.public_key(),
+        subject.public_key(),
+        Some(caps_list),
+        Some(actor.tags.clone()),
+        days_from_now_to_jwt_time(actor.common.expires_in_days),
+        days_from_now_to_jwt_time(actor.common.not_before_days),
+        actor.provider,
+        actor.rev,
+        actor.ver.clone(),
+    );
+    println!("{}", claims.encode(&issuer)?);
+    Ok(())
+}
+
+fn generate_operator(operator: &OperatorMetadata) -> Result<(), Box<dyn ::std::error::Error>> {
+    let keys = get_keypair_vec(&operator.key_paths)?;
+    if keys.len() < 1 {
+        return Err("Must supply at least one seed key for operator self-signing".into());
+    }
+    let claims: Claims<Operator> = Claims::<Operator>::with_dates(
+        operator.name.clone(),
+        keys[0].public_key(),
+        keys[0].public_key(),
+        days_from_now_to_jwt_time(operator.not_before_days),
+        days_from_now_to_jwt_time(operator.expires_in_days),
+        if keys.len() > 1 {
+            keys[1..].iter().map(|k| k.public_key()).collect()
+        } else {
+            vec![]
+        },
+    );
+    println!("{}", claims.encode(&keys[0])?);
+    Ok(())
+}
+
+fn generate_account(account: &AccountMetadata) -> Result<(), Box<dyn ::std::error::Error>> {
+    let keys = get_keypair_vec(&account.key_paths)?;
+    if keys.len() < 2 {
+        return Err("Must supply at least two keys - one for the issuer, one for subject, and an optional list of additional signers".into());
+    }
+
+    let claims: Claims<Account> = Claims::<Account>::with_dates(
+        account.name.clone(),
+        keys[0].public_key(), // issuer
+        keys[1].public_key(), // subject
+        days_from_now_to_jwt_time(account.not_before_days),
+        days_from_now_to_jwt_time(account.expires_in_days),
+        if keys.len() > 2 {
+            keys[2..].iter().map(|k| k.public_key()).collect()
+        } else {
+            vec![]
+        },
+    );
+    println!("{}", claims.encode(&keys[0])?);
+    Ok(())
+}
+
+fn sign_file(cmd: &SignCommand) -> Result<(), Box<dyn ::std::error::Error>> {
+    let mut sfile = File::open(&cmd.source).unwrap();
+    let mut buf = Vec::new();
+    sfile.read_to_end(&mut buf).unwrap();
+
+    let mod_kp = if !cmd.metadata.common.subject_key_path.is_empty() {
+        KeyPair::from_seed(&read_to_string(&cmd.metadata.common.subject_key_path)?.trim_end())?
+    } else {
+        let m = KeyPair::new_module();
+        println!("New module key created. SAVE this seed key: {}", m.seed()?);
+        m
+    };
+
+    let acct_kp = if !cmd.metadata.common.issuer_key_path.is_empty() {
+        KeyPair::from_seed(&read_to_string(&cmd.metadata.common.issuer_key_path)?.trim_end())?
+    } else {
+        let a = KeyPair::new_account();
+        println!("New account key created. SAVE this seed key: {}", a.seed()?);
+        a
+    };
+
+    let mut caps_list = vec![];
+    if cmd.metadata.keyvalue {
+        caps_list.push(wascap::caps::KEY_VALUE.to_string());
+    }
+    if cmd.metadata.msg_broker {
+        caps_list.push(wascap::caps::MESSAGING.to_string());
+    }
+    if cmd.metadata.http_client {
+        caps_list.push(wascap::caps::HTTP_CLIENT.to_string());
+    }
+    if cmd.metadata.http_server {
+        caps_list.push(wascap::caps::HTTP_SERVER.to_string());
+    }
+    if cmd.metadata.blob_store {
+        caps_list.push(wascap::caps::BLOB.to_string());
+    }
+    if cmd.metadata.logging {
+        caps_list.push(wascap::caps::LOGGING.to_string());
+    }
+    if cmd.metadata.extras {
+        caps_list.push(wascap::caps::EXTRAS.to_string());
+    }
+    if cmd.metadata.eventstream {
+        caps_list.push(wascap::caps::EVENTSTREAMS.to_string());
+    }
+    caps_list.extend(cmd.metadata.custom_caps.iter().cloned());
+
+    if cmd.metadata.provider && caps_list.len() > 1 {
+        return Err("Capability providers cannot provide multiple capabilities at once.".into());
+    }
+
+    let signed = sign_buffer_with_claims(
+        cmd.metadata.name.clone(),
+        &buf,
+        mod_kp,
+        acct_kp,
+        cmd.metadata.common.expires_in_days,
+        cmd.metadata.common.not_before_days,
+        caps_list.clone(),
+        cmd.metadata.tags.clone(),
+        cmd.metadata.provider,
+        cmd.metadata.rev,
+        cmd.metadata.ver.clone(),
+    )?;
+
+    let mut outfile = File::create(&cmd.output).unwrap();
+    match outfile.write(&signed) {
+        Ok(_) => {
+            println!(
+                "Successfully signed {} with capabilities: {}",
+                cmd.output,
+                caps_list.join(",")
+            );
+            Ok(())
+        }
+        Err(e) => Err(Box::new(e)),
+    }
+}
+
+fn render_caps(file: &str, raw: bool) -> Result<(), Box<dyn ::std::error::Error>> {
+    let mut wfile = File::open(&file).unwrap();
+    let mut buf = Vec::new();
+    wfile.read_to_end(&mut buf).unwrap();
+
+    // Extract will return an error if it encounters an invalid hash in the claims
+    let claims = wascap::wasm::extract_claims(&buf);
+    match claims {
+        Ok(Some(token)) => {
+            if raw {
+                println!("{}", &token.jwt);
+            } else {
+                let validation = wascap::jwt::validate_token::<Actor>(&token.jwt)?;
+                println!("{}", render_actor_claims(token.claims, validation));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            Err(Box::new(e))
+        }
+        Ok(None) => {
+            eprintln!("No capabilities discovered in : {}", &file);
+            Ok(())
+        }
+    }
+}
+
+/// Prints the claims of an actor to stdout
+fn render_actor_claims(claims: Claims<Actor>, validation: TokenValidation) -> String {
+    let mut table = render_core(&claims, validation);
+
+    let md = claims.metadata.clone().unwrap();        
+    let friendly_rev = md.rev.unwrap_or(0);
+    let friendly_ver = md.ver.unwrap_or_else(|| "None".to_string());
+    let friendly = format!("{} ({})", friendly_ver, friendly_rev);
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Version"),
+        TableCell::new_with_alignment(friendly, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        if md.provider { "Capability Provider" } else { "Capabilities" },
+        2,
+        Alignment::Center,
+    )]));
+
+    let friendly_caps: Vec<String> = if let Some(caps) = &claims.metadata.as_ref().unwrap().caps {
+        caps.iter().map(|c| capability_name(&c)).collect()
+    } else {
+        vec![]
+    };
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        friendly_caps.join("\n"),
+        2,
+        Alignment::Left,
+    )]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        "Tags",
+        2,
+        Alignment::Center,
+    )]));
+
+    let tags = if let Some(tags) = &claims.metadata.as_ref().unwrap().tags {
+        if tags.is_empty() {
+            "None".to_string()
+        } else {
+            tags.join(",")
+        }
+    } else {
+        "None".to_string()
+    };
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        tags,
+        2,
+        Alignment::Left,
+    )]));
+
+    table.render()
+}
+
+// * - we don't need render impls for Operator or Account because those tokens are never embedded into a module,
+// only actors.
+
+fn token_label(pk: &str) -> String {
+    match pk.chars().nth(0).unwrap() {
+        'A' => "Account".to_string(),
+        'M' => "Module".to_string(),
+        'O' => "Operator".to_string(),
+        'S' => "Server".to_string(),
+        'U' => "User".to_string(),
+        _ => "<Unknown>".to_string(),
+    }
+}
+
+fn render_core<T>(claims: &Claims<T>, validation: TokenValidation) -> Table
+where
+    T: serde::Serialize + DeserializeOwned + WascapEntity,
+{
+    let mut table = Table::new();
+    table.max_column_width = 68;
+    table.style = TableStyle::extended();
+    let headline = format!("{} - {}", claims.name(), token_label(&claims.subject));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        headline,
+        2,
+        Alignment::Center,
+    )]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new(token_label(&claims.issuer)),
+        TableCell::new_with_alignment(&claims.issuer, 1, Alignment::Right),
+    ]));
+    table.add_row(Row::new(vec![
+        TableCell::new(token_label(&claims.subject)),
+        TableCell::new_with_alignment(&claims.subject, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Expires"),
+        TableCell::new_with_alignment(validation.expires_human, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Can Be Used"),
+        TableCell::new_with_alignment(validation.not_before_human, 1, Alignment::Right),
+    ]));
+
+    table
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,269 @@
+use nkeys::{KeyPair, KeyPairType};
+use serde_json::json;
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+use structopt::StructOpt;
+use std::fs;
+use std::fs::File;
+use std::env;
+use std::io::prelude::*;
+
+#[derive(StructOpt, Debug, Clone)]
+pub enum Output {
+    Text,
+    JSON,
+}
+
+impl FromStr for Output {
+    type Err = OutputParseErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(Output::JSON),
+            "text" => Ok(Output::Text),
+            _ => Err(OutputParseErr),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputParseErr;
+
+impl Error for OutputParseErr {}
+
+impl fmt::Display for OutputParseErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            "error parsing output type, see help for the list of accepted outputs"
+        )
+    }
+}
+#[derive(Debug, Clone, StructOpt)]
+pub struct KeysCli {
+    #[structopt(flatten)]
+    command: KeysCliCommand
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum KeysCliCommand {
+    #[structopt(name = "gen", about = "Generates a keypair")]
+    GenCommand {
+        /// The type of keypair to generate. May be Account, User, Module (Actor), Service (Capability Provider), Server, Operator, Cluster
+        #[structopt(case_insensitive = true)]
+        keytype: KeyPairType,
+        #[structopt(
+            short = "o",
+            long = "output",
+            default_value = "text",
+            help = "Specify output format (text or json)"
+        )]
+        output: Output,
+    },
+    #[structopt(name = "get", about = "Retrieves a keypair and prints the contents")]
+    GetCommand {
+        #[structopt(help = "The name of the key to output")]
+        keyname: String,
+        #[structopt(
+            short = "d",
+            long = "directory",
+            env = "WASH_HOME",
+            hide_env_values = true,
+            help = "Absolute path to where keypairs are stored. Defaults to `$HOME/.wash/keys`"
+        )]
+        directory: Option<String>,
+    },
+    #[structopt(name = "list", about = "Lists all keypairs in a directory")]
+    ListCommand {
+        #[structopt(
+            short = "d",
+            long = "directory",
+            env = "WASH_HOME",
+            hide_env_values = true,
+            help = "Absolute path to where keypairs are stored. Defaults to `$HOME/.wash/keys`"
+        )]
+        directory: Option<String>,
+    },
+}
+
+pub fn handle_command(cli: KeysCli) -> Result<(), Box<dyn ::std::error::Error>>{
+    match cli.command {
+        KeysCliCommand::GenCommand { keytype, output } => {
+            println!("{}", generate(&keytype, &output));
+        }
+        KeysCliCommand::GetCommand { keyname, directory } => {
+            get(&keyname, directory);
+        }
+        KeysCliCommand::ListCommand { directory } => {
+            list(directory);
+        }
+    }
+    Ok(())
+}
+
+/// Generates a keypair of the specified KeyPairType, as either Text or JSON
+pub fn generate(kt: &KeyPairType, output_type: &Output) -> String {
+    let kp = KeyPair::new(kt.clone());
+    match output_type {
+        Output::Text => format!(
+            "Public Key: {}\nSeed: {}\n\nRemember that the seed is private, treat it as a secret.",
+            kp.public_key(),
+            kp.seed().unwrap()
+        ),
+        Output::JSON => json!({
+            "public_key": kp.public_key(),
+            "seed": kp.seed().unwrap(),
+        })
+        .to_string(),
+    }
+}
+
+/// Retrieves a keypair by name in a specified directory, or WASH_HOME ($HOME/.wash/keys) if directory is not specified
+pub fn get(keyname: &String, directory: Option<String>) {
+    let dir = determine_directory(directory);
+    let mut f = match File::open(format!("{}/{}", dir, keyname)){
+        Ok(f) => f,
+        Err(f) => {
+            println!("Error: {}.\nPlease ensure {}/{} exists.", f, dir, keyname);
+            return;
+        }
+    };
+    let mut s = String::new();
+    let res = match f.read_to_string(&mut s) {
+        Ok(_) => Ok(s),
+        Err(e) => Err(e),
+    };
+    match res {
+        Err(e) => println!("Error: {:?}", e.kind()),
+        Ok(s) => println!("{}", s),
+    }
+}
+
+/// Lists all keypairs (file extension .nk) in a specified directory or WASH_HOME($HOME/.wash/keys) if directory is not specified
+pub fn list(directory: Option<String>) {
+    let dir = determine_directory(directory);
+
+    match fs::read_dir(dir.clone()) {
+        Err(e) => println!("Error: {}, please ensure directory {} exists", e, dir),
+        Ok(paths) => {
+            println!("====== Keys found in {} ======\n", dir);
+            for path in paths {
+                let f = String::from(path.unwrap().file_name().to_str().unwrap());
+                if f.ends_with(".nk") {
+                    println!("{}", f);
+                }
+            };
+    }
+    }
+}
+
+fn determine_directory(directory: Option<String>) -> String {
+    match directory {
+        Some(d) => d,
+        None => format!("{}/.wash/keys", env::var("HOME").unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate, get, list, Output};
+    use nkeys::KeyPairType;
+    use serde::Deserialize;
+
+    #[test]
+    fn keys_generate_basic_test() {
+        let kt = KeyPairType::Account;
+
+        let keypair = generate(&kt, &Output::Text);
+        let keypair_json = generate(&kt, &Output::JSON);
+
+        assert_eq!(keypair.contains("Public Key: "), true);
+        assert_eq!(keypair.contains("Seed: "), true);
+        assert_eq!(
+            keypair.contains("Remember that the seed is private, treat it as a secret."),
+            true
+        );
+        assert_ne!(keypair, "");
+        assert_ne!(keypair_json, "");
+    }
+
+    #[derive(Debug, Clone, Deserialize)]
+    struct KeyPairJSON {
+        public_key: String,
+        seed: String,
+    }
+
+    #[test]
+    fn keys_generate_valid_keypair() {
+        let sample_public_key = "MBBLAHS7MCGNQ6IR4ZDSGRIAF7NVS7FCKFTKGO5JJJKN2QQRVAH7BSIO";
+        let sample_seed = "SMAH45IUULL57OSX23NOOOTLSVNQOORMDLE3Y3PQLJ4J5MY7MN2K7BIFI4";
+
+        let kt = KeyPairType::Module;
+
+        let keypair_json = generate(&kt, &Output::JSON);
+        let keypair: KeyPairJSON = serde_json::from_str(&keypair_json).unwrap();
+
+        assert_eq!(keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(keypair.seed.len(), sample_seed.len());
+        assert_eq!(keypair.public_key.starts_with("M"), true);
+        assert_eq!(keypair.seed.starts_with("SM"), true);
+    }
+
+    #[test]
+    fn keys_generate_all_types() {
+        let sample_public_key = "MBBLAHS7MCGNQ6IR4ZDSGRIAF7NVS7FCKFTKGO5JJJKN2QQRVAH7BSIO";
+        let sample_seed = "SMAH45IUULL57OSXNOOAKOTLSVNQOORMDLE3Y3PQLJ4J5MY7MN2K7BIFI4";
+
+        let account_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Account, &Output::JSON)).unwrap();
+        let user_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::User, &Output::JSON)).unwrap();
+        let module_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Module, &Output::JSON)).unwrap();
+        let service_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Service, &Output::JSON)).unwrap();
+        let server_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Server, &Output::JSON)).unwrap();
+        let operator_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Operator, &Output::JSON)).unwrap();
+        let cluster_keypair: KeyPairJSON =
+            serde_json::from_str(&generate(&KeyPairType::Cluster, &Output::JSON)).unwrap();
+
+        assert_eq!(account_keypair.public_key.starts_with("A"), true);
+        assert_eq!(account_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(account_keypair.seed.starts_with("SA"), true);
+        assert_eq!(account_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(user_keypair.public_key.starts_with("U"), true);
+        assert_eq!(user_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(user_keypair.seed.starts_with("SU"), true);
+        assert_eq!(user_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(module_keypair.public_key.starts_with("M"), true);
+        assert_eq!(module_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(module_keypair.seed.starts_with("SM"), true);
+        assert_eq!(module_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(service_keypair.public_key.starts_with("V"), true);
+        assert_eq!(service_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(service_keypair.seed.starts_with("SV"), true);
+        assert_eq!(service_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(server_keypair.public_key.starts_with("N"), true);
+        assert_eq!(server_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(server_keypair.seed.starts_with("SN"), true);
+        assert_eq!(server_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(operator_keypair.public_key.starts_with("O"), true);
+        assert_eq!(operator_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(operator_keypair.seed.starts_with("SO"), true);
+        assert_eq!(operator_keypair.seed.len(), sample_seed.len());
+
+        assert_eq!(cluster_keypair.public_key.starts_with("C"), true);
+        assert_eq!(cluster_keypair.public_key.len(), sample_public_key.len());
+        assert_eq!(cluster_keypair.seed.starts_with("SC"), true);
+        assert_eq!(cluster_keypair.seed.len(), sample_seed.len());
+    }
+}

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -1,0 +1,337 @@
+extern crate latticeclient;
+
+// use latticeclient::*;
+use std::error::Error;
+use std::{collections::HashMap, path::PathBuf, time::Duration};
+
+use crossbeam::unbounded;
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(
+global_settings(& [AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands, AppSettings::GlobalVersion]),
+name = "lattice",
+about = "A command line utility for interacting with a waSCC lattice")]
+/// latticectl interacts with a waSCC lattice the same way the waSCC host would, and uses the same
+/// environment variables to connect by default
+pub struct LatticeCli {
+    #[structopt(flatten)]
+    pub command: LatticeCliCommand,
+
+    /// The host IP of the nearest NATS server/leaf node to connect to the lattice
+    #[structopt(
+        short,
+        long,
+        env = "LATTICE_HOST",
+        hide_env_values = true,
+        default_value = "127.0.0.1"
+    )]
+    pub url: String,
+
+    /// Credentials file used to authenticate against NATS
+    #[structopt(
+        short,
+        long,
+        env = "LATTICE_CREDS_FILE",
+        hide_env_values = true,
+        parse(from_os_str)
+    )]
+    pub creds: Option<PathBuf>,
+
+    /// Lattice invocation / request timeout period, in milliseconds
+    #[structopt(
+        short = "t",
+        long = "timeout",
+        env = "LATTICE_RPC_TIMEOUT_MILLIS",
+        hide_env_values = true,
+        default_value = "600"
+    )]
+    pub call_timeout: u64,
+
+    /// Lattice namespace
+    #[structopt(
+        short = "n",
+        long = "namespace",
+        env = "LATTICE_NAMESPACE",
+        hide_env_values = true
+    )]
+    pub namespace: Option<String>,
+    /// Render the output in JSON (if the command supports it)
+    #[structopt(short, long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum LatticeCliCommand {
+    /// List entities of various types within the lattice
+    #[structopt(name = "list")]
+    List {
+        /// The entity type to list (actors, bindings, capabilities(caps), hosts)
+        entity_type: String,
+    },
+    #[structopt(name = "watch")]
+    /// Watch events on the lattice
+    Watch,
+    #[structopt(name = "start")]
+    /// Hold a lattice auction for a given actor and start it if a suitable host is found
+    Start {
+        /// An OCI image reference of the actor to be launched
+        actor_ref: String,
+        /// Add limiting constraints to filter potential target hosts (in the form of label=value)
+        #[structopt(short = "c", parse(try_from_str = parse_key_val), number_of_values = 1)]
+        constraint: Vec<(String, String)>,
+    },
+    /// Tell a given host to terminate the given actor
+    #[structopt(name = "stop")]
+    Stop { actor: String, host_id: String },
+}
+
+//         match handle_command(
+//             cmd,
+//             args.url,
+//             args.json,
+//             args.creds,
+//             args.namespace,
+//             Duration::from_millis(args.call_timeout),
+//         ) {
+//             Ok(_) => 0,
+//             Err(e) => {
+//                 eprintln!("Latticectl Error: {}", e);
+//                 1
+//             }
+//         },
+//     )
+// }
+
+pub fn handle_command(
+    cli: LatticeCli,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let cmd = cli.command;
+    let url = cli.url;
+    let json = cli.json;
+    let creds = cli.creds;
+    let namespace = cli.namespace;
+    let timeout = Duration::from_millis(cli.call_timeout);
+    match cmd {
+        LatticeCliCommand::List { entity_type } => {
+            list_entities(&entity_type, &url, creds, timeout, json, namespace)
+        }
+        LatticeCliCommand::Watch => watch_events(&url, creds, timeout, json, namespace),
+        LatticeCliCommand::Start {
+            actor_ref,
+            constraint,
+        } => start_actor(&url, creds, timeout, json, namespace, actor_ref, constraint),
+        LatticeCliCommand::Stop { actor, host_id } => {
+            stop_actor(&url, creds, timeout, json, namespace, actor, host_id)
+        }
+    }
+}
+
+fn start_actor(
+    url: &str,
+    creds: Option<PathBuf>,
+    timeout: Duration,
+    json: bool,
+    namespace: Option<String>,
+    actor: String,
+    constraints: Vec<(String, String)>,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let client = latticeclient::Client::new(url, creds, timeout, namespace);
+    let candidates =
+        client.perform_actor_launch_auction(&actor, constraints_to_hashmap(constraints))?;
+    if candidates.len() > 0 {
+        let ack = client.launch_actor_on_host(&actor, &candidates[0].host_id)?;
+        if ack.actor_id != actor || ack.host != candidates[0].host_id {
+            return Err(format!("Received unexpected acknowledgement: {:?}", ack).into());
+        }
+        if json {
+            println!("{}", serde_json::to_string(&ack)?);
+        } else {
+            println!(
+                "Host {} acknowledged request to launch actor {}.",
+                ack.host, ack.actor_id
+            );
+        }
+    } else {
+        println!("Did not receive a response to the actor schedule auction.");
+    }
+    Ok(())
+}
+
+fn stop_actor(
+    url: &str,
+    creds: Option<PathBuf>,
+    timeout: Duration,
+    _json: bool,
+    namespace: Option<String>,
+    actor: String,
+    host_id: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = latticeclient::Client::new(url, creds, timeout, namespace);
+    client.stop_actor_on_host(&actor, &host_id)?;
+    println!("Termination command sent.");
+    Ok(())
+}
+
+fn watch_events(
+    url: &str,
+    creds: Option<PathBuf>,
+    timeout: Duration,
+    json: bool,
+    namespace: Option<String>,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    if !json {
+        println!("Watching lattice events, Ctrl+C to abort...");
+    }
+    let client = latticeclient::Client::new(url, creds, timeout, namespace);
+    let (s, r) = unbounded();
+    client.watch_events(s)?;
+    loop {
+        let be = r.recv()?;
+        if json {
+            let raw = serde_json::to_string(&be)?;
+            println!("{}", raw);
+        } else {
+            println!("{}", be);
+        }
+    }
+}
+
+fn list_entities(
+    entity_type: &str,
+    url: &str,
+    creds: Option<PathBuf>,
+    timeout: Duration,
+    json: bool,
+    namespace: Option<String>,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let client = latticeclient::Client::new(url, creds, timeout, namespace);
+    match entity_type.to_lowercase().trim() {
+        "hosts" => render_hosts(&client, json),
+        "actors" => render_actors(&client, json),
+        "bindings" => render_bindings(&client, json),
+        "capabilities" | "caps" => render_capabilities(&client, json),
+        _ => Err(
+            "Unknown entity type. Valid types are: hosts, actors, capabilities, bindings".into(),
+        ),
+    }
+}
+
+fn render_actors(
+    client: &latticeclient::Client,
+    json: bool,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let actors = client.get_actors()?;
+    if json {
+        println!("{}", serde_json::to_string(&actors)?);
+    } else {
+        for (host, actors) in actors {
+            println!("\nHost {}:", host);
+            for actor in actors {
+                let md = actor.metadata.clone().unwrap();
+                println!(
+                    "\t{} - {}  v{} ({})",
+                    actor.subject,
+                    actor.name(),
+                    md.ver.unwrap_or("???".into()),
+                    md.rev.unwrap_or(0)
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_hosts(
+    client: &latticeclient::Client,
+    json: bool,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let hosts = client.get_hosts()?;
+    if json {
+        println!("{}", serde_json::to_string(&hosts)?);
+    } else {
+        for host in hosts {
+            println!(
+                "[{}] Uptime {}s, Labels: {}",
+                host.id,
+                host.uptime_ms / 1000,
+                host.labels
+                    .keys()
+                    .map(|k| k.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn render_capabilities(
+    client: &latticeclient::Client,
+    json: bool,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let caps = client.get_capabilities()?;
+    if json {
+        println!("{}", serde_json::to_string(&caps)?);
+    } else {
+        for (host, caps) in caps {
+            println!("{}", host);
+            for cap in caps {
+                println!(
+                    "\t{},{} - Total Operations {}",
+                    cap.descriptor.id,
+                    cap.binding_name,
+                    cap.descriptor.supported_operations.len()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_bindings(
+    client: &latticeclient::Client,
+    json: bool,
+) -> Result<(), Box<dyn ::std::error::Error>> {
+    let bindings = client.get_bindings()?;
+    if json {
+        println!("{}", serde_json::to_string(&bindings)?);
+    } else {
+        for (host, bindings) in bindings {
+            println!("Host {}", host);
+            for binding in bindings {
+                println!(
+                    "\t{} -> {},{} - {} values",
+                    binding.actor,
+                    binding.capability_id,
+                    binding.binding_name,
+                    binding.configuration.len()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{}`", s))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+fn constraints_to_hashmap(input: Vec<(String, String)>) -> HashMap<String, String> {
+    let mut hm = HashMap::new();
+    for (k, v) in input {
+        hm.insert(k.to_owned(), v.to_owned());
+    }
+    hm
+}


### PR DESCRIPTION
This PR does not introduce additional functionality or convenience to `wash` commands (with the exception of initial implementations of `wash keys get` and `wash keys list`), rather it is focused on migrating existing functionality from previously used CLIs. 

Some feedback that I'm looking for here is around structure of the `wash` CLI in terms of file separation in `src`, any additional feedback for the README as I'm attempting to base all of the structopt messages off of the README, and the readability of `main.rs`. My goal of this CLI is essentially:

1. Receive command
2. Delegate functionality to each module's `handle_command`
3. Execute the command accordingly

This structure will keep the CLI fairly simple, and each module can be updated as needed without changing the tool itself.