### PR TITLE
No lattice repl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
 wasmcloud-control-interface = "0.1.0"
-wasmcloud-host = "0.15.1"
+wasmcloud-host = "0.15.3"
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,18 +22,18 @@ tui-logger = "0.6.0"
 tui = { version = "0.14.0", default-features = true }
 log = "0.4.14"
 termion = "1.5"
-actix-rt = "1.1.1"
+actix-rt = "2.2.0"
 spinners = "1.2.0"
 nats = "0.8.6"
 once_cell = "1.5.2"
 term-table = "1.3.1"
-oci-distribution = "0.5.0"
+oci-distribution = "0.6.0"
 
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
-wasmcloud-control-interface = "0.1.0"
-wasmcloud-host = "0.15.3"
+wasmcloud-control-interface = "0.2.1"
+wasmcloud-host = "0.16.1"
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
 wasmcloud-control-interface = "0.2.1"
-wasmcloud-host = "0.16.1"
+wasmcloud-host = "0.17.0"
 
 [dev-dependencies]
 test_bin = "0.3.0"
-reqwest = { version = "0.11", features = ["blocking"] }
+awc = "3.0.0-beta.4"
 
 [[bin]]
 name = "wash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ oci-distribution = "0.6.0"
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
-wasmcloud-control-interface = { path = "../wasmcloud/crates/wasmcloud-control-interface", version = "0.3.0" }
-wasmcloud-host = { path = "../wasmcloud/crates/wasmcloud-host", version = "0.18.0" }
+wasmcloud-control-interface = "0.3.0"
+wasmcloud-host = "0.18.0"
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ oci-distribution = "0.6.0"
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
-wasmcloud-control-interface = "0.2.1"
-wasmcloud-host = "0.17.0"
+wasmcloud-control-interface = { path = "../wasmcloud/crates/wasmcloud-control-interface", version = "0.3.0" }
+wasmcloud-host = { path = "../wasmcloud/crates/wasmcloud-host", version = "0.18.0" }
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -430,7 +430,11 @@ fn generate_actor(actor: ActorMetadata) -> Result<String, Box<dyn ::std::error::
     );
 
     let jwt = claims.encode(&issuer)?;
-    let out = format_output(jwt.clone(), json!({ "token": jwt }), &actor.common.output);
+    let out = format_output(
+        jwt.clone(),
+        json!({ "token": jwt }),
+        &actor.common.output.kind,
+    );
 
     Ok(out)
 }
@@ -471,7 +475,7 @@ fn generate_operator(operator: OperatorMetadata) -> Result<String, Box<dyn ::std
     let out = format_output(
         jwt.clone(),
         json!({ "token": jwt }),
-        &operator.common.output,
+        &operator.common.output.kind,
     );
     Ok(out)
 }
@@ -514,7 +518,11 @@ fn generate_account(account: AccountMetadata) -> Result<String, Box<dyn ::std::e
         },
     );
     let jwt = claims.encode(&issuer)?;
-    let out = format_output(jwt.clone(), json!({ "token": jwt }), &account.common.output);
+    let out = format_output(
+        jwt.clone(),
+        json!({ "token": jwt }),
+        &account.common.output.kind,
+    );
     Ok(out)
 }
 
@@ -550,7 +558,7 @@ fn generate_provider(provider: ProviderMetadata) -> Result<String, Box<dyn ::std
     let out = format_output(
         jwt.clone(),
         json!({ "token": jwt }),
-        &provider.common.output,
+        &provider.common.output.kind,
     );
     Ok(out)
 }
@@ -654,7 +662,7 @@ fn sign_file(cmd: SignCommand) -> Result<String, Box<dyn ::std::error::Error>> {
                 caps_list.join(",")
             ),
             json!({"result": "success", "destination": destination, "capabilities": caps_list}),
