### PR TITLE
A second breakfast first pass to add repl focus cues to the wash repl

### DIFF
--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -1093,7 +1093,7 @@ fn draw_input_panel(frame: &mut Frame<ReplTermionBackend>, state: &mut InputStat
     state.input_width = chunk.width as usize - 3;
 
     let style = if state.focused {
-        Style::default().add_modifier(Modifier::BOLD)
+        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD | Modifier::SLOW_BLINK)
     } else {
         Style::default()
     };
@@ -1144,7 +1144,7 @@ fn draw_output_panel(
     state.output_width = chunk.width as usize - 1;
 
     let style = if focused {
-        Style::default().add_modifier(Modifier::BOLD)
+        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
     } else {
         Style::default()
     };
@@ -1170,7 +1170,7 @@ fn draw_smart_logger(
     focused: bool,
 ) {
     let style = if focused {
-        Style::default().add_modifier(Modifier::BOLD)
+        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
     } else {
         Style::default()
     };

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -1093,7 +1093,9 @@ fn draw_input_panel(frame: &mut Frame<ReplTermionBackend>, state: &mut InputStat
     state.input_width = chunk.width as usize - 3;
 
     let style = if state.focused {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD | Modifier::SLOW_BLINK)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD | Modifier::SLOW_BLINK)
     } else {
         Style::default()
     };
@@ -1144,7 +1146,9 @@ fn draw_output_panel(
     state.output_width = chunk.width as usize - 1;
 
     let style = if focused {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default()
     };
@@ -1170,7 +1174,9 @@ fn draw_smart_logger(
     focused: bool,
 ) {
     let style = if focused {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default()
     };


### PR DESCRIPTION
Intended to close [#106](https://github.com/wasmCloud/wash/issues/106).

I plan to revisit this functionality, I think it would look nice to bind the output panel and the logging panel to when alt or cmd KeyEvents are detected so those key modifiers are more intuitively tied to the output/logging windows for scrolling. 

I ran the tests that failed prior without issue so I expect this one to be in the clear.