### PR TITLE
Commit cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "actix-rt",
  "awc",


### PR DESCRIPTION
I'm not exactly sure why, but the GH action for release seems to think that Cargo.lock is not committed to the repository. Perhaps this is because my manifest PR didn't add it, but the flake.nix PR did.

This should solve the issue.