-            &cmd.metadata.common.output,
+            &cmd.metadata.common.output.kind,
         )),
         Err(e) => Err(Box::new(e)),
     }?;

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -759,7 +759,7 @@ pub(crate) fn render_actor_claims(
         .unwrap_or_else(|| "(Not set)".to_string());
 
     match output.kind {
-        OutputKind::JSON => {
+        OutputKind::Json => {
             let iss_label = token_label(&claims.issuer).to_ascii_lowercase();
             let sub_label = token_label(&claims.subject).to_ascii_lowercase();
             let provider_json = provider.replace(" ", "_").to_ascii_lowercase();
@@ -1110,7 +1110,7 @@ mod test {
                 assert_eq!(metadata.common.expires_in_days.unwrap(), 3);
                 assert_eq!(metadata.common.not_before_days.unwrap(), 1);
                 assert!(metadata.common.disable_keygen);
-                assert_eq!(metadata.common.output.kind, OutputKind::JSON);
+                assert_eq!(metadata.common.output.kind, OutputKind::Json);
                 assert!(metadata.keyvalue);
                 assert!(metadata.msg_broker);
                 assert!(metadata.http_server);
@@ -1183,7 +1183,7 @@ mod test {
                 assert_eq!(metadata.common.expires_in_days.unwrap(), 3);
                 assert_eq!(metadata.common.not_before_days.unwrap(), 1);
                 assert!(metadata.common.disable_keygen);
-                assert_eq!(metadata.common.output.kind, OutputKind::JSON);
+                assert_eq!(metadata.common.output.kind, OutputKind::Json);
                 assert!(metadata.keyvalue);
                 assert!(metadata.msg_broker);
                 assert!(metadata.http_server);
@@ -1262,7 +1262,7 @@ mod test {
                     NBFR.parse::<u64>().unwrap()
                 );
                 assert!(common.disable_keygen);
-                assert_eq!(common.output.kind, OutputKind::JSON);
+                assert_eq!(common.output.kind, OutputKind::Json);
                 assert_eq!(issuer.unwrap(), OPERATOR_KEY);
                 assert_eq!(subject.unwrap(), ACCOUNT_KEY);
                 let adds = additional_signing_keys.unwrap();
@@ -1339,7 +1339,7 @@ mod test {
                     NBFR.parse::<u64>().unwrap()
                 );
                 assert!(common.disable_keygen);
-                assert_eq!(common.output.kind, OutputKind::JSON);
+                assert_eq!(common.output.kind, OutputKind::Json);
                 assert_eq!(issuer.unwrap(), ACCOUNT_KEY);
                 assert_eq!(subject.unwrap(), ACTOR_KEY);
                 assert!(keyvalue);
@@ -1399,7 +1399,7 @@ mod test {
                     NBFR.parse::<u64>().unwrap()
                 );
                 assert!(common.disable_keygen);
-                assert_eq!(common.output.kind, OutputKind::JSON);
+                assert_eq!(common.output.kind, OutputKind::Json);
                 assert_eq!(issuer.unwrap(), OPERATOR_KEY);
                 let adds = additional_signing_keys.unwrap();
                 assert_eq!(adds.len(), 1);
@@ -1459,7 +1459,7 @@ mod test {
                     NBFR.parse::<u64>().unwrap()
                 );
                 assert!(common.disable_keygen);
-                assert_eq!(common.output.kind, OutputKind::JSON);
+                assert_eq!(common.output.kind, OutputKind::Json);
                 assert_eq!(issuer.unwrap(), ACCOUNT_KEY);
                 assert_eq!(subject.unwrap(), PROVIDER_KEY);
                 assert_eq!(capid, "wasmcloud:test");

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -28,7 +28,7 @@ use structopt::StructOpt;
 use term_table::{
     row::Row,
     table_cell::{Alignment, TableCell},
-    Table, TableStyle,
+    Table,
 };
 use wascap::caps::*;
 use wascap::jwt::{
@@ -842,7 +842,7 @@ where
 {
     let mut table = Table::new();
     table.max_column_width = max_width.unwrap_or(68);
-    table.style = TableStyle::blank();
+    table.style = crate::util::empty_table_style();
     table.separate_rows = false;
     let headline = format!("{} - {}", claims.name(), token_label(&claims.subject));
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1,10 +1,9 @@
 extern crate wasmcloud_control_interface;
 use crate::util::{
-    convert_error, format_output, json_str_to_msgpack_bytes, labels_vec_to_hashmap,
-    output_destination, Output, OutputDestination, OutputKind, Result, WASH_CMD_INFO,
+    convert_error, json_str_to_msgpack_bytes, labels_vec_to_hashmap, output_destination, Output,
+    OutputDestination, OutputKind, Result, WASH_CMD_INFO,
 };
 use log::debug;
-use serde_json::json;
 use spinners::{Spinner, Spinners};
 use std::time::Duration;
 use structopt::StructOpt;
@@ -435,18 +434,13 @@ pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {
                 "Sending request to update actor {} to {}",
                 cmd.actor_id, cmd.new_actor_ref
             );
-            match update_actor(cmd.clone()).await {
-                Ok(r) => format_output(
-                    format!("\nActor {} updated to {}", cmd.actor_id, cmd.new_actor_ref),
-                    json!({ "ack": r }),
-                    &output.kind,
-                ),
-                Err(e) => format_output(
-                    format!("\nError updating actor: {}", e),
-                    json!({ "error": format!("{}", e) }),
-                    &output.kind,
-                ),
-            }
+            let ack = update_actor(cmd.clone()).await;
+            update_actor_output(
+                &cmd.actor_id,
+                &cmd.new_actor_ref,
+                ack.map_or_else(|e| Some(format!("{}", e)), |_| None),
+                &cmd.output.kind,
+            )
         }
     };
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -201,7 +201,7 @@ pub(crate) struct GetHostInventoryCommand {
 
     /// Id of host
     #[structopt(name = "host-id")]
-    host_id: String,
+    pub(crate) host_id: String,
 }
 
 #[derive(Debug, Clone, StructOpt)]

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -611,7 +611,7 @@ fn update_spinner_message(
     if let Some(sp) = spinner {
         sp.message(msg);
         Some(sp)
-    } else if output.kind == OutputKind::Text && output_destination() == OutputDestination::CLI {
+    } else if output.kind == OutputKind::Text && output_destination() == OutputDestination::Cli {
         Some(Spinner::new(Spinners::Dots12, msg))
     } else {
         None
@@ -664,7 +664,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(operation, "HandleOperation");
                 assert_eq!(data, vec!["{ \"hello\": \"world\"}".to_string()])
@@ -706,7 +706,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(host_id.unwrap(), HOST_ID.to_string());
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v1".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
@@ -752,7 +752,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
                 assert_eq!(host_id.unwrap(), HOST_ID.to_string());
@@ -789,7 +789,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(host_id, HOST_ID.to_string());
                 assert_eq!(actor_id, ACTOR_ID.to_string());
             }
@@ -827,7 +827,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(host_id, HOST_ID.to_string());
                 assert_eq!(provider_id, PROVIDER_ID.to_string());
                 assert_eq!(link_name, "default".to_string());
@@ -862,7 +862,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(timeout, 5);
             }
             cmd => panic!("ctl get hosts constructed incorrect command {:?}", cmd),
@@ -893,7 +893,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(host_id, HOST_ID.to_string());
             }
             cmd => panic!("ctl get inventory constructed incorrect command {:?}", cmd),
@@ -919,7 +919,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),
         }
@@ -957,7 +957,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(actor_id, ACTOR_ID.to_string());
                 assert_eq!(provider_id, PROVIDER_ID.to_string());
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
@@ -996,7 +996,7 @@ mod test {
                 assert_eq!(opts.rpc_port, RPC_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.rpc_timeout, 1);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(host_id, HOST_ID.to_string());
                 assert_eq!(actor_id, ACTOR_ID.to_string());
                 assert_eq!(new_actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -1,0 +1,337 @@
+extern crate wasmcloud_control_interface;
+use crate::util::{format_output, OutputKind, WASH_CMD_INFO};
+use log::debug;
+use serde_json::json;
+use term_table::{row::Row, table_cell::*, Table, TableStyle};
+use wasmcloud_control_interface::*;
+
+// Helper output functions, used to ensure consistent output between ctl & standalone commands
+
+pub(crate) fn call_output(error: Option<String>, msg: Vec<u8>, output_kind: &OutputKind) -> String {
+    match error {
+        Some(e) => format_output(
+            format!("\nError invoking actor: {}", e),
+            json!({ "error": e }),
+            &output_kind,
+        ),
+        None => {
+            //TODO(brooksmtownsend): String::from_utf8_lossy should be decoder only if one is not available
+            let call_response = String::from_utf8_lossy(&msg);
+            format_output(
+                format!("\nCall response (raw): {}", call_response),
+                json!({ "response": call_response }),
+                &output_kind,
+            )
+        }
+    }
+}
+pub(crate) fn get_hosts_output(hosts: Vec<Host>, output_kind: &OutputKind) -> String {
+    debug!(target: WASH_CMD_INFO, "Hosts:{:?}", hosts);
+    match output_kind {
+        OutputKind::Text => hosts_table(hosts, None),
+        OutputKind::JSON => format!("{}", json!({ "hosts": hosts })),
+    }
+}
+pub(crate) fn get_host_inventory_output(inv: HostInventory, output_kind: &OutputKind) -> String {
+    debug!(target: WASH_CMD_INFO, "Inventory:{:?}", inv);
+    match output_kind {
+        OutputKind::Text => host_inventory_table(inv, None),
+        OutputKind::JSON => format!("{}", json!({ "inventory": inv })),
+    }
+}
+pub(crate) fn get_claims_output(claims: ClaimsList, output_kind: &OutputKind) -> String {
+    debug!(target: WASH_CMD_INFO, "Claims:{:?}", claims);
+    match output_kind {
+        OutputKind::Text => claims_table(claims, None),
+        OutputKind::JSON => format!("{}", json!({ "claims": claims })),
+    }
+}
+pub(crate) fn link_output(
+    actor_id: &str,
+    provider_id: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    debug!(
+        target: WASH_CMD_INFO,
+        "Publishing link between {} and {}", actor_id, provider_id
+    );
+    match failure {
+        None => format_output(
+            format!(
+                "\nAdvertised link ({}) <-> ({}) successfully",
+                actor_id, provider_id
+            ),
+            json!({"actor_id": actor_id, "provider_id": provider_id, "result": "published"}),
+            output_kind,
+        ),
+        Some(f) => format_output(
+            format!("\nError advertising link: {}", f),
+            json!({ "error": f }),
+            output_kind,
+        ),
+    }
+}
+pub(crate) fn start_actor_output(
+    actor_ref: &str,
+    host_id: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    debug!(
+        target: WASH_CMD_INFO,
+        "Sending request to start actor {}", actor_ref
+    );
+    match failure {
+        None => format_output(
+            format!("\nActor starting on host {}", host_id),
+            json!({ "actor_ref": actor_ref, "host_id": host_id }),
+            &output_kind,
+        ),
+        Some(f) => format_output(
+            format!("\nError starting actor: {}", f),
+            json!({ "error": f }),
+            &output_kind,
+        ),
+    }
+}
+pub(crate) fn start_provider_output(
+    provider_ref: &str,
+    host_id: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    debug!(
+        target: WASH_CMD_INFO,
+        "Sending request to start provider {}", provider_ref
+    );
+    match failure {
+        None => format_output(
+            format!("\nProvider starting on host {}", host_id),
+            json!({ "provider_ref": provider_ref, "host_id": host_id}),
+            output_kind,
+        ),
+        Some(e) => format_output(
+            format!("\nError starting provider: {}", e),
+            json!({ "error": e }),
+            output_kind,
+        ),
+    }
+}
+pub(crate) fn stop_actor_output(
+    actor_ref: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    match failure {
+        Some(f) => format_output(
+            format!("\nError stopping actor: {}", f),
+            json!({ "error": f }),
+            &output_kind,
+        ),
+        None => format_output(
+            format!("\nStopping actor: {}", actor_ref),
+            json!({ "actor_ref": actor_ref }),
+            &output_kind,
+        ),
+    }
+}
+pub(crate) fn stop_provider_output(
+    provider_ref: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    match failure {
+        Some(f) => format_output(
+            format!("\nError stopping provider: {}", f),
+            json!({ "error": f }),
+            output_kind,
+        ),
+        None => format_output(
+            format!("\nStopping provider: {}", provider_ref),
+            json!({ "provider_ref": provider_ref }),
+            output_kind,
+        ),
+    }
+}
+
+/// Helper function to print a Host list to stdout as a table
+pub(crate) fn hosts_table(hosts: Vec<Host>, max_width: Option<usize>) -> String {
+    let mut table = Table::new();
+    table.max_column_width = max_width.unwrap_or(80);
+    table.style = TableStyle::blank();
+    table.separate_rows = false;
+
+    table.add_row(Row::new(vec![
+        TableCell::new_with_alignment("Host ID", 1, Alignment::Left),
+        TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Left),
+    ]));
+    hosts.iter().for_each(|h| {
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment(h.id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(format!("{}", h.uptime_seconds), 1, Alignment::Left),
+        ]))
+    });
+
+    table.render()
+}
+
+/// Helper function to print a HostInventory to stdout as a table
+pub(crate) fn host_inventory_table(inv: HostInventory, max_width: Option<usize>) -> String {
+    let mut table = Table::new();
+    table.max_column_width = max_width.unwrap_or(80);
+    table.style = TableStyle::blank();
+    table.separate_rows = false;
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        format!("Host Inventory ({})", inv.host_id),
+        4,
+        Alignment::Center,
+    )]));
+
+    if !inv.labels.is_empty() {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "",
+            4,
+            Alignment::Center,
+        )]));
+        inv.labels.iter().for_each(|(k, v)| {
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(k, 2, Alignment::Left),
+                TableCell::new_with_alignment(v, 2, Alignment::Left),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No labels present",
+            4,
+            Alignment::Center,
+        )]));
+    }
+
+    if !inv.actors.is_empty() {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "",
+            4,
+            Alignment::Center,
+        )]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Actor ID", 2, Alignment::Left),
+            TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
+        ]));
+        inv.actors.iter().for_each(|a| {
+            let a = a.clone();
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(a.id, 2, Alignment::Left),
+                TableCell::new_with_alignment(
+                    a.image_ref.unwrap_or_else(|| "N/A".to_string()),
+                    2,
+                    Alignment::Left,
+                ),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No actors found",
+            4,
+            Alignment::Center,
+        )]));
+    }
+
+    if !inv.providers.is_empty() {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "",
+            4,
+            Alignment::Center,
+        )]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Provider ID", 2, Alignment::Left),
+            TableCell::new_with_alignment("Link Name", 1, Alignment::Left),
+            TableCell::new_with_alignment("Image Reference", 1, Alignment::Left),
+        ]));
+        inv.providers.iter().for_each(|p| {
+            let p = p.clone();
+            table.add_row(Row::new(vec![
+                TableCell::new_with_alignment(p.id, 2, Alignment::Left),
+                TableCell::new_with_alignment(p.link_name, 1, Alignment::Left),
+                TableCell::new_with_alignment(
+                    p.image_ref.unwrap_or_else(|| "N/A".to_string()),
+                    1,
+                    Alignment::Left,
+                ),
+            ]))
+        });
+    } else {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "No providers found",
+            4,
+            Alignment::Left,
+        )]));
+    }
+
+    table.render()
+}
+
+/// Helper function to print a ClaimsList to stdout as a table
+pub(crate) fn claims_table(list: ClaimsList, max_width: Option<usize>) -> String {
+    let mut table = Table::new();
+    table.style = TableStyle::blank();
+    table.separate_rows = false;
+    table.max_column_width = max_width.unwrap_or(80);
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        "Claims",
+        2,
+        Alignment::Center,
+    )]));
+
+    list.claims.iter().for_each(|c| {
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Issuer", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("iss").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Left,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Subject", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("sub").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Left,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Capabilities", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("caps").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Left,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Version", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("version").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Left,
+            ),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment("Revision", 1, Alignment::Left),
+            TableCell::new_with_alignment(
+                c.values.get("rev").unwrap_or(&"".to_string()),
+                1,
+                Alignment::Left,
+            ),
+        ]));
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            format!(""),
+            2,
+            Alignment::Center,
+        )]));
+    });
+
+    table.render()
+}

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -15,7 +15,7 @@ pub(crate) fn call_output(error: Option<String>, msg: Vec<u8>, output_kind: &Out
             &output_kind,
         ),
         None => {
-            //TODO(brooksmtownsend): String::from_utf8_lossy should be decoder only if one is not available
+            //TODO(issue #32): String::from_utf8_lossy should be decoder only if one is not available
             let call_response = String::from_utf8_lossy(&msg);
             format_output(
                 format!("\nCall response (raw): {}", call_response),
@@ -152,6 +152,26 @@ pub(crate) fn stop_provider_output(
             json!({ "provider_ref": provider_ref }),
             output_kind,
         ),
+    }
+}
+pub(crate) fn update_actor_output(
+    actor_id: &str,
+    new_actor_ref: &str,
+    error: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    if let Some(e) = error {
+        format_output(
+            format!("\nError updating actor: {}", e),
+            json!({ "error": format!("{}", e) }),
+            output_kind,
+        )
+    } else {
+        format_output(
+            format!("\nActor {} updated to {}", actor_id, new_actor_ref),
+            json!({ "accepted": error.is_none() }),
+            output_kind,
+        )
     }
 }
 

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -29,21 +29,21 @@ pub(crate) fn get_hosts_output(hosts: Vec<Host>, output_kind: &OutputKind) -> St
     debug!(target: WASH_CMD_INFO, "Hosts:{:?}", hosts);
     match output_kind {
         OutputKind::Text => hosts_table(hosts, None),
-        OutputKind::JSON => format!("{}", json!({ "hosts": hosts })),
+        OutputKind::Json => format!("{}", json!({ "hosts": hosts })),
     }
 }
 pub(crate) fn get_host_inventory_output(inv: HostInventory, output_kind: &OutputKind) -> String {
     debug!(target: WASH_CMD_INFO, "Inventory:{:?}", inv);
     match output_kind {
         OutputKind::Text => host_inventory_table(inv, None),
-        OutputKind::JSON => format!("{}", json!({ "inventory": inv })),
+        OutputKind::Json => format!("{}", json!({ "inventory": inv })),
     }
 }
 pub(crate) fn get_claims_output(claims: ClaimsList, output_kind: &OutputKind) -> String {
     debug!(target: WASH_CMD_INFO, "Claims:{:?}", claims);
     match output_kind {
         OutputKind::Text => claims_table(claims, None),
-        OutputKind::JSON => format!("{}", json!({ "claims": claims })),
+        OutputKind::Json => format!("{}", json!({ "claims": claims })),
     }
 }
 pub(crate) fn link_output(
@@ -163,7 +163,7 @@ pub(crate) fn update_actor_output(
     if let Some(e) = error {
         format_output(
             format!("\nError updating actor: {}", e),
-            json!({ "error": format!("{}", e) }),
+            json!({ "error": e }),
             output_kind,
         )
     } else {

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -2,7 +2,7 @@ extern crate wasmcloud_control_interface;
 use crate::util::{format_output, OutputKind, WASH_CMD_INFO};
 use log::debug;
 use serde_json::json;
-use term_table::{row::Row, table_cell::*, Table, TableStyle};
+use term_table::{row::Row, table_cell::*, Table};
 use wasmcloud_control_interface::*;
 
 // Helper output functions, used to ensure consistent output between ctl & standalone commands
@@ -159,7 +159,7 @@ pub(crate) fn stop_provider_output(
 pub(crate) fn hosts_table(hosts: Vec<Host>, max_width: Option<usize>) -> String {
     let mut table = Table::new();
     table.max_column_width = max_width.unwrap_or(80);
-    table.style = TableStyle::blank();
+    table.style = crate::util::empty_table_style();
     table.separate_rows = false;
 
     table.add_row(Row::new(vec![
@@ -180,7 +180,7 @@ pub(crate) fn hosts_table(hosts: Vec<Host>, max_width: Option<usize>) -> String 
 pub(crate) fn host_inventory_table(inv: HostInventory, max_width: Option<usize>) -> String {
     let mut table = Table::new();
     table.max_column_width = max_width.unwrap_or(80);
-    table.style = TableStyle::blank();
+    table.style = crate::util::empty_table_style();
     table.separate_rows = false;
 
     table.add_row(Row::new(vec![TableCell::new_with_alignment(
@@ -275,7 +275,7 @@ pub(crate) fn host_inventory_table(inv: HostInventory, max_width: Option<usize>)
 /// Helper function to print a ClaimsList to stdout as a table
 pub(crate) fn claims_table(list: ClaimsList, max_width: Option<usize>) -> String {
     let mut table = Table::new();
-    table.style = TableStyle::blank();
+    table.style = crate::util::empty_table_style();
     table.separate_rows = false;
     table.max_column_width = max_width.unwrap_or(80);
 

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -70,7 +70,7 @@ impl DrainCliCommand {
         }
         Ok(match self.output_kind() {
             OutputKind::Text => format!("Successfully cleared caches at: {:?}", cleared),
-            OutputKind::JSON => json!({ "drained": cleared }).to_string(),
+            OutputKind::Json => json!({ "drained": cleared }).to_string(),
         })
     }
 }
@@ -110,7 +110,7 @@ mod test {
         }
         let oci = DrainCli::from_iter_safe(&["drain", "oci", "-o", "json"]).unwrap();
         match oci.command.selection {
-            DrainSelection::Oci(output) => assert_eq!(output.kind, OutputKind::JSON),
+            DrainSelection::Oci(output) => assert_eq!(output.kind, OutputKind::Json),
             _ => panic!("drain constructed incorrect command"),
         }
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -113,7 +113,7 @@ pub(crate) fn get(
         Ok(s) => Ok(format_output(
             s.trim().to_string(),
             json!({ "seed": s.trim() }),
-            output,
+            &output.kind,
         )),
     }
 }
@@ -211,7 +211,7 @@ If you'd like to use alternative keys, you can supply them as a flag.\n",
                         path
                     ),
                     json!({"status": "No keypair found", "path": path, "keygen": "true"}),
-                    &Output::default(),
+                    &Output::default().kind,
                 ));
 
                 let kp = KeyPair::new(keygen_type);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -85,7 +85,7 @@ pub(crate) fn generate(kt: &KeyPairType, output: &OutputKind) -> String {
             kp.public_key(),
             kp.seed().unwrap()
         ),
-        OutputKind::JSON => json!({
+        OutputKind::Json => json!({
             "public_key": kp.public_key(),
             "seed": kp.seed().unwrap(),
         })
@@ -138,7 +138,7 @@ pub(crate) fn list(
 
     Ok(match output.kind {
         OutputKind::Text => format!("====== Keys found in {} ======\n{}", dir, keys.join("\n")),
-        OutputKind::JSON => format!("{}", json!({ "keys": keys })),
+        OutputKind::Json => format!("{}", json!({ "keys": keys })),
     })
 }
 
@@ -261,7 +261,7 @@ mod tests {
         let kt = KeyPairType::Account;
 
         let keypair = generate(&kt, &OutputKind::Text);
-        let keypair_json = generate(&kt, &OutputKind::JSON);
+        let keypair_json = generate(&kt, &OutputKind::Json);
 
         assert_eq!(keypair.contains("Public Key: "), true);
         assert_eq!(keypair.contains("Seed: "), true);
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[derive(Debug, Clone, Deserialize)]
-    struct KeyPairJSON {
+    struct KeyPairJson {
         public_key: String,
         seed: String,
     }
@@ -286,8 +286,8 @@ mod tests {
 
         let kt = KeyPairType::Module;
 
-        let keypair_json = generate(&kt, &OutputKind::JSON);
-        let keypair: KeyPairJSON = serde_json::from_str(&keypair_json).unwrap();
+        let keypair_json = generate(&kt, &OutputKind::Json);
+        let keypair: KeyPairJson = serde_json::from_str(&keypair_json).unwrap();
 
         assert_eq!(keypair.public_key.len(), sample_public_key.len());
         assert_eq!(keypair.seed.len(), sample_seed.len());
@@ -300,20 +300,20 @@ mod tests {
         let sample_public_key = "MBBLAHS7MCGNQ6IR4ZDSGRIAF7NVS7FCKFTKGO5JJJKN2QQRVAH7BSIO";
         let sample_seed = "SMAH45IUULL57OSXNOOAKOTLSVNQOORMDLE3Y3PQLJ4J5MY7MN2K7BIFI4";
 
-        let account_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Account, &OutputKind::JSON)).unwrap();
-        let user_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::User, &OutputKind::JSON)).unwrap();
-        let module_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Module, &OutputKind::JSON)).unwrap();
-        let service_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Service, &OutputKind::JSON)).unwrap();
-        let server_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Server, &OutputKind::JSON)).unwrap();
-        let operator_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Operator, &OutputKind::JSON)).unwrap();
-        let cluster_keypair: KeyPairJSON =
-            serde_json::from_str(&generate(&KeyPairType::Cluster, &OutputKind::JSON)).unwrap();
+        let account_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Account, &OutputKind::Json)).unwrap();
+        let user_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::User, &OutputKind::Json)).unwrap();
+        let module_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Module, &OutputKind::Json)).unwrap();
+        let service_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Service, &OutputKind::Json)).unwrap();
+        let server_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Server, &OutputKind::Json)).unwrap();
+        let operator_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Operator, &OutputKind::Json)).unwrap();
+        let cluster_keypair: KeyPairJson =
+            serde_json::from_str(&generate(&KeyPairType::Cluster, &OutputKind::Json)).unwrap();
 
         assert_eq!(account_keypair.public_key.starts_with('A'), true);
         assert_eq!(account_keypair.public_key.len(), sample_public_key.len());
