### PR TITLE
Initial ctl implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wash-cli"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Brooks Townsend <brooksmtownsend@gmail.com>"]
 edition = "2018"
-repository = "https://github.com/wascc/wash"
-description = "waSCC Shell (wash) CLI tool"
+repository = "https://github.com/wasmcloud/wash"
+description = "wasmCloud Shell (wash) CLI tool"
 license = "Apache-2.0"
 readme = "README.md"
-keywords = ["webassembly", "wascc", "wash"]
+keywords = ["webassembly", "wasmCloud", "wasmcloud", "wash"]
 categories = ["wasm", "command-line-utilities"]
 
 [badges]
@@ -21,6 +21,7 @@ serde = { version = "1.0.117", features = ["derive"] }
 crossbeam = "0.7.3"
 tokio = { version = "0.2.0" }
 spinners = "1.2.0"
+nats = "0.8.6"
 
 nkeys = "0.0.11"
 latticeclient = "0.4.0"
@@ -28,6 +29,7 @@ wascap = "0.5.1"
 term-table = "1.3.0"
 provider-archive = "0.3.0"
 oci-distribution = { git = "https://github.com/brooksmtownsend/krustlet", branch = "oci-push" }
+control-interface = { git = "https://github.com/wascc/wasmCloud", branch = "main"}
 
 [[bin]]
 name = "wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wascap = "0.5.1"
 term-table = "1.3.0"
 provider-archive = "0.3.0"
 oci-distribution = { git = "https://github.com/brooksmtownsend/krustlet", branch = "oci-push" }
-control-interface = { git = "https://github.com/wascc/wasmCloud", branch = "main"}
+control-interface = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main"}
 
 [[bin]]
 name = "wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wash-cli"
