### PR TITLE
Initial wash up commit with command parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ env_logger = "0.7.1"
 serde_json = "1.0.59"
 serde = { version = "1.0.117", features = ["derive"] }
 crossbeam = "0.7.3"
+tui-logger = "0.4.8"
+text_io = "0.1.8"
+tui = "0.13.0"
+termion = "1.5.5"
+log = "0.4.11"
 
 nkeys = "0.0.11"
 latticeclient = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde_json = "1.0.59"
 serde = { version = "1.0.117", features = ["derive"] }
 crossbeam = "0.7.3"
 tui-logger =  { version = "0.4.8", default-features = false, features = ["tui-crossterm"] }
-text_io = "0.1.3"
 tui = { version = "0.12.0", default-features = false, features = ["crossterm"] }
 log = "0.4.11"
 crossterm = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ env_logger = "0.7.1"
 serde_json = "1.0.59"
 serde = { version = "1.0.117", features = ["derive"] }
 crossbeam = "0.7.3"
-tui-logger = "0.4.8"
-text_io = "0.1.8"
-tui = "0.13.0"
-termion = "1.5.5"
+tui-logger =  { version = "0.4.8", default-features = false, features = ["tui-crossterm"] }
+text_io = "0.1.3"
+tui = { version = "0.12.0", default-features = false, features = ["crossterm"] }
 log = "0.4.11"
+crossterm = "0.18.2"
+unicode-width = "0.1.8"
 
 nkeys = "0.0.11"
 latticeclient = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Brooks Townsend <brooksmtownsend@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/wascc/wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,16 @@ tui = { version = "0.12.0", default-features = false, features = ["crossterm"] }
 log = "0.4.11"
 crossterm = "0.18.2"
 unicode-width = "0.1.8"
+tokio = { version = "0.2.0" }
+nats = "0.8.5"
 
 nkeys = "0.0.11"
 latticeclient = "0.4.0"
 wascap = "0.5.1"
 term-table = "1.3.0"
 provider-archive = "0.3.0"
+wascc-host = { git = "https://github.com/wascc/wasccd", branch = "main"}
+once_cell = "1.5.2"
 
 [[bin]]
 name = "wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ latticeclient = "0.4.0"
 wascap = "0.5.1"
 term-table = "1.3.0"
 provider-archive = "0.3.0"