@@ -394,7 +394,7 @@ mod tests {
                         Operator => assert_eq!(*cmd, "operator"),
                         Cluster => assert_eq!(*cmd, "cluster"),
                     }
-                    assert_eq!(output.kind, OutputKind::JSON);
+                    assert_eq!(output.kind, OutputKind::Json);
                 }
                 _ => panic!("`keys gen` constructed incorrect command"),
             };
@@ -431,7 +431,7 @@ mod tests {
             } => {
                 assert_eq!(keyname, KEYNAME);
                 assert_eq!(directory, Some(KEYPATH.to_string()));
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             other_cmd => panic!("keys get generated other command {:?}", other_cmd),
         }
@@ -454,7 +454,7 @@ mod tests {
         match list_all_flags.command {
             KeysCliCommand::ListCommand { directory, output } => {
                 assert_eq!(directory, Some(KEYPATH.to_string()));
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             other_cmd => panic!("keys get generated other command {:?}", other_cmd),
         }

--- a/src/par.rs
+++ b/src/par.rs
@@ -269,7 +269,7 @@ pub(crate) fn handle_create(cmd: CreateCommand) -> Result<String> {
             format_output(
                 format!("Successfully created archive {}", outfile),
                 json!({"result": "success", "file": outfile}),
-                &cmd.output,
+                &cmd.output.kind,
             )
         },
     )
@@ -417,7 +417,7 @@ pub(crate) fn handle_insert(cmd: InsertCommand) -> Result<String> {
             cmd.binary, cmd.archive
         ),
         json!({"result": "success", "file": cmd.archive}),
-        &cmd.output,
+        &cmd.output.kind,
     ))
 }
 

