### PR TITLE
properly generate tokens for providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -530,7 +530,7 @@ fn generate_provider(provider: ProviderMetadata) -> Result<String, Box<dyn ::std
         provider.subject.clone(),
         Some(provider.name.clone()),
         provider.common.directory.clone(),
-        KeyPairType::Module,
+        KeyPairType::Service,
         provider.common.disable_keygen,
     )?;
 


### PR DESCRIPTION
Previously, `wash claims token provider` would generate a module key instead of a service key for providers. This is not correct, and any JWTs created this way could be mistaken for actors.