### PR TITLE
Fix help text for reg command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/src/up.rs
+++ b/src/up.rs
@@ -135,7 +135,7 @@ enum ReplCliCommand {
     #[structopt(name = "par")]
     Par(ParCliCommand),
 
-    /// Launch wasmcloud REPL environment
+    /// Interact with an OCI registry
     #[structopt(name = "reg")]
     Reg(RegCliCommand),
 


### PR DESCRIPTION
Changes `reg --help` output as `Interact with an OCI registry`.

Closes #112 