--- a/src/par.rs
+++ b/src/par.rs
@@ -321,11 +321,11 @@ pub(crate) async fn handle_inspect(cmd: InspectCommand) -> Result<String> {
         OutputKind::Text => {
             use term_table::row::Row;
             use term_table::table_cell::*;
-            use term_table::{Table, TableStyle};
+            use term_table::Table;
 
             let mut table = Table::new();
             table.max_column_width = 68;
-            table.style = TableStyle::blank();
+            table.style = crate::util::empty_table_style();
 
             table.add_row(Row::new(vec![TableCell::new_with_alignment(
                 format!("{} - Provider Archive", metadata.name.unwrap()),

--- a/src/par.rs
+++ b/src/par.rs
@@ -300,7 +300,7 @@ pub(crate) async fn handle_inspect(cmd: InspectCommand) -> Result<String> {
     let metadata = claims.metadata.unwrap();
 
     let output = match cmd.output.kind {
-        OutputKind::JSON => {
+        OutputKind::Json => {
             let friendly_rev = if metadata.rev.is_some() {
                 format!("{}", metadata.rev.unwrap())
             } else {
@@ -556,7 +556,7 @@ mod test {
                 assert_eq!(directory.unwrap(), "./tests/fixtures");
                 assert_eq!(issuer.unwrap(), ISSUER);
                 assert_eq!(subject.unwrap(), SUBJECT);
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(name, "CreateTest");
                 assert_eq!(vendor, "TestRunner");
                 assert_eq!(destination.unwrap(), "./test.par.gz");
@@ -695,7 +695,7 @@ mod test {
                 assert!(!insecure);
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "secret");
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             cmd => panic!("par inspect constructed incorrect command {:?}", cmd),
         }
@@ -731,7 +731,7 @@ mod test {
                 assert!(insecure);
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "secret");
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             cmd => panic!("par inspect constructed incorrect command {:?}", cmd),
         }

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -169,7 +169,7 @@ pub(crate) async fn handle_pull(cmd: PullCommand) -> Result<String, Box<dyn ::st
             SHOWER_EMOJI, outfile
         ),
         json!({"result": "success", "file": outfile}),
-        &cmd.output,
+        &cmd.output.kind,
     ))
 }
 
@@ -333,7 +333,7 @@ pub(crate) async fn handle_push(cmd: PushCommand) -> Result<String, Box<dyn ::st
             SHOWER_EMOJI, cmd.url
         ),
         json!({"result": "success", "url": cmd.url}),
-        &cmd.output,
+        &cmd.output.kind,
     ))
 }
 

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -140,7 +140,7 @@ pub(crate) async fn handle_command(
 pub(crate) async fn handle_pull(cmd: PullCommand) -> Result<String, Box<dyn ::std::error::Error>> {
     let image: Reference = cmd.url.parse().unwrap();
     let spinner = match cmd.output.kind {
-        OutputKind::Text if output_destination() == OutputDestination::CLI => Some(Spinner::new(
+        OutputKind::Text if output_destination() == OutputDestination::Cli => Some(Spinner::new(
             Spinners::Dots12,
             format!(" Downloading {} ...", image.whole()),
         )),
@@ -305,7 +305,7 @@ fn validate_provider_archive(
 
 pub(crate) async fn handle_push(cmd: PushCommand) -> Result<String, Box<dyn ::std::error::Error>> {
     let spinner = match cmd.output.kind {
-        OutputKind::Text if output_destination() == OutputDestination::CLI => Some(Spinner::new(
+        OutputKind::Text if output_destination() == OutputDestination::Cli => Some(Spinner::new(
             Spinners::Dots12,
             format!(" Pushing {} to {} ...", cmd.artifact, cmd.url),
         )),
@@ -585,7 +585,7 @@ mod tests {
                 assert_eq!(config.unwrap(), format!("{}/config.json", TESTDIR));
                 assert_eq!(opts.user.unwrap(), "localuser");
                 assert_eq!(opts.password.unwrap(), "supers3cr3t");
-                assert_eq!(output.kind, OutputKind::JSON);
+                assert_eq!(output.kind, OutputKind::Json);
             }
             _ => panic!("`reg push` constructed incorrect command"),
         };

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -33,7 +33,7 @@ use wasmcloud_host::HostBuilder;
 mod standalone;
 use standalone::HostCommand;
 
-type REPLTermionBackend =
+type ReplTermionBackend =
     tui::backend::TermionBackend<AlternateScreen<RawTerminal<std::io::Stdout>>>;
 
 const CTL_NS: &str = "default";
@@ -248,7 +248,7 @@ impl Default for WashRepl {
 
 impl WashRepl {
     /// Using the state of the REPL, display information in the terminal window
-    fn draw_ui(&mut self, terminal: &mut Terminal<REPLTermionBackend>) -> Result<()> {
+    fn draw_ui(&mut self, terminal: &mut Terminal<ReplTermionBackend>) -> Result<()> {
         terminal.draw(|frame| {
             let main_chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -733,10 +733,8 @@ refer to https://wasmcloud.dev/overview/getting-started/ for instructions on how
                                                 values.insert("caps".to_string(), caps.join(","));
                                             }
                                             if let Some(ver) = &metadata.ver {
-                                                values.insert(
-                                                    "version".to_string(),
-                                                    format!("{}", ver),
-                                                );
+                                                values
+                                                    .insert("version".to_string(), ver.to_string());
                                             }
                                             if let Some(rev) = &metadata.rev {
                                                 values
@@ -1009,7 +1007,7 @@ async fn handle_reg(reg_cmd: RegCliCommand, output_state: Arc<Mutex<OutputState>
 }
 
 /// Helper function to exit the alternate tui terminal without corrupting the user terminal
-fn cleanup_terminal(terminal: &mut Terminal<REPLTermionBackend>) {
+fn cleanup_terminal(terminal: &mut Terminal<ReplTermionBackend>) {
     terminal.show_cursor().unwrap();
     terminal.clear().unwrap();
 }
@@ -1063,7 +1061,7 @@ fn format_input_for_display(input_vec: Vec<char>, input_width: usize) -> String 
 }
 
 /// Display the wash REPL in the provided panel, automatically scroll with overflow
-fn draw_input_panel(frame: &mut Frame<REPLTermionBackend>, state: &mut InputState, chunk: Rect) {
+fn draw_input_panel(frame: &mut Frame<ReplTermionBackend>, state: &mut InputState, chunk: Rect) {
     let history: String = state
         .history
         .iter()
@@ -1123,7 +1121,7 @@ fn draw_input_panel(frame: &mut Frame<REPLTermionBackend>, state: &mut InputStat
 
 /// Display command output in the provided panel
 fn draw_output_panel(
-    frame: &mut Frame<REPLTermionBackend>,
+    frame: &mut Frame<ReplTermionBackend>,
     state: Arc<Mutex<OutputState>>,
     chunk: Rect,
     focused: bool,
@@ -1166,7 +1164,7 @@ fn draw_output_panel(
 
 /// Draws the Tui smart logger widget in the provided frame
 fn draw_smart_logger(
-    frame: &mut Frame<REPLTermionBackend>,
+    frame: &mut Frame<ReplTermionBackend>,
     chunk: Rect,
     state: &TuiWidgetState,
     focused: bool,

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -665,10 +665,10 @@ refer to https://wasmcloud.dev/overview/getting-started/ for instructions on how
                                 }
                                 GetInventory { } => {
                                     let actors = host
-                                        .get_actors()
+                                        .actors()
                                         .await.unwrap().join("\n  ");
                                     let providers = host
-                                        .get_providers()
+                                        .providers()
                                         .await.unwrap().join("\n  ");
                                     warn!(target: WASH_CMD_INFO, "Retrieving host inventory is only partially supported in standalone mode");
                                     format!("Host ID\n  {}\nActors\n  {}\nProviders\n  {}", host.id(), actors, providers)

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -379,7 +379,7 @@ impl WashRepl {
                             ReplCliCommand::Claims(claimscmd) => {
                                 let output_state = Arc::clone(&self.output_state);
                                 std::thread::spawn(|| {
-                                    let mut rt = actix_rt::System::new("cmd");
+                                    let rt = actix_rt::System::new();
                                     rt.block_on(async {
                                         match handle_claims(claimscmd, output_state).await {
                                             Ok(r) => r,
@@ -395,7 +395,7 @@ impl WashRepl {
                                     sender.send(ctlcmd)?
                                 } else {
                                     std::thread::spawn(|| {
-                                        let mut rt = actix_rt::System::new("cmd");
+                                        let rt = actix_rt::System::new();
                                         rt.block_on(async {
                                             match handle_ctl(ctlcmd, output_state).await {
                                                 Ok(r) => r,
@@ -408,7 +408,7 @@ impl WashRepl {
                             ReplCliCommand::Keys(keyscmd) => {
                                 let output_state = Arc::clone(&self.output_state);
                                 std::thread::spawn(|| {
-                                    let mut rt = actix_rt::System::new("cmd");
+                                    let rt = actix_rt::System::new();
                                     rt.block_on(async {
                                         match handle_keys(keyscmd, output_state).await {
                                             Ok(r) => r,
@@ -420,7 +420,7 @@ impl WashRepl {
                             ReplCliCommand::Par(parcmd) => {
                                 let output_state = Arc::clone(&self.output_state);
                                 std::thread::spawn(|| {
-                                    let mut rt = actix_rt::System::new("cmd");
+                                    let rt = actix_rt::System::new();
                                     rt.block_on(async {
                                         match handle_par(parcmd, output_state).await {
                                             Ok(r) => r,
@@ -432,7 +432,7 @@ impl WashRepl {
                             ReplCliCommand::Reg(regcmd) => {
                                 let output_state = Arc::clone(&self.output_state);
                                 std::thread::spawn(|| {
-                                    let mut rt = actix_rt::System::new("cmd");
+                                    let rt = actix_rt::System::new();
                                     rt.block_on(async {
                                         match handle_reg(regcmd, output_state).await {
                                             Ok(r) => r,
@@ -569,7 +569,7 @@ async fn handle_up(cmd: UpCliCommand) -> Result<()> {
     // Channel for host output (in standalone mode)
     let (host_output_sender, host_output_receiver) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let mut rt = actix_rt::System::new("replhost");
+        let rt = actix_rt::System::new();
         rt.block_on(async move {
             let nats_connection =
                 nats::asynk::connect(&format!("{}:{}", cmd.rpc_host, cmd.rpc_port)).await;
@@ -673,7 +673,10 @@ refer to https://wasmcloud.dev/overview/getting-started/ for instructions on how
                                     warn!(target: WASH_CMD_INFO, "Retrieving host inventory is only partially supported in standalone mode");
                                     format!("Host ID\n  {}\nActors\n  {}\nProviders\n  {}", host.id(), actors, providers)
                                 }
-                                GetClaims {} => "Retrieving claims is not currently supported in standalone mode".to_string(),
+                                GetClaims {} => {
+                                    // let claims = host.get_claims();
+                                    "Retrieving claims is not currently supported in standalone mode".to_string()
+                                }
                                 Link {
                                     actor_id,
                                     provider_id,
@@ -759,7 +762,7 @@ refer to https://wasmcloud.dev/overview/getting-started/ for instructions on how
                             };
                             host_output_sender.send(output).unwrap();
                         } else {
-                            actix_rt::time::delay_for(std::time::Duration::from_millis(100)).await;
+                            actix_rt::time::sleep(std::time::Duration::from_millis(100)).await;
                         }
                     }
                 }

--- a/src/up/standalone.rs
+++ b/src/up/standalone.rs
@@ -1,0 +1,107 @@
+use super::CtlCliCommand;
+use crate::ctl::*;
+use crate::util::{labels_vec_to_hashmap, OutputKind};
+use std::collections::HashMap;
+use CtlCliCommand::*;
+pub(crate) enum HostCommand {
+    Call {
+        actor: String,
+        operation: String,
+        msg: Vec<u8>,
+        output_kind: OutputKind,
+    },
+    GetHost {
+        output_kind: OutputKind,
+    },
+    GetInventory {},
+    GetClaims {},
+    Link {
+        actor_id: String,
+        provider_id: String,
+        contract_id: String,
+        link_name: Option<String>,
+        values: HashMap<String, String>,
+        output_kind: OutputKind,
+    },
+    StartActor {
+        actor_ref: String,
+        output_kind: OutputKind,
+    },
+    StartProvider {
+        provider_ref: String,
+        link_name: String,
+        output_kind: OutputKind,
+    },
+    StopActor {
+        actor_ref: String,
+        output_kind: OutputKind,
+    },
+    StopProvider {
+        provider_ref: String,
+        contract_id: String,
+        link_name: String,
+        output_kind: OutputKind,
+    },
+    UpdateActor {},
+}
+
+impl From<CtlCliCommand> for HostCommand {
+    /// Transforms a CtlCliCommand to a command to invoke on a standalone host
+    fn from(cmd: CtlCliCommand) -> Self {
+        match cmd {
+            Call(CallCommand {
+                actor_id,
+                operation,
+                data,
+                output,
+                ..
+            }) => HostCommand::Call {
+                actor: actor_id,
+                operation,
+                msg: crate::util::json_str_to_msgpack_bytes(data).unwrap(), //TODO(brooksmtownsend): handle unwrap better
+                output_kind: output.kind,
+            },
+            Get(GetCommand::Hosts(cmd)) => HostCommand::GetHost {
+                output_kind: cmd.output.kind,
+            },
+            Get(GetCommand::HostInventory(_cmd)) => HostCommand::GetInventory {},
+            Get(GetCommand::Claims(_cmd)) => HostCommand::GetClaims {},
+            Start(StartCommand::Actor(cmd)) => HostCommand::StartActor {
+                actor_ref: cmd.actor_ref,
+                output_kind: cmd.output.kind,
+            },
+            Start(StartCommand::Provider(cmd)) => HostCommand::StartProvider {
+                provider_ref: cmd.provider_ref,
+                link_name: cmd.link_name,
+                output_kind: cmd.output.kind,
+            },
+            Stop(StopCommand::Actor(cmd)) => HostCommand::StopActor {
+                actor_ref: cmd.actor_id,
+                output_kind: cmd.output.kind,
+            },
+            Stop(StopCommand::Provider(cmd)) => HostCommand::StopProvider {
+                provider_ref: cmd.provider_id,
+                contract_id: cmd.contract_id,
+                link_name: cmd.link_name,
+                output_kind: cmd.output.kind,
+            },
+            Link(LinkCommand {
+                actor_id,
+                provider_id,
+                contract_id,
+                link_name,
+                values,
+                output,
+                ..
+            }) => HostCommand::Link {
+                actor_id,
+                provider_id,
+                contract_id,
+                link_name,
+                values: labels_vec_to_hashmap(values).unwrap(), //TODO(brooksmtownsend): catch this unwrap
+                output_kind: output.kind,
+            },
+            Update(UpdateCommand::Actor(_cmd)) => HostCommand::UpdateActor {},
+        }
+    }
+}

--- a/src/up/standalone.rs
+++ b/src/up/standalone.rs
@@ -13,7 +13,9 @@ pub(crate) enum HostCommand {
     GetHost {
         output_kind: OutputKind,
     },
-    GetInventory {},
+    GetInventory {
+        output_kind: OutputKind,
+    },
     GetClaims {
         output_kind: OutputKind,
     },
@@ -66,7 +68,9 @@ impl From<CtlCliCommand> for HostCommand {
             Get(GetCommand::Hosts(cmd)) => HostCommand::GetHost {
                 output_kind: cmd.output.kind,
             },
-            Get(GetCommand::HostInventory(_cmd)) => HostCommand::GetInventory {},
+            Get(GetCommand::HostInventory(cmd)) => HostCommand::GetInventory {
+                output_kind: cmd.output.kind,
+            },
             Get(GetCommand::Claims(cmd)) => HostCommand::GetClaims {
                 output_kind: cmd.output.kind,
             },

--- a/src/up/standalone.rs
+++ b/src/up/standalone.rs
@@ -14,7 +14,9 @@ pub(crate) enum HostCommand {
         output_kind: OutputKind,
     },
     GetInventory {},
-    GetClaims {},
+    GetClaims {
+        output_kind: OutputKind,
+    },
     Link {
         actor_id: String,
         provider_id: String,
@@ -65,7 +67,9 @@ impl From<CtlCliCommand> for HostCommand {
                 output_kind: cmd.output.kind,
             },
             Get(GetCommand::HostInventory(_cmd)) => HostCommand::GetInventory {},
-            Get(GetCommand::Claims(_cmd)) => HostCommand::GetClaims {},
+            Get(GetCommand::Claims(cmd)) => HostCommand::GetClaims {
+                output_kind: cmd.output.kind,
+            },
             Start(StartCommand::Actor(cmd)) => HostCommand::StartActor {
                 actor_ref: cmd.actor_ref,
                 output_kind: cmd.output.kind,

--- a/src/util.rs
+++ b/src/util.rs
@@ -75,8 +75,12 @@ impl fmt::Display for OutputParseErr {
 }
 
 /// Returns string output for provided output kind
-pub(crate) fn format_output(text: String, json: serde_json::Value, output: &Output) -> String {
-    match output.kind {
+pub(crate) fn format_output(
+    text: String,
+    json: serde_json::Value,
+    output_kind: &OutputKind,
+) -> String {
+    match output_kind {
         OutputKind::Text => text,
         OutputKind::JSON => format!("{}", json),
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -110,7 +110,7 @@ pub(crate) fn labels_vec_to_hashmap(constraints: Vec<String>) -> Result<HashMap<
     Ok(hm)
 }
 
-/// Transform a json str (e.g. "{"hello": "world"}") and transform it into msgpack bytes
+/// Transform a json str (e.g. "{"hello": "world"}") into msgpack bytes
 pub(crate) fn json_str_to_msgpack_bytes(payload: Vec<String>) -> Result<Vec<u8>> {
     let json: serde_json::value::Value = serde_json::from_str(&payload.join(""))?;
     let payload = serdeconv::to_msgpack_vec(&json)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,14 +31,14 @@ pub(crate) struct Output {
 #[derive(StructOpt, Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum OutputKind {
     Text,
-    JSON,
+    Json,
 }
 
 /// Used to supress `println!` macro calls in the REPL
 #[derive(StructOpt, Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum OutputDestination {
-    CLI,
-    REPL,
+    Cli,
+    Repl,
 }
 
 impl Default for Output {
@@ -54,7 +54,7 @@ impl FromStr for OutputKind {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "json" => Ok(OutputKind::JSON),
+            "json" => Ok(OutputKind::Json),
             "text" => Ok(OutputKind::Text),
             _ => Err(OutputParseErr),
         }
@@ -83,7 +83,7 @@ pub(crate) fn format_output(
 ) -> String {
     match output_kind {
         OutputKind::Text => text,
-        OutputKind::JSON => format!("{}", json),
+        OutputKind::Json => format!("{}", json),
     }
 }
 
@@ -120,8 +120,8 @@ pub(crate) fn json_str_to_msgpack_bytes(payload: Vec<String>) -> Result<Vec<u8>>
 /// Helper function to either display input to stdout or log the output in the REPL
 pub(crate) fn print_or_log(output: String) {
     match output_destination() {
-        OutputDestination::REPL => info!(target: WASH_LOG_INFO, "{}", output),
-        OutputDestination::CLI => println!("{}", output),
+        OutputDestination::Repl => info!(target: WASH_LOG_INFO, "{}", output),
+        OutputDestination::Cli => println!("{}", output),
     }
 }
 
@@ -129,8 +129,8 @@ pub(crate) fn print_or_log(output: String) {
 pub(crate) fn output_destination() -> OutputDestination {
     // REPL_MODE is Some("true") when in REPL, otherwise CLI
     match REPL_MODE.get() {
-        Some(_) => OutputDestination::REPL,
-        None => OutputDestination::CLI,
+        Some(_) => OutputDestination::Repl,
+        None => OutputDestination::Cli,
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
 use structopt::StructOpt;
+use term_table::TableStyle;
 
 pub(crate) type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
 
@@ -130,5 +131,21 @@ pub(crate) fn output_destination() -> OutputDestination {
     match REPL_MODE.get() {
         Some(_) => OutputDestination::REPL,
         None => OutputDestination::CLI,
+    }
+}
+
+pub(crate) fn empty_table_style() -> TableStyle {
+    TableStyle {
+        top_left_corner: ' ',
+        top_right_corner: ' ',
+        bottom_left_corner: ' ',
+        bottom_right_corner: ' ',
+        outer_left_vertical: ' ',
+        outer_right_vertical: ' ',
+        outer_bottom_horizontal: ' ',
+        outer_top_horizontal: ' ',
+        intersection: ' ',
+        vertical: ' ',
+        horizontal: ' ',
     }
 }

--- a/tests/integration_ctl.rs
+++ b/tests/integration_ctl.rs
@@ -89,12 +89,13 @@ async fn integration_ctl_actor_roundtrip() -> Result<()> {
         .output()
         .expect("failed to get start actor acknowledgement");
     let failed_echo = output_to_string(start_echo_again);
-    assert!(failed_echo.contains(&format!("\"actor_ref\":\"{}\"", ECHO)));
-    assert!(failed_echo.contains(&format!(
-        "\"failure\":\"Actor with image ref \'{}\' is already running on this host\"",
-        ECHO
-    )));
-    assert!(failed_echo.contains(&format!("\"host_id\":\"{}\"", host_id)));
+    assert_eq!(
+        failed_echo,
+        format!(
+            "{{\"error\":\"Actor with image ref '{}' is already running on this host\"}}\n",
+            ECHO
+        )
+    );
 
     let payload = "{\"method\": \"GET\", \"path\": \"/echo\", \"body\": \"\", \"queryString\":\"\", \"header\":{}}";
     let call_echo = wash()
@@ -199,14 +200,13 @@ async fn integration_ctl_actor_provider_roundtrip() -> Result<()> {
         .output()
         .expect("failed to get start actor acknowledgement");
     let failed_httpserver = output_to_string(start_httpserver_again);
-    assert!(failed_httpserver.contains(&format!(
-        "\"failure\":\"Provider with image ref \'{}\' is already running on this host.\"",
-        HTTPSERVER
-    )));
-    assert!(failed_httpserver.contains(&format!("\"host_id\":\"{}\"", host_id)));
-    // TODO: this should be tested, but is a bug as of wasmcloud-host 0.15.1.
-    // Once https://github.com/wasmcloud/wasmcloud/issues/106 is closed, this should be uncommented
-    // assert!(failed_httpserver.contains(&format!("\"provider_ref\":\"{}\"", HTTPSERVER)));
+    assert_eq!(
+        failed_httpserver,
+        format!(
+            "{{\"error\":\"Provider with image ref '{}' is already running on this host.\"}}\n",
+            HTTPSERVER
+        )
+    );
 
     let link_echo_httpserver = wash()
         .args(&[

--- a/tests/integration_ctl.rs
+++ b/tests/integration_ctl.rs
@@ -309,41 +309,40 @@ async fn integration_ctl_actor_provider_roundtrip() -> Result<()> {
     //     .is_err());
 
     let resp = client.get("http://localhost:8080/echotest").send().await;
-    println!("RESPO: {:?}", resp);
+    assert!(resp.unwrap().status().is_server_error());
 
     Ok(())
 }
 
-//TODO: Updates with actors with different OCI references are not yet supported.
-// This issue is being tracked at https://github.com/wasmcloud/wasmcloud/issues/108
-// #[actix_rt::test]
-// /// Tests starting and updating an actor
-// async fn integration_ctl_update_actor() -> Result<()> {
-//     const ECHO: &str = "wasmcloud.azurecr.io/echo:0.2.0";
-//     const ECHO_NEW: &str = "wasmcloud.azurecr.io/echo:0.2.1";
-//     const ECHO_PKEY: &str = "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5";
-//     const NS: &str = "update_actor";
-//     let host_id = create_host(NS.to_string()).await?;
+//TODO(brooksmtownsend): Need to ensure OCI references are updated before asserting this
+#[actix_rt::test]
+/// Tests starting and updating an actor
+async fn integration_ctl_update_actor() -> Result<()> {
+    const ECHO: &str = "wasmcloud.azurecr.io/echo:0.2.0";
+    const ECHO_NEW: &str = "wasmcloud.azurecr.io/echo:0.2.1";
+    const ECHO_PKEY: &str = "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5";
+    const NS: &str = "update_actor";
+    let host_id = create_host(NS.to_string()).await?;
 
-//     let start_echo = wash()
-//         .args(&["ctl", "start", "actor", ECHO, "-h", &host_id, "-n", NS])
-//         .output()
-//         .expect("failed to get start actor acknowledgement");
-//     assert!(start_echo.status.success());
+    let start_echo = wash()
+        .args(&["ctl", "start", "actor", ECHO, "-h", &host_id, "-n", NS])
+        .output()
+        .expect("failed to get start actor acknowledgement");
+    assert!(start_echo.status.success());
 
-//     assert!(wait_for_start(&host_id, NS, ECHO, 30).await);
+    assert!(wait_for_start(&host_id, NS, ECHO, 30).await);
 
-//     let update_echo = wash()
-//         .args(&[
-//             "ctl", "update", "actor", &host_id, ECHO_PKEY, ECHO_NEW, "-n", NS, "-o", "json",
-//         ])
-//         .output()
-//         .expect("failed to issue update actor command");
-//     assert!(update_echo.status.success());
-//     assert!(wait_for_start(&host_id, NS, ECHO_NEW, 30).await);
+    let update_echo = wash()
+        .args(&[
+            "ctl", "update", "actor", &host_id, ECHO_PKEY, ECHO_NEW, "-n", NS, "-o", "json",
+        ])
+        .output()
+        .expect("failed to issue update actor command");
+    assert!(update_echo.status.success());
+    // assert!(wait_for_start(&host_id, NS, ECHO_NEW, 30).await);
 
-//     Ok(())
-// }
+    Ok(())
+}
 
 /// Helper function to initialize a host in a separate thread
 /// and return its ID. We create a host in a separate thread because

--- a/tests/integration_ctl.rs
+++ b/tests/integration_ctl.rs
@@ -333,7 +333,7 @@ async fn integration_ctl_actor_provider_roundtrip() -> Result<()> {
 async fn create_host(namespace: String) -> Result<String> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let mut rt = actix_rt::System::new("testhost");
+        let rt = actix_rt::System::new();
         rt.block_on(async move {
             let nats_conn = nats::asynk::connect("0.0.0.0:4222").await.unwrap();
             let host = HostBuilder::new()
@@ -370,7 +370,7 @@ async fn wait_for_start(host_id: &str, namespace: &str, resource: &str, retries:
             return true;
         } else {
             count += 1;
-            actix_rt::time::delay_for(std::time::Duration::from_secs(1)).await;
+            actix_rt::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
     false
@@ -390,7 +390,7 @@ async fn wait_for_stop(host_id: &str, namespace: &str, resource: &str, retries: 
             return true;
         } else {
             count += 1;
-            actix_rt::time::delay_for(std::time::Duration::from_secs(1)).await;
+            actix_rt::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
     false

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -3,6 +3,7 @@ use common::wash;
 
 // Unfortunately, launching the REPL will corrupt a terminal session without being able to properly
 // clean up the interactive mode. Until this can be fixed, we'll run these in certain situations
+//TODO: Investigate possibility of "detatching" terminal _or_ starting a new session just for these tests.
 
 #[test]
 #[ignore]


### PR DESCRIPTION
Addresses #92 

No-nats mode now supports all but the following commands from the standard lattice connected mode:
1. `ctl get claims`
2. `ctl update actor`
3. `ctl get inventory` (partial)
These are all unsupported at the moment because there are not equivalent commands to invoke on the host directly, and some make use of the host controller on the control interface side in order to return the correct information. This will need to be addressed. I'm primarily concerned about implementing `get inventory` for the host inventory, as that contains much needed information, specifically link names and OCI references. @autodidaddict I've added what I can of support for now (see the host inventory implementation for standalone) however we might be better off implementing some of this functionality on the host side.

For this PR, I've added a few additional threads and channels to allow `wash up` to run a REPL without connecting to NATS, as indicated by the `Standalone` title by the REPL. This launches an embedded host, as usual, however, commands will be invoked directly on that host instead of proxying through the control interface.

A few modifications for reviewers:
- `ctl` and `up` are getting to contain large amounts of code, so I've split some large pieces into separate files under a folder of the same name. This is a pretty standard Rust pattern. I didn't split larger pieces of the REPL out into separate files because I made many assumptions about accessing fields, and I'd have to write just as much code as I'd save in getters, setters, and modifications.
- the `output` module under `ctl/output.rs` is used to standardize the output format for control interface operations and embedded host operations, that way what the user sees should be identical for standalone mode and lattice connected mode.
- I edited some integration tests to better check for failures while I was refactoring the output modules.