### PR TITLE
added support for WASH_RPC_HOST, _TIMEOUT, and _PORT to wash ctl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ spinners = "1.2.0"
 nats = "0.8.6"
 once_cell = "1.5.2"
 
-nkeys = "0.0.11"
+nkeys = "0.0.12"
 wascap = "0.5.1"
 term-table = "1.3.0"
 provider-archive = "0.3.1"

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -30,11 +30,21 @@ impl CtlCli {
 #[derive(Debug, Clone, StructOpt)]
 pub(crate) struct ConnectionOpts {
     /// RPC Host for connection, defaults to 0.0.0.0 for local nats
-    #[structopt(short = "r", long = "rpc-host", default_value = "0.0.0.0")]
+    #[structopt(
+        short = "r",
+        long = "rpc-host",
+        default_value = "0.0.0.0",
+        env = "WASH_RPC_HOST"
+    )]
     rpc_host: String,
 
     /// RPC Port for connections, defaults to 4222 for local nats
-    #[structopt(short = "p", long = "rpc-port", default_value = "4222")]
+    #[structopt(
+        short = "p",
+        long = "rpc-port",
+        default_value = "4222",
+        env = "WASH_RPC_PORT"
+    )]
     rpc_port: String,
 
     /// Namespace prefix for wasmCloud command interface
@@ -42,7 +52,12 @@ pub(crate) struct ConnectionOpts {
     ns_prefix: String,
 
     /// Timeout length for RPC, defaults to 5 seconds
-    #[structopt(short = "t", long = "rpc-timeout", default_value = "5")]
+    #[structopt(
+        short = "t",
+        long = "rpc-timeout",
+        default_value = "5",
+        env = "WASH_RPC_TIMEOUT"
+    )]
     rpc_timeout: u64,
 }
 


### PR DESCRIPTION
This PR adds support for the env variables `WASH_RPC_HOST`, `WASH_RPC_TIMEOUT`, and `WASH_RPC_PORT` to `wash ctl`.

These variables are used for `wash up` but were missing for the related flags in `wash ctl`
