### PR TITLE
Link README badges to their resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![Latest Release](https://img.shields.io/github/v/release/wasmcloud/wash?color=success&include_prereleases)
-![Rust Build](https://img.shields.io/github/workflow/status/wasmcloud/wash/Rust/main)
-[![Rust Version](https://img.shields.io/badge/rustc-1.50.0-orange.svg)](https://blog.rust-lang.org/2020/12/31/Rust-1.50.0.html) 
-![Contributors](https://img.shields.io/github/contributors/wasmcloud/wash)
-![Good first issues](https://img.shields.io/github/issues/wasmcloud/wash/good%20first%20issue?label=good%20first%20issues)
+[![Latest Release](https://img.shields.io/github/v/release/wasmcloud/wash?color=success&include_prereleases)](https://github.com/wasmCloud/wash/releases)
+[![Rust Build](https://img.shields.io/github/workflow/status/wasmcloud/wash/Rust/main)](https://github.com/wasmCloud/wash/actions/workflows/rust.yml)
+[![Rust Version](https://img.shields.io/badge/rustc-1.50.0-orange.svg)](https://blog.rust-lang.org/2015/12/10/Rust-1.5.html) 
+[![Contributors](https://img.shields.io/github/contributors/wasmcloud/wash)](https://github.com/wasmCloud/wash/graphs/contributors)
+[![Good first issues](https://img.shields.io/github/issues/wasmcloud/wash/good%20first%20issue?label=good%20first%20issues)](https://github.com/wasmCloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 ```
                                      _                 _    _____ _          _ _ 
                                 ____| |               | |  / ____| |        | | |
@@ -43,7 +43,7 @@ Interact directly with a wasmcloud [control-interface](https://github.com/wasmcl
 ### drain
 Manage contents of the local wasmcloud cache. wasmcloud manages a local cache that will avoid redundant fetching of content when possible. `drain` allows you to manually clear that cache to ensure you're always pulling the latest versions of actors and providers that are hosted in remote OCI registries.
 ### keys
-Generate ed25519 keys for securely signing and identifying wasmcloud entities (actors, providers, hosts). Read more about our decision to use ed25519 keys in our [ADR](https://wasmcloud.github.io/adr/0005-security-nkeys.html)
+Generate ed25519 keys for securely signing and identifying wasmcloud entities (actors, providers, hosts). Read more about our decision to use ed25519 keys in our [ADR](https://wasmcloud.github.io/adr/0005-security-nkeys.html).
 ### par
 Create, modify and inspect [provider archives](https://github.com/wasmcloud/provider-archive), a TAR format that contains a signed JWT and OS/Architecture specific binaries for native capability providers.
 ### reg
@@ -52,4 +52,4 @@ Push and Pull actors and capability providers to/from OCI compliant registries. 
 Launch a fully interactive wasmcloud REPL environment, where all of the above subcommands are available to you. `up` provides you with a wasmcloud host, so you can get started running actors and providers without ever touching a line of code.
 
 ## Contributing to wash
-If you have any feature suggestions, find any bugs, or otherwise have a question, please submit an issue [here](https://github.com/wasmcloud/wash/issues/new). Forking & submitting Pull Requests are welcome, and the [good first issue](https://github.com/wasmcloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) label is a great way to find a place to start if you're looking to contribute.
+If you have any feature suggestions, find any bugs, or otherwise have a question, please submit an issue [here](https://github.com/wasmcloud/wash/issues/new/choose). Forking & submitting Pull Requests are welcome, and the [good first issue](https://github.com/wasmcloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) label is a great way to find a place to start if you're looking to contribute.


### PR DESCRIPTION
Currently, the README shields.io badges just link to the badge image itself, this PR allows repository viewers to click on the badge to go to the appropriate resource (rust build status, contributors, good first issues, etc)