### PR TITLE
refactor how we manage pushing deb/rpm to many distributions

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -30,6 +30,6 @@ jobs:
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
-        run: curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+        run: curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
       - name: Push x86_64 (rpm)
         run: curl -F "package[distro_version_id]=${{ matrix.rpm }}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -11,6 +11,12 @@ jobs:
     env:
       REF: ${{ github.ref }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
+
+    strategy:
+      matrix:
+        # distribution version numbers as supported by packagecloud.io
+        deb: [35, 150, 155, 156, 203, 206, 207, 210, 215, 219]
+        rpm: [140, 141, 146, 194, 204, 205, 209, 216]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -24,6 +30,6 @@ jobs:
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
-        run: curl -F "package[distro_version_id]=35" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push x86_64 (Fedora 32)
-        run: curl -F "package[distro_version_id]=216" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+        run: curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push x86_64 (rpm)
+        run: curl -F "package[distro_version_id]=${{ matrix.rpm }}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json


### PR DESCRIPTION
This refactors how we manage pushing to _many_ distributions.

Packagecloud uses "distribution version id's" which means in order to support different versions of ubuntu, debian, fedora, etc, we need to push a package with the specific id. 

Using the matrix for deb and rpm distribution id's, we can simplify this action considerably. If or when packagecloud adds support for a new distribution, we can simply add the ID to the matrix.