### PR TITLE
Bump all non-breaking changes with wascap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wash-cli"
-version = "0.1.18"
-authors = ["Brooks Townsend <brooksmtownsend@gmail.com>"]
+version = "0.1.19"
+authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"
 description = "wasmCloud Shell (wash) CLI tool"
@@ -14,23 +14,23 @@ categories = ["wasm", "command-line-utilities"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-structopt = "0.3.18"
-serde_json = { version = "1.0.60", features = ["raw_value"] }
-serde = { version = "1.0.117", features = ["derive"] }
+structopt = "0.3.21"
+serde_json = { version = "1.0.62", features = ["raw_value"] }
+serde = { version = "1.0.123", features = ["derive"] }
 serdeconv = "0.4.0"
 tui-logger =  { version = "0.4.9", default-features = false, features = ["tui-crossterm"] }
 tui = { version = "0.14.0", default-features = false, features = ["crossterm"] }
-log = "0.4.11"
+log = "0.4.14"
 crossterm = "0.18.2"
 actix-rt = "1.1.1"
 spinners = "1.2.0"
 nats = "0.8.6"
 once_cell = "1.5.2"
+term-table = "1.3.1"
 
-nkeys = "0.0.12"
-wascap = "0.5.2"
-term-table = "1.3.0"
-provider-archive = "0.3.2"
+nkeys = "0.1.0"
+wascap = "0.6.0"
+provider-archive = "0.4.0"
 oci-distribution = { git = "https://github.com/brooksmtownsend/krustlet", branch = "oci-push" }
 control-interface = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main"}
 wasmcloud-host = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ term-table = "1.3.1"
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
-oci-distribution = { git = "https://github.com/brooksmtownsend/krustlet", branch = "oci-push" }
+oci-distribution = "0.5.0"
 control-interface = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main"}
 wasmcloud-host = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main" }
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -424,6 +424,7 @@ fn generate_actor(actor: ActorMetadata) -> Result<String, Box<dyn ::std::error::
         actor.provider,
         actor.rev,
         actor.ver.clone(),
+        None,
     );
 
     let jwt = claims.encode(&issuer)?;
@@ -615,6 +616,7 @@ fn sign_file(cmd: SignCommand) -> Result<String, Box<dyn ::std::error::Error>> {
         cmd.metadata.provider,
         cmd.metadata.rev,
         cmd.metadata.ver.clone(),
+        None,
     )?;
 
     let destination = match cmd.destination.clone() {


### PR DESCRIPTION
`wascap` `0.5.2` -> `0.6.0`
`nkeys` `0.0.12` -> `0.1.0`
`provider-archive` `0.3.2` -> `0.4.0`
All other dependencies were updated patch versions to the latest available.