-wascc-host = { git = "https://github.com/wascc/wasccd", branch = "main"}
+wasmcloud-host = { git = "https://github.com/wascc/wasccd", branch = "main"}
 once_cell = "1.5.2"
 
 [[bin]]

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -238,7 +238,7 @@ struct ActorMetadata {
     #[structopt(short = "g", long = "msg")]
     msg_broker: bool,
     /// Enable the HTTP server standard capability
-    #[structopt(short = "s", long = "http_server")]
+    #[structopt(short = "q", long = "http_server")]
     http_server: bool,
     /// Enable the HTTP client standard capability
     #[structopt(short = "h", long = "http_client")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod keys;
 use keys::KeysCli;
 mod par;
 use par::ParCli;
+mod up;
+use up::UpCli;
 
 /// This renders appropriately with escape characters
 const ASCII: &str = "
@@ -44,17 +46,21 @@ enum CliCommand {
     /// Utilities for creating, inspecting, and modifying capability provider archive files
     #[structopt(name = "par")]
     Par(ParCli),
+    /// Utility to launch waSCC REPL environment
+    #[structopt(name = "up")]
+    Up(UpCli),
 }
 
 fn main() {
     let cli = Cli::from_args();
-    env_logger::init();
+    // env_logger::init();
 
     let res = match cli.command {
         CliCommand::Keys(keyscli) => keys::handle_command(keyscli),
         CliCommand::Lattice(latticecli) => lattice::handle_command(latticecli),
         CliCommand::Claims(claimscli) => claims::handle_command(claimscli),
         CliCommand::Par(parcli) => par::handle_command(parcli),
+        CliCommand::Up(upcli) => up::handle_command(upcli),
     };
 
     match res {

--- a/src/up.rs
+++ b/src/up.rs
@@ -17,7 +17,7 @@ use tui::{
 };
 use tui_logger::*;
 
-use wascc_host::{Host, HostBuilder};
+use wasmcloud_host::{Host, HostBuilder};
 
 type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
 

--- a/src/up.rs
+++ b/src/up.rs
@@ -1,0 +1,200 @@
+use log::{info, LevelFilter};
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+use text_io::read;
+use tui_logger::*;
+
+use std::{
+    error::Error,
+    io,
+    sync::atomic::{AtomicBool, Ordering},
+    sync::mpsc,
+    sync::Arc,
+    thread,
+    time::Duration,
+};
+use termion::{
+    event::Key, input::MouseTerminal, input::TermRead, raw::IntoRawMode, screen::AlternateScreen,
+};
+use tui::{
+    backend::TermionBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::Span,
+    widgets::{Block, BorderType, Borders},
+    Terminal,
+};
+
+type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(
+    global_settings(&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]),
+    name = "up")]
+pub struct UpCli {
+    #[structopt(flatten)]
+    command: UpCommand,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+struct UpCommand {}
+
+pub fn handle_command(cli: UpCli) -> Result<()> {
+    match cli.command {
+        UpCommand { .. } => handle_up(),
+    }
+}
+
+#[derive(StructOpt, Debug, Clone)]
+#[structopt(global_settings(&[AppSettings::NoBinaryName]))]
+struct ReplCli {
+    #[structopt(flatten)]
+    cmd: ReplCliCommand,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+enum ReplCliCommand {
+    #[structopt(name = "link")]
+    Link(LinkCommand),
+
+    #[structopt(name = "call")]
+    Call(CallCommand),
+
+    #[structopt(name = "start")]
+    Start(StartCommand),
+
+    #[structopt(name = "exit")]
+    Exit,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+struct LinkCommand {
+    url: String,
+    capid: String,
+    env: Vec<String>,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+struct CallCommand {
+    url: String,
+    op: String,
+    payload: Vec<String>,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+struct StartCommand {
+    url: String,
+}
+
+/// Launches REPL environment
+fn handle_up() -> Result<()> {
+    // Early initialization of the logger
+
+    // Set max_log_level to Trace
+    // init_logger(LevelFilter::Trace).unwrap();
+
+    // Set default level for unknown targets to Trace
+    // set_default_level(LevelFilter::Trace);
+
+    // Terminal initialization
+    // let stdout = io::stdout().into_raw_mode()?;
+    // let stdout = MouseTerminal::from(stdout);
+    // let stdout = AlternateScreen::from(stdout);
+    // let backend = TermionBackend::new(stdout);
+    // let mut terminal = Terminal::new(backend)?;
+
+    // let exit_key = Key::Char('q');
+
+    // Setup event handlers
+    // let (tx, rx) = mpsc::channel();
+    // let ignore_exit_key = Arc::new(AtomicBool::new(false));
+    // let input_handle = {
+    //     let tx = tx.clone();
+    //     let ignore_exit_key = ignore_exit_key.clone();
+    //     thread::spawn(move || {
+    //         let stdin = io::stdin();
+    //         for evt in stdin.keys() {
+    //             if let Ok(key) = evt {
+    //                 if let Err(err) = tx.send(key) {
+    //                     eprintln!("{}", err);
+    //                     return;
+    //                 }
+    //                 if !ignore_exit_key.load(Ordering::Relaxed) && key == exit_key {
+    //                     return;
+    //                 }
+    //             }
+    //         }
+    //     })
+    // };
+
+    // Event loop
+    // loop {
+    // terminal.draw(|f| {
+    // Wrapping block for a group
+    // Just draw the block and the group on the same area and build the group
+    // with at least a margin of 1
+    // let size = f.size();
+    // let block = Block::default()
+    //     .borders(Borders::ALL)
+    //     .title("waSCC REPL")
+    //     .border_type(BorderType::Rounded);
+    // f.render_widget(block, size);
+    // let chunks = Layout::default()
+    //     .direction(Direction::Vertical)
+    //     .margin(1)
+    //     .constraints([Constraint::Percentage(100), Constraint::Percentage(50)].as_ref())
+    //     .split(f.size());
+
+    // let top_chunks = Layout::default()
+    //     .direction(Direction::Horizontal)
+    //     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+    //     .split(chunks[0]);
+    // let block = Block::default().title(vec![]);
+    // f.render_widget(block, top_chunks[0]);
+
+    // let block = Block::default().borders(Borders::LEFT).title(Span::styled(
+    //     "Logs",
+    //     Style::default().add_modifier(Modifier::BOLD),
+    // ));
+    // f.render_widget(block, top_chunks[1]);
+
+    // let bottom_chunks = Layout::default()
+    //     .direction(Direction::Horizontal)
+    //     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+    //     .split(chunks[1]);
+    // let block = Block::default().title("With borders").borders(Borders::ALL);
+    // f.render_widget(block, bottom_chunks[0]);
+    // let block = Block::default()
+    //     .title("With styled borders and doubled borders")
+    //     .border_style(Style::default().fg(Color::Cyan))
+    //     .borders(Borders::LEFT | Borders::RIGHT)
+    //     .border_type(BorderType::Double);
+    // f.render_widget(block, bottom_chunks[1]);
+    // })?;
+
+    // if let key = rx.recv()? {
+    //     if key == Key::Char('q') {
+    //         break;
+    //     }
+    //     info!("I GOT A KEY {:?}", key);
+    // }
+    // }
+
+    loop {
+        print!("wash> ");
+        use std::io::Write;
+        io::stdout().flush()?;
+        let input: String = read!("{}\n");
+        // This works but doesn't correctly interpret strings, like "{"x": 10}" will make two tokens: '{"x":' and '10}'
+        // For now, leaving this as a Vec of strings and `join`ing the vec by a space character will work.
+        let iter = input.split_ascii_whitespace();
+        let cli = ReplCli::from_iter(iter);
+
+        if let ReplCliCommand::Exit = cli.cmd {
+            println!("Have a good day!");
+            break;
+        }
+        println!("Command parsed! {:?}\n", cli.cmd);
+    }
+    Ok(())
+}

--- a/src/up.rs
+++ b/src/up.rs
@@ -1,29 +1,20 @@
-use log::{info, LevelFilter};
-use structopt::clap::AppSettings;
-use structopt::StructOpt;
-use text_io::read;
-use tui_logger::*;
-
-use std::{
-    error::Error,
-    io,
-    sync::atomic::{AtomicBool, Ordering},
-    sync::mpsc,
-    sync::Arc,
-    thread,
-    time::Duration,
+use crossterm::event::{
+    read, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
 };
-use termion::{
-    event::Key, input::MouseTerminal, input::TermRead, raw::IntoRawMode, screen::AlternateScreen,
-};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use log::{debug, error, info, trace, warn, LevelFilter};
+use std::io::{self, Stdout};
+use std::{cell::RefCell, io::Write, rc::Rc};
+use structopt::{clap::AppSettings, StructOpt};
 use tui::{
-    backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::Span,
-    widgets::{Block, BorderType, Borders},
-    Terminal,
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame, Terminal,
 };
+use tui_logger::*;
 
 type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
 
@@ -54,15 +45,19 @@ struct ReplCli {
 
 #[derive(StructOpt, Debug, Clone)]
 enum ReplCliCommand {
+    /// Links an actor and a capability provider
     #[structopt(name = "link")]
     Link(LinkCommand),
 
+    /// Invokes an operation on an actor
     #[structopt(name = "call")]
     Call(CallCommand),
 
+    /// Starts an actor
     #[structopt(name = "start")]
     Start(StartCommand),
 
+    /// Terminates the REPL environment
     #[structopt(name = "exit")]
     Exit,
 }
@@ -86,115 +81,236 @@ struct StartCommand {
     url: String,
 }
 
+#[derive(Debug, Clone)]
+struct InputState {
+    history: Vec<Vec<char>>,
+    history_cursor: usize,
+    input: Vec<char>,
+    input_cursor: usize,
+}
+
+impl Default for InputState {
+    fn default() -> Self {
+        InputState {
+            history: vec![],
+            history_cursor: 0,
+            input: vec![],
+            input_cursor: 0,
+        }
+    }
+}
+
+impl InputState {
+    fn cursor_location(&self, width: usize) -> (u16, u16) {
+        let mut position = (0, 0);
+
+        for current_char in self.input.iter().take(self.input_cursor) {
+            let char_width = unicode_width::UnicodeWidthChar::width(*current_char).unwrap_or(0);
+
+            position.0 += char_width;
+
+            match position.0.cmp(&width) {
+                std::cmp::Ordering::Equal => {
+                    position.0 = 0;
+                    position.1 += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    // Handle a char with width > 1 at the end of the row
+                    // width - (char_width - 1) accounts for the empty column(s) left behind
+                    position.0 -= width - (char_width - 1);
+                    position.1 += 1;
+                }
+                _ => (),
+            }
+        }
+
+        (position.0 as u16, position.1 as u16)
+    }
+}
+
+fn handle_key(state: &mut InputState, code: KeyCode, _modifiers: KeyModifiers) -> Result<()> {
+    match code {
+        KeyCode::Char(c) => {
+            state.input.push(c);
+            state.input_cursor += 1;
+        }
+        KeyCode::Left => {
+            if state.input_cursor > 0 {
+                state.input_cursor -= 1
+            }
+        }
+        KeyCode::Right => {
+            if state.input_cursor < state.input.len() {
+                state.input_cursor += 1
+            }
+        }
+        KeyCode::Backspace => {
+            if state.input_cursor > 0 && state.input_cursor <= state.input.len() {
+                state.input_cursor -= 1;
+                state.input.remove(state.input_cursor);
+            };
+        }
+        KeyCode::Enter => {
+            let cmd: String = state.input.iter().collect();
+            let iter = cmd.split_ascii_whitespace();
+            let cli = ReplCli::from_iter_safe(iter);
+
+            state.history.push(state.input.clone());
+            state.history_cursor += 1;
+            state.input.clear();
+            state.input_cursor = 0;
+
+            match cli {
+                Ok(ReplCli {
+                    cmd: ReplCliCommand::Exit,
+                }) => {
+                    println!("Have a good day!");
+                    return Err("REPL Exited".into());
+                }
+                Err(e) => info!(target: "info", "{}", e.message),
+                _ => info!(target:"info", "command parsed without error"),
+            };
+        }
+        _ => (),
+    };
+    Ok(())
+}
+
 /// Launches REPL environment
 fn handle_up() -> Result<()> {
-    // Early initialization of the logger
+    // Initialize logger at default level Trace
+    init_logger(LevelFilter::Trace).unwrap();
+    set_default_level(LevelFilter::Trace);
 
-    // Set max_log_level to Trace
-    // init_logger(LevelFilter::Trace).unwrap();
+    // Initialize terminal
+    let backend = {
+        crossterm::terminal::enable_raw_mode().unwrap();
+        let mut stdout = io::stdout();
+        crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture).unwrap();
+        CrosstermBackend::new(stdout)
+    };
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.clear().unwrap();
+    terminal.hide_cursor().unwrap();
 
-    // Set default level for unknown targets to Trace
-    // set_default_level(LevelFilter::Trace);
+    // Initialize state and dispatcher, draw initial UI
+    let mut state = InputState::default();
+    let tui_state = TuiWidgetState::new();
+    let dispatcher = Rc::new(RefCell::new(Dispatcher::<Event>::new()));
+    info!(target:"WASH_REPL_INFO", "Welcome to the WASH REPL! Your commands are being executed whenever you hit Return");
+    info!(target:"WASH_REPL_INFO", "To see a list of commands, type 'help'. To exit, type 'exit'");
+    info!(target:"WASH_REPL_INFO", "Press 'tab' to toggle between entering commands and changing log level");
+    draw_ui(&state, &mut terminal, &tui_state, &dispatcher)?;
 
-    // Terminal initialization
-    // let stdout = io::stdout().into_raw_mode()?;
-    // let stdout = MouseTerminal::from(stdout);
-    // let stdout = AlternateScreen::from(stdout);
-    // let backend = TermionBackend::new(stdout);
-    // let mut terminal = Terminal::new(backend)?;
-
-    // let exit_key = Key::Char('q');
-
-    // Setup event handlers
-    // let (tx, rx) = mpsc::channel();
-    // let ignore_exit_key = Arc::new(AtomicBool::new(false));
-    // let input_handle = {
-    //     let tx = tx.clone();
-    //     let ignore_exit_key = ignore_exit_key.clone();
-    //     thread::spawn(move || {
-    //         let stdin = io::stdin();
-    //         for evt in stdin.keys() {
-    //             if let Ok(key) = evt {
-    //                 if let Err(err) = tx.send(key) {
-    //                     eprintln!("{}", err);
-    //                     return;
-    //                 }
-    //                 if !ignore_exit_key.load(Ordering::Relaxed) && key == exit_key {
-    //                     return;
-    //                 }
-    //             }
-    //         }
-    //     })
-    // };
-
-    // Event loop
-    // loop {
-    // terminal.draw(|f| {
-    // Wrapping block for a group
-    // Just draw the block and the group on the same area and build the group
-    // with at least a margin of 1
-    // let size = f.size();
-    // let block = Block::default()
-    //     .borders(Borders::ALL)
-    //     .title("waSCC REPL")
-    //     .border_type(BorderType::Rounded);
-    // f.render_widget(block, size);
-    // let chunks = Layout::default()
-    //     .direction(Direction::Vertical)
-    //     .margin(1)
-    //     .constraints([Constraint::Percentage(100), Constraint::Percentage(50)].as_ref())
-    //     .split(f.size());
-
-    // let top_chunks = Layout::default()
-    //     .direction(Direction::Horizontal)
-    //     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-    //     .split(chunks[0]);
-    // let block = Block::default().title(vec![]);
-    // f.render_widget(block, top_chunks[0]);
-
-    // let block = Block::default().borders(Borders::LEFT).title(Span::styled(
-    //     "Logs",
-    //     Style::default().add_modifier(Modifier::BOLD),
-    // ));
-    // f.render_widget(block, top_chunks[1]);
-
-    // let bottom_chunks = Layout::default()
-    //     .direction(Direction::Horizontal)
-    //     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-    //     .split(chunks[1]);
-    // let block = Block::default().title("With borders").borders(Borders::ALL);
-    // f.render_widget(block, bottom_chunks[0]);
-    // let block = Block::default()
-    //     .title("With styled borders and doubled borders")
-    //     .border_style(Style::default().fg(Color::Cyan))
-    //     .borders(Borders::LEFT | Borders::RIGHT)
-    //     .border_type(BorderType::Double);
-    // f.render_widget(block, bottom_chunks[1]);
-    // })?;
-
-    // if let key = rx.recv()? {
-    //     if key == Key::Char('q') {
-    //         break;
-    //     }
-    //     info!("I GOT A KEY {:?}", key);
-    // }
-    // }
-
+    let mut repl_focus = true;
     loop {
-        print!("wash> ");
-        use std::io::Write;
-        io::stdout().flush()?;
-        let input: String = read!("{}\n");
-        // This works but doesn't correctly interpret strings, like "{"x": 10}" will make two tokens: '{"x":' and '10}'
-        // For now, leaving this as a Vec of strings and `join`ing the vec by a space character will work.
-        let iter = input.split_ascii_whitespace();
-        let cli = ReplCli::from_iter(iter);
+        let res = match read()? {
+            // Tab toggles input focus between REPL and Tui logger selector
+            Event::Key(KeyEvent {
+                code: KeyCode::Tab, ..
+            }) => {
+                repl_focus = !repl_focus;
+                Ok(())
+            }
+            // Dispatch events for REPL interpretation
+            Event::Key(KeyEvent { code, modifiers }) if repl_focus => {
+                handle_key(&mut state, code, modifiers)
+            }
+            // Dispatch events for Tui Target interpretation
+            evt => {
+                dispatcher.borrow_mut().dispatch(&evt);
+                Ok(())
+            }
+        };
+        draw_ui(&state, &mut terminal, &tui_state, &dispatcher)?;
 
-        if let ReplCliCommand::Exit = cli.cmd {
-            println!("Have a good day!");
+        // Exit the terminal gracefully
+        if res.is_err() {
+            terminal.show_cursor().unwrap();
+            terminal.clear().unwrap();
+            crossterm::execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture).unwrap();
+            terminal::disable_raw_mode().unwrap();
             break;
         }
-        println!("Command parsed! {:?}\n", cli.cmd);
     }
     Ok(())
+}
+
+fn draw_ui(
+    state: &InputState,
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    tui_state: &TuiWidgetState,
+    dispatcher: &Rc<RefCell<Dispatcher<Event>>>,
+) -> Result<()> {
+    terminal.draw(|frame| {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(10), Constraint::Percentage(67)].as_ref())
+            .split(frame.size());
+
+        draw_input_panel(frame, state, chunks[0]);
+        draw_selector_panel(frame, chunks[1], tui_state, &dispatcher);
+    })?;
+    Ok(())
+}
+
+/// Draws the waSH REPL in the provided frame
+fn draw_input_panel(frame: &mut Frame<CrosstermBackend<Stdout>>, state: &InputState, chunk: Rect) {
+    let history: String = state
+        .history
+        .iter()
+        .map(|h| format!("wash> {}\n", h.iter().collect::<String>()))
+        .collect();
+    let prompt: String = "wash> ".to_string();
+    let input = state.input.iter().collect::<String>();
+    let display = format!("{}{}{}", history, prompt, input);
+
+    // 3 is the offset from the bottom of the screen
+    let scroll_offset = if state.history.len() as u16 >= chunk.height - 3 {
+        state.history.len() as u16 + 3 - chunk.height
+    } else {
+        0
+    };
+
+    // Draw REPL panel
+    let input_panel = Paragraph::new(display)
+        .block(Block::default().borders(Borders::ALL).title(Span::styled(
+            "REPL",
+            Style::default().add_modifier(Modifier::BOLD),
+        )))
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Left)
+        .scroll((scroll_offset, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(input_panel, chunk);
+
+    // Draw cursor on screen
+    // Offset X by length of prompt plus current cursor
+    // Offset Y by length of history (*2 for newlines)
+    let x_offset = prompt.len() as u16;
+    let input_cursor = state.cursor_location((chunk.width - 2) as usize);
+    frame.set_cursor(
+        chunk.x + 1 + input_cursor.0 + x_offset,
+        chunk.y + 1 + input_cursor.1 + state.history.len() as u16 - scroll_offset,
+    )
+}
+
+/// Draws the Tui smart logger widget in the provided frame
+fn draw_selector_panel(
+    frame: &mut Frame<CrosstermBackend<Stdout>>,
+    chunk: Rect,
+    state: &TuiWidgetState,
+    dispatcher: &Rc<RefCell<Dispatcher<Event>>>,
+) {
+    dispatcher.borrow_mut().clear();
+    let selector_panel = TuiLoggerSmartWidget::default()
+        .style_error(Style::default().fg(Color::Red))
+        .style_debug(Style::default().fg(Color::Green))
+        .style_warn(Style::default().fg(Color::Yellow))
+        .style_trace(Style::default().fg(Color::Magenta))
+        .style_info(Style::default().fg(Color::Cyan))
+        .state(state)
+        .dispatcher(dispatcher.clone());
+
+    frame.render_widget(selector_panel, chunk);
 }


### PR DESCRIPTION
This commit implements a terminal UI for the wash REPL as well as command parsing within that REPL.

In order to accomplish this, I'm making use of a few crates:
- `tui` and `crossterm` for the alternate terminal UI
- `tui-logger` for the smart logger widget that allows for runtime log level selection
- `log` for easy log macros (debug!, info!, warn!, error!, trace!)
- `unicode-width` as a helper crate for cursor position

TODO for wash up implementation:
- [x] Clean up Structopt error / help text (some characters are not interpreted correctly)
- [x] Ensure edge cases are handled (for example, just passing the version flag in the REPL crashes the REPL without graceful exit)

This PR does not actually execute any of the commands in the REPL, it only provides help text and will log to the `info` level that it parsed the command successfully. Work to implement these commands will likely happen in the `lattice` module of this project, (potentially renamed to command interface), and then used in addition to creating a Host for the REPL to interact with.

Feedback welcome, you can install this version of `wash` with the following command to check out the UI:
```
cargo install wash-cli --git https://github.com/brooksmtownsend/wash --branch wash-up --force
```