### PR TITLE
Change push distribution code to 35

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -23,11 +23,7 @@ jobs:
           export VERSION=$(echo $REF | cut -d/ -f3)
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
-      - name: Push amd64 (Ubuntu 18.04)
-        run: curl -F "package[distro_version_id]=190" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push amd64 (Ubuntu 19.04)
-        run: curl -F "package[distro_version_id]=203" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push amd64 (Ubuntu 20.04)
-        run: curl -F "package[distro_version_id]=210" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push amd64 (deb)
+        run: curl -F "package[distro_version_id]=35" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
       - name: Push x86_64 (Fedora 32)
         run: curl -F "package[distro_version_id]=216" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json


### PR DESCRIPTION
Removes specific distribution id's from the push to package cloud.

Distribution ID `35` will allow any debian based distribution:
```
    {
      "display_name": "Any deb-based distribution.",
      "index_name": "any",
      "versions": [
        {
          "id": 35,
          "display_name": "Any version.",
          "index_name": "any",
          "version_number": null
        }
      ]
    }
```