### PR TITLE
Fix build matrix. Adds bionic to deb release versions

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -12,11 +12,6 @@ jobs:
       REF: ${{ github.ref }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
 
-    strategy:
-      matrix:
-        # distribution version numbers as supported by packagecloud.io
-        deb: [35, 150, 155, 156, 203, 206, 207, 210, 215, 219]
-        rpm: [140, 141, 146, 194, 204, 205, 209, 216]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -30,6 +25,14 @@ jobs:
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
-        run: curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+        run: |
+          debs=(35 150 155 156 190 203 206 207 210 215 219)
+          for distro_version in "${debs[@]}"; do
+            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json;
+          done
       - name: Push x86_64 (rpm)
-        run: curl -F "package[distro_version_id]=${{ matrix.rpm }}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+        run: |
+          rpms=(140 141 146 194 204 205 209 216)
+          for distro_version in "${rpms[@]}"; do 
+            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json;
+          done


### PR DESCRIPTION
@brooksmtownsend this should fix the issue with the build matrix. Decided to go with simple bash `for` loops. It also adds ubuntu bionic `190` to the list of distribution id's.