### PR TITLE
Wash watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "actix-rt",
  "awc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ dependencies = [
  "socket2",
  "vec-arena",
  "waker-fn",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "cap-std",
  "rustc_version 0.3.3",
  "unsafe-io",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -568,7 +568,7 @@ dependencies = [
  "posish",
  "rustc_version 0.3.3",
  "unsafe-io",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
  "winx",
 ]
@@ -653,7 +653,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time 0.1.44",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1011,7 +1011,7 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users 0.3.5",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users 0.4.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1119,7 +1119,7 @@ checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.6",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1248,7 +1248,26 @@ checksum = "28f1ca01f517bba5770c067dc6c466d290b962e08214c8f2598db98d66087e55"
 dependencies = [
  "posish",
  "unsafe-io",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1256,6 +1275,22 @@ name = "fsio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50045aa8931ae01afbc5d72439e8f57f326becb8c70d07dfc816778eff3d167"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -1472,6 +1507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotwatch"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61ee702e77f237b41761361a82e5c4bf6277dbb4bc8b6b7d745cb249cc82b31"
+dependencies = [
+ "log",
+ "notify",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1665,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1729,7 +1804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1829,15 +1904,58 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1846,7 +1964,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1922,7 +2040,18 @@ dependencies = [
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
  "webpki",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1964,12 +2093,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2599080e87c9bd051ddb11b10074f4da7b1223298df65d4c2ec5bcf309af1533"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2136,7 +2283,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.6",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2220,7 +2367,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2538,7 +2685,7 @@ dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2547,7 +2694,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2597,7 +2744,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2731,13 +2878,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3031,7 +3187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3254,7 +3410,7 @@ dependencies = [
  "posish",
  "rustc_version 0.3.3",
  "unsafe-io",
- "winapi",
+ "winapi 0.3.9",
  "winx",
 ]
 
@@ -3286,7 +3442,7 @@ dependencies = [
  "rand 0.8.3",
  "redox_syscall 0.2.6",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3296,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3374,7 +3530,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3389,7 +3545,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check 0.9.3",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3440,13 +3596,13 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.11",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3670,7 +3826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe39acfe60d3754452ea6881613c3240100b23ffd94a627c138863f8cd314b1b"
 dependencies = [
  "rustc_version 0.3.3",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3749,6 +3905,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,6 +3966,8 @@ version = "0.4.4"
 dependencies = [
  "actix-rt",
  "awc",
+ "crossbeam-channel",
+ "hotwatch",
  "log",
  "nats 0.8.6",
  "nkeys 0.1.0",
@@ -3851,7 +4020,7 @@ dependencies = [
  "tracing",
  "unsafe-io",
  "wasi-common",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3868,7 +4037,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "wiggle",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4126,7 +4295,7 @@ dependencies = [
  "wasmtime-profiling",
  "wasmtime-runtime",
  "wat",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4146,7 +4315,7 @@ dependencies = [
  "serde",
  "sha2",
  "toml",
- "winapi",
+ "winapi 0.3.9",
  "zstd",
 ]
 
@@ -4208,7 +4377,7 @@ checksum = "d92da32e31af2e3d828f485f5f24651ed4d3b7f03a46ea6555eae6940d1402cd"
 dependencies = [
  "cc",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4241,7 +4410,7 @@ dependencies = [
  "wasmtime-obj",
  "wasmtime-profiling",
  "wasmtime-runtime",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4314,7 +4483,7 @@ dependencies = [
  "region",
  "thiserror",
  "wasmtime-environ",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4471,6 +4640,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4478,6 +4653,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4491,7 +4672,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4506,7 +4687,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4516,7 +4697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a316462681accd062e32c37f9d78128691a4690764917d13bd8ea041baf2913e"
 dependencies = [
  "bitflags",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4529,6 +4710,16 @@ dependencies = [
  "log",
  "thiserror",
  "wast 33.0.0",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ nats = "0.8.6"
 once_cell = "1.5.2"
 term-table = "1.3.1"
 oci-distribution = "0.6.0"
+crossbeam-channel = "0.5.1"
+hotwatch = "0.4.5"
 
 nkeys = "0.1.0"
 wascap = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -770,6 +770,7 @@ pub(crate) fn render_actor_claims(
                 "expires": validation.expires_human,
                 "can_be_used": validation.not_before_human,
                 "version": friendly_ver,
+                "revision": friendly_rev,
                 provider_json: friendly_caps,
                 "tags": tags,
                 "call_alias": call_alias,

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -57,6 +57,17 @@ pub(crate) struct ConnectionOpts {
     rpc_timeout: u64,
 }
 
+impl Default for ConnectionOpts {
+    fn default() -> Self {
+        ConnectionOpts {
+            rpc_host: "0.0.0.0".to_string(),
+            rpc_port: "4222".to_string(),
+            ns_prefix: "default".to_string(),
+            rpc_timeout: 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone, StructOpt)]
 pub(crate) enum CtlCliCommand {
     /// Invoke an operation on an actor
@@ -237,6 +248,26 @@ pub(crate) struct StartActorCommand {
     timeout: u64,
 }
 
+impl StartActorCommand {
+    pub(crate) fn new(
+        opts: ConnectionOpts,
+        output: Output,
+        host_id: Option<String>,
+        actor_ref: String,
+        constraints: Option<Vec<String>>,
+        timeout: u64,
+    ) -> Self {
+        StartActorCommand {
+            opts,
+            output,
+            host_id,
+            actor_ref,
+            constraints,
+            timeout,
+        }
+    }
+}
+
 #[derive(Debug, Clone, StructOpt)]
 pub(crate) struct StartProviderCommand {
     #[structopt(flatten)]
@@ -324,9 +355,27 @@ pub(crate) struct UpdateActorCommand {
     #[structopt(name = "actor-id")]
     pub(crate) actor_id: String,
 
-    /// Actor reference, e.g. the OCI URL for the actor
+    /// Actor reference, e.g. the OCI URL for the actor. This can also be a signed local wasm file when using the REPL host
     #[structopt(name = "new-actor-ref")]
     pub(crate) new_actor_ref: String,
+}
+
+impl UpdateActorCommand {
+    pub(crate) fn new(
+        opts: ConnectionOpts,
+        output: Output,
+        host_id: String,
+        actor_id: String,
+        new_actor_ref: String,
+    ) -> Self {
+        UpdateActorCommand {
+            opts,
+            output,
+            host_id,
+            actor_id,
+            new_actor_ref,
+        }
+    }
 }
 
 pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -349,7 +349,7 @@ pub(crate) struct UpdateActorCommand {
 
     /// Id of host
     #[structopt(name = "host-id")]
-    host_id: String,
+    pub(crate) host_id: String,
 
     /// Actor Id, e.g. the public key for the actor
     #[structopt(name = "actor-id")]

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -239,7 +239,7 @@ async fn handle_up(cmd: UpCliCommand) -> Result<()> {
 
     let embedded_host = EmbeddedHost::new(host.id(), mode, host_op_sender);
     //TODO(brooksmtownsend): Will need to replace with vec logic
-    let hotwatch = if let Some(actor_path) = cmd.actor.clone() {
+    let _hotwatch = if let Some(actor_path) = cmd.actor.clone() {
         if let Some(actor_ref) = actor_path.to_str() {
             embedded_host.watch_actor(actor_ref)
         } else {

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -239,6 +239,7 @@ async fn handle_up(cmd: UpCliCommand) -> Result<()> {
 
     let embedded_host = EmbeddedHost::new(host.id(), mode, host_op_sender);
     //TODO(brooksmtownsend): Will need to replace with vec logic
+    // Ownership of the hotwatch object is moved to this thread, where it won't be dropped
     let _hotwatch = if let Some(actor_path) = cmd.actor.clone() {
         if let Some(actor_ref) = actor_path.to_str() {
             embedded_host.watch_actor(actor_ref)

--- a/src/up/repl.rs
+++ b/src/up/repl.rs
@@ -133,17 +133,15 @@ impl EmbeddedHost {
     pub(crate) fn watch_actors(&self, actors: Vec<PathBuf>) -> Vec<Hotwatch> {
         actors
             .iter()
-            .filter_map(|actor| {
-                let path = actor.to_str();
-                if std::fs::metadata(actor).is_ok() && path.is_some() {
-                    match self.watch_actor(path.unwrap()) {
-                        Ok(hw) => Some(hw),
-                        Err(e) => {
-                            error!(target: WASH_CMD_INFO, "Unable to watch actor: {}", e);
-                            None
-                        }
+            .filter_map(|actor| match actor.to_str() {
+                Some(path) if std::fs::metadata(actor).is_ok() => match self.watch_actor(path) {
+                    Ok(hw) => Some(hw),
+                    Err(e) => {
+                        error!(target: WASH_CMD_INFO, "Unable to watch actor: {}", e);
+                        None
                     }
-                } else {
+                },
+                _ => {
                     error!(
                         target: WASH_CMD_INFO,
                         "Unable to watch actor: file does not exist"

--- a/src/up/repl.rs
+++ b/src/up/repl.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::util::{Result, WASH_CMD_INFO, WASH_LOG_INFO};
+use crate::ctl::{StartActorCommand, UpdateActorCommand};
+use crate::util::{Output, Result, WASH_CMD_INFO, WASH_LOG_INFO};
 use log::{debug, error, info};
 use std::sync::{mpsc::Sender, Arc, Mutex};
 use structopt::StructOpt;
@@ -120,6 +121,32 @@ impl EmbeddedHost {
             mode,
             op_sender,
         }
+    }
+
+    pub(crate) fn watch_actor(&self, actor_ref: &str) -> Result<()> {
+        // need to then monitor that actor, waiting for changes.
+        // when a change occurs, construct update ctl command
+
+        let start_cmd = CtlCliCommand::Start(StartCommand::Actor(StartActorCommand::new(
+            ConnectionOpts::default(),
+            Output::default(),
+            Some(self.id.to_string()),
+            actor_ref.to_string(),
+            None,
+            1,
+        )));
+        self.op_sender.send(start_cmd)?;
+
+        let update_cmd = CtlCliCommand::Update(UpdateCommand::Actor(UpdateActorCommand::new(
+            ConnectionOpts::default(),
+            Output::default(),
+            self.id.to_string(),
+            actor_ref.to_string(),
+            "MADQAFWOOOCZFDKYEYHC7AUQKDJTP32XUC5TDSMN4JLTDTU2WXBVPG4G".to_string(),
+        )));
+        self.op_sender.send(update_cmd)?;
+
+        Ok(())
     }
 }
 

--- a/src/up/repl.rs
+++ b/src/up/repl.rs
@@ -4,7 +4,7 @@ use crate::util::{Output, Result, WASH_CMD_INFO, WASH_LOG_INFO};
 use crossbeam_channel::Sender;
 use hotwatch::{Event, Hotwatch};
 use log::{debug, error, info};
-use std::fs::{metadata, File};
+use std::fs::metadata;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
 use termion::event::Key;

--- a/src/up/standalone.rs
+++ b/src/up/standalone.rs
@@ -48,8 +48,7 @@ pub(crate) enum HostCommand {
     },
     UpdateActor {
         actor_id: String,
-        new_oci_ref: Option<String>,
-        bytes: Vec<u8>,
+        new_actor_ref: String,
         output_kind: OutputKind,
     },
 }
@@ -116,8 +115,7 @@ impl From<CtlCliCommand> for HostCommand {
             },
             Update(UpdateCommand::Actor(cmd)) => HostCommand::UpdateActor {
                 actor_id: cmd.actor_id,
-                new_oci_ref: Some(cmd.new_actor_ref),
-                bytes: vec![],
+                new_actor_ref: cmd.new_actor_ref,
                 output_kind: cmd.output.kind,
             },
         }

--- a/tests/integration_ctl.rs
+++ b/tests/integration_ctl.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::{output_to_string, wash, Result};
+use crossbeam_channel::unbounded;
 use wasmcloud_host::HostBuilder;
 
 #[actix_rt::test]
@@ -353,7 +354,7 @@ async fn integration_ctl_update_actor() -> Result<()> {
 /// `namespace` is used to create hosts in isolation in the lattice,
 /// as we wouldn't want multiple hosts to interact between tests
 async fn create_host(namespace: String) -> Result<String> {
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = unbounded();
     std::thread::spawn(move || {
         let rt = actix_rt::System::new();
         rt.block_on(async move {

--- a/tests/integration_par.rs
+++ b/tests/integration_par.rs
@@ -18,7 +18,6 @@ fn integration_create_and_insert() {
     remove_dir_all(test_dir).unwrap();
 }
 
-//TODO: test for issuer too
 /// Tests creation of a provider archive file with an initial binary
 fn integration_par_create(issuer: &str, subject: &str, archive: &str) {
     const ARCH: &str = "x86_64-linux";


### PR DESCRIPTION
Fixes #131, Fixes #132, Fixes #105 

Draft PR for now, I wanted to make it visible that I've fixed a few bugs here to avoid anyone taking on that work.

Currently, `wash up --watch` works for standalone and lattice mode to hot-reload an actor with an increased revision. I'd love to do a few more things before I promote this PR:

- [x] Error handling (what happens when an upgrade fails? What if you remove the signed actor file entirely?)
- [x] Allow watching multiple actors (vec argument to `up`)
- [x] Come up with a few recommendations for _how_ to set up a hot-reload environment. It's best to leave the signing and building up to the user (imo) but we should have an easy way to show people how to setup their VSCode / terminal environment that way. ( created https://github.com/wasmCloud/new-actor-template/issues/14 to track this )