### PR TITLE
Truncate id and add name to inventory output

### DIFF
--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -1,5 +1,5 @@
 extern crate wasmcloud_control_interface;
-use crate::util::{format_output, OutputKind, WASH_CMD_INFO};
+use crate::util::{format_ellipsis, format_optional, format_output, OutputKind, WASH_CMD_INFO};
 use log::debug;
 use serde_json::json;
 use term_table::{row::Row, table_cell::*, Table};
@@ -198,6 +198,7 @@ pub(crate) fn hosts_table(hosts: Vec<Host>, max_width: usize) -> String {
 pub(crate) fn host_inventory_table(inv: HostInventory, max_width: usize) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 4, max_width);
+    let max_id_width = crate::util::get_max_column_width(&table, 0, true);
 
     table.add_row(Row::new(vec![TableCell::new_with_alignment(
         format!("Host Inventory ({})", inv.host_id),
@@ -232,18 +233,20 @@ pub(crate) fn host_inventory_table(inv: HostInventory, max_width: usize) -> Stri
             Alignment::Center,
         )]));
         table.add_row(Row::new(vec![
-            TableCell::new_with_alignment("Actor ID", 2, Alignment::Left),
+            TableCell::new_with_alignment("Actor ID", 1, Alignment::Left),
+            TableCell::new_with_alignment("Name", 1, Alignment::Left),
             TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
         ]));
         inv.actors.iter().for_each(|a| {
             let a = a.clone();
             table.add_row(Row::new(vec![
-                TableCell::new_with_alignment(a.id, 2, Alignment::Left),
                 TableCell::new_with_alignment(
-                    a.image_ref.unwrap_or_else(|| "N/A".to_string()),
-                    2,
+                    format_ellipsis(a.id, max_id_width),
+                    1,
                     Alignment::Left,
                 ),
+                TableCell::new_with_alignment(format_optional(a.name), 1, Alignment::Left),
+                TableCell::new_with_alignment(format_optional(a.image_ref), 2, Alignment::Left),
             ]))
         });
     } else {
@@ -261,20 +264,22 @@ pub(crate) fn host_inventory_table(inv: HostInventory, max_width: usize) -> Stri
             Alignment::Center,
         )]));
         table.add_row(Row::new(vec![
-            TableCell::new_with_alignment("Provider ID", 2, Alignment::Left),
+            TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),
+            TableCell::new_with_alignment("Name", 1, Alignment::Left),
             TableCell::new_with_alignment("Link Name", 1, Alignment::Left),
             TableCell::new_with_alignment("Image Reference", 1, Alignment::Left),
         ]));
         inv.providers.iter().for_each(|p| {
             let p = p.clone();
             table.add_row(Row::new(vec![
-                TableCell::new_with_alignment(p.id, 2, Alignment::Left),
-                TableCell::new_with_alignment(p.link_name, 1, Alignment::Left),
                 TableCell::new_with_alignment(
-                    p.image_ref.unwrap_or_else(|| "N/A".to_string()),
+                    format_ellipsis(p.id, max_id_width),
                     1,
                     Alignment::Left,
                 ),
+                TableCell::new_with_alignment(format_optional(p.name), 1, Alignment::Left),
+                TableCell::new_with_alignment(p.link_name, 1, Alignment::Left),
+                TableCell::new_with_alignment(format_optional(p.image_ref), 1, Alignment::Left),
             ]))
         });
     } else {

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -199,6 +199,7 @@ pub(crate) fn host_inventory_table(inv: HostInventory, max_width: usize) -> Stri
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 4, max_width);
 
+    // TableCells have 1 char padding left and right. See [TableCell::pad_content].
     let content_padding_width = 2;
     let max_id_width = crate::util::get_max_column_width(&table, 0) - content_padding_width;
 

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -198,7 +198,9 @@ pub(crate) fn hosts_table(hosts: Vec<Host>, max_width: usize) -> String {
 pub(crate) fn host_inventory_table(inv: HostInventory, max_width: usize) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 4, max_width);
-    let max_id_width = crate::util::get_max_column_width(&table, 0, true);
+
+    let content_padding_width = 2;
+    let max_id_width = crate::util::get_max_column_width(&table, 0) - content_padding_width;
 
     table.add_row(Row::new(vec![TableCell::new_with_alignment(
         format!("Host Inventory ({})", inv.host_id),

--- a/src/util.rs
+++ b/src/util.rs
@@ -184,13 +184,11 @@ pub(crate) fn configure_table_style(table: &mut Table<'_>, columns: usize, max_t
     table.separate_rows = false;
 }
 
-pub(crate) fn get_max_column_width(table: &Table<'_>, column_index: usize, padding: bool) -> usize {
-    let padding_width = if padding { 2 } else { 0 };
+pub(crate) fn get_max_column_width(table: &Table<'_>, column_index: usize) -> usize {
     *table
         .max_column_widths
         .get(&column_index)
         .unwrap_or(&table.max_column_width)
-        - padding_width
 }
 
 fn empty_table_style() -> TableStyle {

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,7 +66,9 @@ impl FromStr for OutputKind {
             "text" => Ok(OutputKind::Text {
                 max_width: get_max_text_output_width(),
             }),
-            "wide" => Ok(OutputKind::Text { max_width: 0 }),
+            "wide" => Ok(OutputKind::Text {
+                max_width: usize::MAX,
+            }),
             _ => Err(OutputParseErr),
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -209,8 +209,18 @@ fn empty_table_style() -> TableStyle {
 
 #[cfg(test)]
 mod test {
-    use super::configure_table_style;
+    use super::{configure_table_style, format_ellipsis};
     use term_table::{row::Row, table_cell::TableCell, Table};
+
+    #[test]
+    fn format_ellipsis_truncates_to_max_width() {
+        assert_eq!("hello w...", &format_ellipsis("hello world".into(), 10));
+    }
+
+    #[test]
+    fn format_ellipsis_no_ellipsis_necessary() {
+        assert_eq!("hello world", &format_ellipsis("hello world".into(), 11));
+    }
 
     #[test]
     fn max_table_width_one_column() {


### PR DESCRIPTION
Hi again. I started to play with truncating the actor/provider id and adding a name column. It feels tricky to strike the right balance here. I think ideally we don't truncate the id if there is enough space. This  seems okay to me.

- Truncate actor/provider id in host inventory to fit into one column

  - We use the available column width to truncate the id and add an ellipsis
  - Truncation only happens if the output width is restricted, which is currently only the case in the REPL
  - The flag `--output wide` also sets the output width to be unrestricted

- Add actor/provider name column to host inventory

Fixes #114

![](https://user-images.githubusercontent.com/3579251/121944321-d5a05900-cd52-11eb-9f15-a66e72a53662.png)

What do you think?