### PR TITLE
initial add of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.49 as builder
+
+WORKDIR /build
+
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY ./src ./src
+
+RUN apt update -y && apt install clang libssl-dev -y
+RUN cargo build --release
+
+FROM rust:1.49-slim-buster
+
+COPY --from=builder /build/target/release/wash /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/wash"]


### PR DESCRIPTION
This currently only adds the `Dockerfile` to our repo. If we prefer, we can hold on merging this until we add the CI action.