-version = "0.1.9"
+version = "0.1.11"
 authors = ["Brooks Townsend <brooksmtownsend@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"
 description = "wasmCloud Shell (wash) CLI tool"
 license = "Apache-2.0"
 readme = "README.md"
-keywords = ["webassembly", "wasmCloud", "wasmcloud", "wash"]
+keywords = ["webassembly", "wasmcloud", "wash"]
 categories = ["wasm", "command-line-utilities"]
 
 [badges]
@@ -21,6 +21,7 @@ serde = { version = "1.0.117", features = ["derive"] }
 crossbeam = "0.7.3"
 tokio = { version = "0.2.0" }
 spinners = "1.2.0"
+log = "0.4.11"
 nats = "0.8.6"
 
 nkeys = "0.0.11"

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -1,0 +1,461 @@
+extern crate control_interface;
+use control_interface::*;
+use std::time::Duration;
+use structopt::StructOpt;
+use term_table::row::Row;
+use term_table::table_cell::*;
+use term_table::{Table, TableStyle};
+use tokio::runtime::Runtime;
+
+use crate::util::convert_error;
+type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
+
+//TODO(brooksmtownsend): If theres a deadline that elapses, suggest specifying a namespace
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct CtlCli {
+    #[structopt(flatten)]
+    command: CtlCliCommand,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct ConnectionOpts {
+    /// RPC Host for connection, defaults to 0.0.0.0 for local nats
+    #[structopt(short = "r", long = "rpc-host", default_value = "0.0.0.0")]
+    rpc_host: String,
+
+    /// RPC Port for connections, defaults to 4222 for local nats
+    #[structopt(short = "p", long = "rpc-port", default_value = "4222")]
+    rpc_port: String,
+
+    /// Namespace prefix for wasmCloud command interface
+    #[structopt(short = "n", long = "ns-prefix")]
+    ns_prefix: Option<String>,
+
+    /// Timeout length for RPC, defaults to 1 second
+    #[structopt(short = "t", long = "timeout", default_value = "1")]
+    timeout: u64,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum CtlCliCommand {
+    /// Retrieves information about the lattice
+    #[structopt(name = "get")]
+    Get(GetCommand),
+
+    /// Start an actor or a provider
+    #[structopt(name = "start")]
+    Start(StartCommand),
+
+    /// Stop an actor or a provider
+    #[structopt(name = "stop")]
+    Stop(StopCommand),
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum GetCommand {
+    /// Query lattice for running hosts
+    #[structopt(name = "hosts")]
+    Hosts(GetHostsCommand),
+
+    /// Query lattice for the inventory of a host
+    #[structopt(name = "inventory")]
+    HostInventory(GetHostInventoryCommand),
+
+    /// Query lattice for claims present in the lattice
+    #[structopt(name = "claims")]
+    Claims(GetClaimsCommand),
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum StartCommand {
+    /// Launch an actor in a host
+    #[structopt(name = "actor")]
+    Actor(ActorCommand),
+
+    /// Launch a provider in a host
+    #[structopt(name = "provider")]
+    Provider(StartProviderCommand),
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub enum StopCommand {
+    /// Stop an actor running in a host
+    #[structopt(name = "actor")]
+    Actor(ActorCommand),
+
+    /// Stop a provider running in a host
+    #[structopt(name = "provider")]
+    Provider(StopProviderCommand),
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct GetHostsCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct GetHostInventoryCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    /// Id of host
+    #[structopt(name = "host-id")]
+    host_id: String,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct ActorCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    /// Id of host
+    #[structopt(name = "host-id")]
+    host_id: String,
+
+    /// Actor reference, e.g. the OCI URL for the actor
+    #[structopt(name = "actor-ref")]
+    actor_ref: String,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct StartProviderCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    /// Id of host
+    #[structopt(name = "host-id")]
+    host_id: String,
+
+    /// Provider reference, e.g. the OCI URL for the provider
+    #[structopt(name = "provider-ref")]
+    provider_ref: String,
+
+    /// Link name of provider
+    #[structopt(short = "l", long = "link-name")]
+    link_name: Option<String>,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct StopProviderCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    /// Id of host
+    #[structopt(name = "host-id")]
+    host_id: String,
+
+    /// Provider reference, e.g. the OCI URL for the provider
+    #[structopt(name = "provider-ref")]
+    provider_ref: String,
+
+    /// Link name of provider
+    #[structopt(name = "link-name")]
+    link_name: String,
+
+    /// Capability contract Id of provider
+    #[structopt(name = "contract-id")]
+    contract_id: String,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct GetClaimsCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+}
+
+pub fn handle_command(cli: CtlCli) -> Result<()> {
+    let mut rt = Runtime::new().unwrap();
+    // Since match arms are incompatible types, I can't surround this with a block_on
+    use CtlCliCommand::*;
+    match cli.command {
+        Get(GetCommand::Hosts(cmd)) => {
+            let ns = cmd.opts.ns_prefix.clone();
+            let hosts = rt.block_on(get_hosts(cmd))?;
+            display_hosts(hosts, ns);
+        }
+        Get(GetCommand::HostInventory(cmd)) => {
+            let inv = rt.block_on(get_host_inventory(cmd))?;
+            display_host_inventory(inv);
+        }
+        Get(GetCommand::Claims(cmd)) => {
+            let ns = cmd.opts.ns_prefix.clone();
+            let claims = rt.block_on(get_claims(cmd))?;
+            display_claims(claims, ns);
+        }
+        Start(StartCommand::Actor(cmd)) => {
+            rt.block_on(start_actor(cmd))?;
+        }
+        Start(StartCommand::Provider(cmd)) => {
+            rt.block_on(start_provider(cmd))?;
+        }
+        Stop(StopCommand::Actor(cmd)) => {
+            rt.block_on(stop_actor(cmd))?;
+        }
+        Stop(StopCommand::Provider(cmd)) => {
+            rt.block_on(stop_provider(cmd))?;
+        }
+    };
+    Ok(())
+}
+
+pub async fn new_ctl_client(
+    host: &str,
+    port: &str,
+    ns_prefix: Option<String>,
+    timeout: Duration,
+) -> Result<Client> {
+    let nc = nats::asynk::connect(&format!("{}:{}", host, port)).await?;
+    Ok(Client::new(nc, ns_prefix, timeout))
+}
+
+async fn client_from_opts(opts: ConnectionOpts) -> Result<Client> {
+    new_ctl_client(
+        &opts.rpc_host,
+        &opts.rpc_port,
+        opts.ns_prefix,
+        Duration::from_secs(opts.timeout),
+    )
+    .await
+}
+
+pub async fn get_hosts(cmd: GetHostsCommand) -> Result<Vec<Host>> {
+    let timeout = Duration::from_secs(cmd.opts.timeout);
+    let client = client_from_opts(cmd.opts).await?;
+    client.get_hosts(timeout).await.map_err(convert_error)
+}
+
+pub async fn get_host_inventory(cmd: GetHostInventoryCommand) -> Result<HostInventory> {
+    let client = client_from_opts(cmd.opts).await?;
+    client
+        .get_host_inventory(&cmd.host_id)
+        .await
+        .map_err(convert_error)
+}
+
+pub async fn get_claims(cmd: GetClaimsCommand) -> Result<ClaimsList> {
+    let client = client_from_opts(cmd.opts).await?;
+    client.get_claims().await.map_err(convert_error)
+}
+
+pub async fn start_actor(cmd: ActorCommand) -> Result<StartActorAck> {
+    let client = client_from_opts(cmd.opts).await?;
+    client
+        .start_actor(&cmd.host_id, &cmd.actor_ref)
+        .await
+        .map_err(convert_error)
+}
+
+pub async fn start_provider(cmd: StartProviderCommand) -> Result<StartProviderAck> {
+    let client = client_from_opts(cmd.opts).await?;
+    client
+        .start_provider(&cmd.host_id, &cmd.provider_ref, cmd.link_name)
+        .await
+        .map_err(convert_error)
+}
+
+pub async fn stop_provider(cmd: StopProviderCommand) -> Result<StopProviderAck> {
+    let client = client_from_opts(cmd.opts).await?;
+    client
+        .stop_provider(
+            &cmd.host_id,
+            &cmd.provider_ref,
+            &cmd.link_name,
+            &cmd.contract_id,
+        )
+        .await
+        .map_err(convert_error)
+}
+
+pub async fn stop_actor(cmd: ActorCommand) -> Result<StopActorAck> {
+    let client = client_from_opts(cmd.opts).await?;
+    client
+        .stop_actor(&cmd.host_id, &cmd.actor_ref)
+        .await
+        .map_err(convert_error)
+}
+
+/// Helper function to print a Host list to stdout as a table
+fn display_hosts(hosts: Vec<Host>, ns_prefix: Option<String>) {
+    let mut table = Table::new();
+    table.max_column_width = 68;
+    table.style = TableStyle::extended();
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        format!("Hosts - {}", ns_prefix.unwrap_or("".to_string())),
+        2,
+        Alignment::Center,
+    )]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new_with_alignment("Host ID", 1, Alignment::Left),
+        TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Right),
+    ]));
+    hosts.iter().for_each(|h| {
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment(h.id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(format!("{}", h.uptime_seconds), 1, Alignment::Right),
+        ]))
+    });
+
+    println!("{}", table.render());
+}
+
+/// Helper function to print a HostInventory to stdout as a table
+fn display_host_inventory(inv: HostInventory) {
+    let mut table = Table::new();
+    table.max_column_width = 68;
+    table.style = TableStyle::extended();
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        format!("Host Inventory - {}", inv.host_id),
+        3,
+        Alignment::Center,
+    )]));
+
+    if inv.labels.len() >= 1 {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "Labels",
+            3,
+            Alignment::Center,
+        )]));
+        inv.labels.iter().for_each(|(k, v)| {
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(k, 1, Alignment::Left),
+                TableCell::new_with_alignment(v, 2, Alignment::Right),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No labels present",
+            3,
+            Alignment::Center,
+        )]));
+    }
+
+    if inv.actors.len() >= 1 {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "Actors",
+            3,
+            Alignment::Center,
+        )]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Actor ID", 1, Alignment::Left),
+            TableCell::new_with_alignment("Image Reference", 2, Alignment::Right),
+        ]));
+        inv.actors.iter().for_each(|a| {
+            let a = a.clone();
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(a.id, 1, Alignment::Left),
+                TableCell::new_with_alignment(
+                    a.image_ref.unwrap_or("N/A".to_string()),
+                    2,
+                    Alignment::Right,
+                ),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No actors found",
+            3,
+            Alignment::Center,
+        )]));
+    }
+
+    if inv.providers.len() >= 1 {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "Providers",
+            3,
+            Alignment::Center,
+        )]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),
+            TableCell::new_with_alignment("Link Name", 1, Alignment::Center),
+            TableCell::new_with_alignment("Image Reference", 1, Alignment::Right),
+        ]));
+        inv.providers.iter().for_each(|p| {
+            let p = p.clone();
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(p.id, 1, Alignment::Left),
+                TableCell::new_with_alignment(p.link_name, 1, Alignment::Center),
+                TableCell::new_with_alignment(
+                    p.image_ref.unwrap_or("N/A".to_string()),
+                    1,
+                    Alignment::Right,
+                ),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No providers found",
+            3,
+            Alignment::Center,
+        )]));
+    }
+
+    println!("{}", table.render());
+}
+
+/// Helper function to print a ClaimsList to stdout as a table
+fn display_claims(list: ClaimsList, ns_prefix: Option<String>) {
+    let mut table = Table::new();
+    table.max_column_width = 68;
+    table.style = TableStyle::extended();
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        format!("Claims - {}", ns_prefix.unwrap_or("".to_string())),
+        2,
+        Alignment::Center,
+    )]));
+
+    list.claims.iter().for_each(|c| {
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Issuer", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("iss").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Right,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Subject", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("sub").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Right,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Capabilities", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("caps").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Right,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Version", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("version").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Right,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Revision", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("rev").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Right,
+            ),
+        ]));
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            format!(""),
+            2,
+            Alignment::Center,
+        )]));
+    });
+
+    println!("{}", table.render());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,26 @@ use structopt::StructOpt;
 
 mod claims;
 use claims::ClaimsCli;
