### PR TITLE
Allow tui logger to scroll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,29 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: make test-all
+    - name: Check fmt
+      run: cargo fmt -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -6,7 +6,29 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: make test-all
+    - name: Check fmt
+      run: cargo fmt -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   package:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-20.04
     env:
       REF: ${{ github.ref }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wash-cli"
-version = "0.2.1"
-authors = ["wasmcloud Team"]
+version = "0.3.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"
 description = "wasmcloud Shell (wash) CLI tool"
@@ -18,10 +18,10 @@ structopt = "0.3.21"
 serde_json = { version = "1.0.62", features = ["raw_value"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serdeconv = "0.4.0"
-tui-logger =  { version = "0.4.13", default-features = false, features = ["tui-crossterm"] }
-tui = { version = "0.14.0", default-features = false, features = ["crossterm"] }
+tui-logger = "0.6.0"
+tui = { version = "0.14.0", default-features = true }
 log = "0.4.14"
-crossterm = "0.19.0"
+termion = "1.5"
 actix-rt = "1.1.1"
 spinners = "1.2.0"
 nats = "0.8.6"

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -748,7 +748,7 @@ pub(crate) fn render_actor_claims(
         .unwrap()
         .call_alias
         .clone()
-        .unwrap_or("(Not set)".to_string());
+        .unwrap_or_else(|| "(Not set)".to_string());
 
     match output.kind {
         OutputKind::JSON => {

--- a/src/up.rs
+++ b/src/up.rs
@@ -319,14 +319,14 @@ impl WashRepl {
                     self.input_state.input.remove(self.input_state.input_cursor);
                 };
             }
-            Key::Alt(c) if c == 'b' => {
-                //TODO(issue #67): navigate left one word
-                ()
-            }
-            Key::Alt(c) if c == 'f' => {
-                //TODO(issue #67): navigate right one word
-                ()
-            }
+            //TODO(issue #67): navigate left one word
+            // Key::Alt(c) if c == 'b' => {
+            //     ()
+            // }
+            //TODO(issue #67): navigate right one word
+            // Key::Alt(c) if c == 'f' => {
+            //     ()
+            // }
             Key::Char(c) if c == '\n' => {
                 let cmd: String = self.input_state.input.iter().collect();
                 let iter = cmd.split_ascii_whitespace();
@@ -612,15 +612,12 @@ https://www.wasmcloud.dev/overview/getting-started/#starting-nats for instructio
     let (tx, rx) = std::sync::mpsc::channel();
     let tx_event = tx.clone();
     std::thread::spawn({
-        let f = {
-            let stdin = io::stdin();
-            move || {
-                for c in stdin.events() {
-                    tx_event.send(c).unwrap();
-                }
+        let stdin = io::stdin();
+        move || {
+            for c in stdin.events() {
+                tx_event.send(c).unwrap();
             }
-        };
-        f
+        }
     });
 
     loop {
@@ -818,7 +815,7 @@ fn draw_input_panel(frame: &mut Frame<REPLTermionBackend>, state: &mut InputStat
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(Span::styled(format!(" REPL "), style)),
+                .title(Span::styled(" REPL ", style)),
         )
         .style(Style::default().fg(Color::White))
         .alignment(Alignment::Left)


### PR DESCRIPTION
With the upgrade of tui_logger to `0.6.0`, we had to modify our terminal backend from crossterm to termion, which accounts for most of the code in this PR.

The important new features are:
- Added ALT+UP/DOWN / PageUp + PageDown handlers to the output pane and tui logger, which will scroll the appropriate pane depending on the current focus
- Added indicator of REPL focus, if focused on the input panel (e.g. typing commands) the REPL and Output window titles will be bold, if focused on the tui panel (e.g. scrolling through logs) the Tui panel will be bold.
- Using channels to send events to asynchronously draw REPL (modification needed as crossterm provided a way to asynchronously poll for events, rather than blocking iteration of events)

Because of the change from crossterm to termion, we no longer have support for SHIFT modified keycodes. Because of this, and changing to ALT, this will change the wash REPL API and we will need to bump to `0.3.0`

Before this is merged in, the following must be tested:
- [x] ALT / PgUp / PgDown commands work on Windows and Linux
- [x] Return (Enter) works on Windows and Linux