### PR TITLE
0.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wash-cli"
-version = "0.1.19"
+version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
-repository = "https://github.com/wasmcloud/wash"
+repository = "https://github.com/wasmCloud/wash"
 description = "wasmCloud Shell (wash) CLI tool"
 license = "Apache-2.0"
 readme = "README.md"
@@ -27,13 +27,13 @@ spinners = "1.2.0"
 nats = "0.8.6"
 once_cell = "1.5.2"
 term-table = "1.3.1"
+oci-distribution = "0.5.0"
 
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
-oci-distribution = "0.5.0"
-control-interface = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main"}
-wasmcloud-host = { git = "https://github.com/wasmcloud/wasmcloud", branch = "main" }
+wasmcloud-control-interface = "0.1.0"
+wasmcloud-host = "0.15.0"
 
 [[bin]]
 name = "wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ structopt = "0.3.21"
 serde_json = { version = "1.0.62", features = ["raw_value"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serdeconv = "0.4.0"
-tui-logger =  { version = "0.4.9", default-features = false, features = ["tui-crossterm"] }
+tui-logger =  { version = "0.4.13", default-features = false, features = ["tui-crossterm"] }
 tui = { version = "0.14.0", default-features = false, features = ["crossterm"] }
 log = "0.4.14"
-crossterm = "0.18.2"
+crossterm = "0.19.0"
 actix-rt = "1.1.1"
 spinners = "1.2.0"
 nats = "0.8.6"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Latest Release](https://img.shields.io/github/v/release/wasmcloud/wash?color=success&include_prereleases)
 ![Rust Build](https://img.shields.io/github/workflow/status/wasmcloud/wash/Rust/main)
-[![Rust Version](https://img.shields.io/badge/rustc-1.49.0-orange.svg)](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html) 
+[![Rust Version](https://img.shields.io/badge/rustc-1.50.0-orange.svg)](https://blog.rust-lang.org/2020/12/31/Rust-1.50.0.html) 
 ![Contributors](https://img.shields.io/github/contributors/wasmcloud/wash)
 ![Good first issues](https://img.shields.io/github/issues/wasmcloud/wash/good%20first%20issue?label=good%20first%20issues)
 ```
@@ -25,6 +25,8 @@ cargo install --git https://github.com/wasmcloud/wash --tag v0.1.18
 Generate JWTs for actors, capability providers, accounts and operators. Sign actor modules with claims including capability IDs, expiration, and keys to verify identity. Inspect actor modules to view their claims.
 ### ctl
 Interact directly with a wasmCloud [control-interface](https://github.com/wasmCloud/wasmCloud/tree/main/crates/control-interface), allowing you to imperatively schedule actors, providers and modify configurations of a wasmCloud host. Can be used to interact with local and remote control-interfaces.
+### drain
+Manage contents of the local wasmCloud cache. wasmCloud manages a local cache that will avoid redundant fetching of content when possible. `drain` allows you to manually clear that cache to ensure you're always pulling the latest versions of actors and providers that are hosted in remote OCI registries.
 ### keys
 Generate ed25519 keys for securely signing and identifying wasmCloud entities (actors, providers, hosts). Read more about our decision to use ed25519 keys in our [ADR](https://wasmcloud.github.io/adr/0005-security-nkeys.html)
 ### par
@@ -32,7 +34,7 @@ Create, modify and inspect [provider archives](https://github.com/wasmCloud/prov
 ### reg
 Push and Pull actors and capability providers to/from OCI compliant registries. Used extensively in our own CI/CD and in local development, where a local registry is used to store your development artifacts.
 ### up
-Launch a fully interactive wasmCloud REPL environment, where all of the above subcommands are available to you. `Up` provides you with a wasmCloud host, so you can get started running actors and providers without ever touching a line of code.
+Launch a fully interactive wasmCloud REPL environment, where all of the above subcommands are available to you. `up` provides you with a wasmCloud host, so you can get started running actors and providers without ever touching a line of code.
 
 ## Contributing to wash
 If you have any feature suggestions, find any bugs, or otherwise have a question, please submit an issue [here](https://github.com/wasmCloud/wash/issues/new). Forking & submitting Pull Requests are welcome, and the [good first issue](https://github.com/wasmCloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) label is a great way to find a place to start if you're looking to contribute.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,23 @@
 `wash` is a bundle of command line tools that, together, form a comprehensive CLI for [wasmCloud](https://github.com/wasmcloud/wasmcloud) development. Everything from generating signing keys to a fully interactive REPL environment is contained within the subcommands of `wash`. Our goal with `wash` is to encapsulate our tools into a single binary to make developing WebAssembly with wasmCloud painless and simple.
 
 ## Installing wash
+### Cargo
 ```
-cargo install --git https://github.com/wasmcloud/wash --tag v0.1.18
+cargo install wash-cli
+```
+### Linux
+```
+# Debian / Ubuntu (deb)
+curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+# Fedora (rpm)
+curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.rpm.sh | sudo bash
+
+sudo apt install wasmcloud wash
+```
+### MacOS
+```
+brew tap wasmcloud/wasmcloud
+brew install wasmcloud wash
 ```
 
 ## Using wash

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -351,9 +351,8 @@ fn get_keypair_vec(
     keys_dir: Option<String>,
     keypair_type: KeyPairType,
     disable_keygen: bool,
-) -> Result<Vec<KeyPair>, Box<dyn ::std::error::Error>> {
-    Ok(keys
-        .iter()
+) -> Vec<KeyPair> {
+    keys.iter()
         .map(|k| {
             extract_keypair(
                 Some(k.to_string()),
@@ -364,7 +363,7 @@ fn get_keypair_vec(
             )
             .unwrap()
         })
-        .collect())
+        .collect()
 }
 
 fn generate_actor(actor: ActorMetadata) -> Result<String, Box<dyn ::std::error::Error>> {
@@ -448,7 +447,7 @@ fn generate_operator(operator: OperatorMetadata) -> Result<String, Box<dyn ::std
             operator.common.directory.clone(),
             KeyPairType::Operator,
             true,
-        )?,
+        ),
         None => vec![],
     };
 
@@ -495,7 +494,7 @@ fn generate_account(account: AccountMetadata) -> Result<String, Box<dyn ::std::e
             account.common.directory.clone(),
             KeyPairType::Account,
             true,
-        )?,
+        ),
         None => vec![],
     };
 

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -1,9 +1,9 @@
-extern crate control_interface;
+extern crate wasmcloud_control_interface;
 use crate::util::{
     convert_error, format_output, json_str_to_msgpack_bytes, labels_vec_to_hashmap,
     output_destination, Output, OutputDestination, OutputKind, Result, WASH_CMD_INFO,
 };
-use control_interface::*;
+use wasmcloud_control_interface::*;
 use log::debug;
 use serde_json::json;
 use spinners::{Spinner, Spinners};

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -3,7 +3,6 @@ use crate::util::{
     convert_error, format_output, json_str_to_msgpack_bytes, labels_vec_to_hashmap,
     output_destination, Output, OutputDestination, OutputKind, Result, WASH_CMD_INFO,
 };
-use wasmcloud_control_interface::*;
 use log::debug;
 use serde_json::json;
 use spinners::{Spinner, Spinners};
@@ -12,6 +11,7 @@ use structopt::StructOpt;
 use term_table::row::Row;
 use term_table::table_cell::*;
 use term_table::{Table, TableStyle};
+use wasmcloud_control_interface::*;
 
 //TODO(brooksmtownsend): If theres a deadline that elapses, suggest specifying a namespace
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ enum CliCommand {
     Drain(DrainCli),
     /// Generate and manage JWTs for wasmCloud Actors
     #[structopt(name = "claims")]
-    Claims(ClaimsCli),
+    Claims(Box<ClaimsCli>),
     /// Utilities for generating and managing keys
     #[structopt(name = "keys", aliases = &["key"])]
     Keys(KeysCli),

--- a/src/par.rs
+++ b/src/par.rs
@@ -325,7 +325,7 @@ pub(crate) async fn handle_inspect(cmd: InspectCommand) -> Result<String> {
 
             let mut table = Table::new();
             table.max_column_width = 68;
-            table.style = TableStyle::extended();
+            table.style = TableStyle::blank();
 
             table.add_row(Row::new(vec![TableCell::new_with_alignment(
                 format!("{} - Provider Archive", metadata.name.unwrap()),

--- a/src/up.rs
+++ b/src/up.rs
@@ -10,7 +10,7 @@ use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use log::{error, info, LevelFilter};
 use std::io::{self, Stdout};
 use std::sync::{Arc, Mutex};
-use std::{cell::RefCell, io::Write, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 use structopt::{clap::AppSettings, StructOpt};
 use tui::{
     backend::CrosstermBackend,

--- a/src/up.rs
+++ b/src/up.rs
@@ -474,10 +474,12 @@ async fn handle_up(cmd: UpCliCommand) -> Result<()> {
                     Err(_e) => {
                         error!(
                             target: WASH_CMD_INFO,
-                            "Error connecting to NATS at {}:{}, running in hostless mode",
+                            "Error connecting to NATS at {}:{}",
                             cmd.rpc_host,
                             cmd.rpc_port
                         );
+                        error!(target: WASH_CMD_INFO, "NATS is required to run control interface (ctl) commands. Please refer to
+https://www.wasmcloud.dev/overview/getting-started/#starting-nats for instructions on how to launch NATS");
                         return;
                     }
                 };
@@ -487,10 +489,12 @@ async fn handle_up(cmd: UpCliCommand) -> Result<()> {
                     Err(_e) => {
                         error!(
                             target: WASH_CMD_INFO,
-                            "Error connecting to NATS at {}:{}, running in hostless mode",
+                            "Error connecting to NATS at {}:{}",
                             cmd.rpc_host,
                             cmd.rpc_port
                         );
+                        error!(target: WASH_CMD_INFO, "NATS is required to run control interface (ctl) commands. Please refer to
+https://www.wasmcloud.dev/overview/getting-started/#starting-nats for instructions on how to launch NATS");
                         return;
                     }
                 };


### PR DESCRIPTION
Fixes #70 , Fixes #41 , Fixes #37 

This fixes the remaining issues left in the 0.2.0 milestone. This PR also includes some help text for `drain`, and finally with git dependencies gone will allow the user to simply use `cargo install wash-cli` to install the cli.

I've also updated the error message when running `wash up` without a NATS connection. It now details the issue with running without NATS, and links to our documentation for installation instructions.