### PR TITLE
Allow starting signed local actors in embedded REPL host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"
@@ -9,6 +9,11 @@ license = "Apache-2.0"
 readme = "README.md"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]
 categories = ["wasm", "command-line-utilities"]
+
+[features]
+default = ["wasm3"]
+wasmtime = ["wasmcloud-host/wasmtime"]
+wasm3 = ["wasmcloud-host/wasm3"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -33,7 +38,7 @@ nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
 wasmcloud-control-interface = "0.3.0"
-wasmcloud-host = "0.18.0"
+wasmcloud-host = { version = "0.18.0", default-features = false }
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@
 test: ## Run unit test suite
 	cargo test --no-fail-fast --verbose --bin wash -- --nocapture
 
-test-integration: ##Run integration test suite
+test-integration-wasm3: ##Run integration test suite with wasm3 engine
 	docker-compose -f ./tools/docker-compose.yml up --detach
-	cargo test --no-fail-fast --verbose --test "integration*" -- --nocapture
+	cargo test --no-fail-fast --verbose --test "integration*" --no-default-features --features wasm3 -- --nocapture
 	docker-compose -f ./tools/docker-compose.yml down
 
-test-all: test test-integration ## Run all tests
+test-integration-wasmtime: ##Run integration test suite with wasmtime engine
+	docker-compose -f ./tools/docker-compose.yml up --detach
+	cargo test --no-fail-fast --verbose --test "integration*" --no-default-features --features wasmtime -- --nocapture
+	docker-compose -f ./tools/docker-compose.yml down
+
+test-all: test test-integration-wasm3 test-integration-wasmtime ## Run all tests
 
 ##@ Helpers
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -222,7 +222,7 @@ pub(crate) struct StartActorCommand {
 
     /// Id of host, if omitted the actor will be auctioned in the lattice to find a suitable host
     #[structopt(short = "h", long = "host-id", name = "host-id")]
-    host_id: Option<String>,
+    pub(crate) host_id: Option<String>,
 
     /// Actor reference, e.g. the OCI URL for the actor
     #[structopt(name = "actor-ref")]

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -224,7 +224,7 @@ pub(crate) struct StartActorCommand {
     #[structopt(short = "h", long = "host-id", name = "host-id")]
     pub(crate) host_id: Option<String>,
 
-    /// Actor reference, e.g. the OCI URL for the actor
+    /// Actor reference, e.g. the OCI URL for the actor. This can also be a signed local wasm file when using the REPL host
     #[structopt(name = "actor-ref")]
     pub(crate) actor_ref: String,
 


### PR DESCRIPTION
This PR allows users, when in the REPL, to start locally signed actor modules within the embedded REPL host. This can be done in standalone or lattice mode, and all OCI references will continue to work as they did before. When starting an actor, the REPL will first check for the existence of a file, and if it exists then the actor will be loaded from disk.

This enables #105, where we will be able to watch a signed actor module for changes.

This PR also includes features that will allow people to choose `wasmtime` as their wasm engine for the embedded REPL host.

Lastly, the default level for logging was changed to `info` to suppress some fairly noisy logs that come from downloading an actor from an OCI registry. This can always be overwritten with the `-l` or `--log-level` flag for `wash up`