-mod lattice;
-use lattice::LatticeCli;
+mod ctl;
+use ctl::CtlCli;
 mod keys;
 use keys::KeysCli;
 mod par;
 use par::ParCli;
 mod reg;
 use reg::RegCli;
+mod util;
 
 /// This renders appropriately with escape characters
 const ASCII: &str = "
-               __    ___   ___   __ _          _ _ 
-__      ____ _/ _\\  / __\\ / __\\ / _\\ |__   ___| | |
-\\ \\ /\\ / / _` \\ \\  / /   / /    \\ \\| '_ \\ / _ \\ | |
- \\ V  V / (_| |\\ \\/ /___/ /___  _\\ \\ | | |  __/ | |
-  \\_/\\_/ \\__,_\\__/\\____/\\____/  \\__/_| |_|\\___|_|_|
+                               _____ _                 _    _____ _          _ _ 
+                              / ____| |               | |  / ____| |        | | |
+ __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
+ \\ \\ /\\ / / _` / __| '_ ` _ \\| |    | |/ _ \\| | | |/ _` |  \\___ \\| '_ \\ / _ \\ | |
+  \\ V  V / (_| \\__ \\ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
+   \\_/\\_/ \\__,_|___/_| |_| |_|\\_____|_|\\___/ \\__,_|\\__,_| |_____/|_| |_|\\___|_|_|
 
-A single CLI to handle all of your waSCC tooling needs
+A single CLI to handle all of your wasmCloud tooling needs
 ";
 
 #[derive(Debug, Clone, StructOpt)]
@@ -34,19 +36,19 @@ struct Cli {
 
 #[derive(Debug, Clone, StructOpt)]
 enum CliCommand {
-    /// Utilities for generating and managing JWTs for waSCC Actors
+    /// Generate and manage JWTs for wasmCloud Actors
     #[structopt(name = "claims")]
     Claims(ClaimsCli),
-    /// Utilities for generating and managing keys
+    /// Generate and manage wasmCloud keys
     #[structopt(name = "keys")]
     Keys(KeysCli),
-    /// Utilities for interacting with a waSCC Lattice
-    #[structopt(name = "lattice")]
-    Lattice(LatticeCli),
-    /// Utilities for creating, inspecting, and modifying capability provider archive files
+    /// Interact with a wasmCloud control interface
+    #[structopt(name = "ctl")]
+    Ctl(CtlCli),
+    /// Create, inspect, and modify capability provider archive files
     #[structopt(name = "par")]
     Par(ParCli),
-    /// Utilities for interacting with OCI compliant registries
+    /// Interact with OCI compliant registries
     #[structopt(name = "reg")]
     Reg(RegCli),
 }
@@ -57,7 +59,7 @@ fn main() {
 
     let res = match cli.command {
         CliCommand::Keys(keyscli) => keys::handle_command(keyscli),
-        CliCommand::Lattice(latticecli) => lattice::handle_command(latticecli),
+        CliCommand::Ctl(ctlcli) => ctl::handle_command(ctlcli),
         CliCommand::Claims(claimscli) => claims::handle_command(claimscli),
         CliCommand::Par(parcli) => par::handle_command(parcli),
         CliCommand::Reg(regcli) => reg::handle_command(regcli),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,6 @@
+/// Helper function to convert from Send + Sync error to standard error
+pub(crate) fn convert_error(
+    e: Box<dyn ::std::error::Error + Send + Sync>,
+) -> Box<dyn ::std::error::Error> {
+    Box::<dyn std::error::Error>::from(format!("{}", e))
+}


### PR DESCRIPTION
This PR implements the `ctl` subcommand which interfaces with the wasmcloud control interface.

The `ctl` subcommand itself has its own subcommands, `get`, `start` and `stop`. The full list of commands is below:
`wash ctl get hosts`
`wash ctl get inventory`
`wash ctl get claims`
`wash ctl start actor`
`wash ctl start provider`
`wash ctl stop actor`
`wash ctl stop provider`

I've tested that these commands work by commenting out the calls to the command interface in this test: https://github.com/wascc/wasmCloud/blob/main/tests/control.rs and instead manually starting / stopping actors and providers while the test waits for the action to complete. 

This PR also does the lifting of renaming `wascc` to `wasmcloud` around the `wash` project, and created a `util` module for helper functions that are shared across the cli.

For `wash ctl start {actor,provider}`, if a host is not provided then an auction will kick off for the actor/provider, then it will be scheduled on the first suitable host