### PR TITLE
wash: don't panic on invalid URL in claims inspect

### DIFF
--- a/src/reg.rs
+++ b/src/reg.rs
@@ -181,7 +181,7 @@ pub(crate) async fn pull_artifact(
     password: Option<String>,
     insecure: bool,
 ) -> Result<Vec<u8>, Box<dyn ::std::error::Error>> {
-    let image: Reference = url.parse().unwrap();
+    let image: Reference = url.parse()?;
 
     if image.tag().unwrap_or("latest") == "latest" && !allow_latest {
         return Err(


### PR DESCRIPTION
Minor tweak; misunderstanding what syntax to pass in to the "claims inspect" function netted me a panic(), I think that could be somewhat nicer ;-)