### PR TITLE
Improved cursor position logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "actix-rt",
  "awc",

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -736,9 +736,9 @@ pub(crate) fn draw_input_panel(
     );
 
     // 5 is the offset from the bottom of the chunk (3) plus 2 lines for buffer
-    let scroll_offset = if state.history.len() as u16 + state.multiline_history >= chunk.height - 3
-    {
-        state.multiline_history + state.history.len() as u16 + 5 - chunk.height
+    let hist_offset = state.vertical_history_offset();
+    let scroll_offset = if hist_offset >= chunk.height - 3 {
+        hist_offset + 5 - chunk.height
     } else {
         0
     };
@@ -768,10 +768,14 @@ pub(crate) fn draw_input_panel(
     let input_cursor = state.cursor_location();
 
     // Draw cursor on screen
-    frame.set_cursor(
-        chunk.x + 1 + input_cursor.0,
-        chunk.y + 1 + input_cursor.1 - scroll_offset,
-    )
+    let x_pos = chunk.x + 1 + input_cursor.0;
+    let mut y_pos = chunk.y + 1 + input_cursor.1;
+    if scroll_offset > y_pos {
+        // This can happen when resizing, the y position updates before the scroll.
+        // Since this would normally create a negative number, make y offset 0 instead.
+        y_pos = scroll_offset;
+    }
+    frame.set_cursor(x_pos, y_pos - scroll_offset)
 }
 
 /// Display command output in the provided panel

--- a/src/up/repl.rs
+++ b/src/up/repl.rs
@@ -84,7 +84,7 @@ impl InputState {
                     1_u16
                 }
             })
-            .fold(0_u16, |acc, el| acc + el);
+            .sum();
         self.history_offset
     }
 }


### PR DESCRIPTION
Fixes #90 

This PR fixes 3 issues (not all documented):
1. #90, where resizing the terminal window does not recompute the position of the cursor
2. Depending on the width of the command, sometimes the cursor vertical position can be off by one
3. At smaller screen widths, the input window would scroll offscreen

In sum, the cursor should now always be in the correct position now. 