### PR TITLE
`up` integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test-all: test test-integration-wasm3 test-integration-wasmtime ## Run all tests
 
 clean:
 	wash drain all
+	docker-compose -f ./tools/docker-compose.yml down
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_\-.*]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,19 +1,31 @@
 mod common;
 use common::wash;
+use std::io::Write;
+use std::process::Stdio;
 
 // Unfortunately, launching the REPL will corrupt a terminal session without being able to properly
 // clean up the interactive mode. Until this can be fixed, we'll run these in certain situations
 //TODO: Investigate possibility of "detatching" terminal _or_ starting a new session just for these tests.
 
-#[test]
-#[ignore]
-fn integration_up_basic() {
-    let up = wash()
+#[actix_rt::test]
+async fn integration_up_basic() {
+    let mut up = wash()
         .args(&["up"])
-        .output()
+        .stdin(Stdio::piped())
+        .spawn()
         .expect("failed to launch repl");
 
-    assert!(up.status.success());
+    let stdin = up.stdin.as_mut().expect("Failed to open stdin");
+    actix_rt::time::sleep(std::time::Duration::from_millis(1000)).await;
+    stdin
+        .write_all("help\n".as_bytes())
+        .expect("Failed to write to stdin");
+    actix_rt::time::sleep(std::time::Duration::from_millis(1000)).await;
+    stdin
+        .write_all("q\n".as_bytes())
+        .expect("Failed to write to stdin");
+
+    assert!(up.wait().unwrap().success());
 }
 
 #[test]


### PR DESCRIPTION
Previously we were not able to test `up` with integration tests because of the way that the REPL hijacks the terminal's stdout. I've been playing around with the REPL and found a configuration that works where we can send commands as stdin to a REPL, the only thing I need to verify first is that it works with the Github runner.

This is becoming more important as the REPL is getting more and more complicated, especially as we have functionality in `Standalone` and `Lattice` mode.