### PR TITLE
add credsfile argument to wash ctl subcommands

### DIFF
--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -51,7 +51,8 @@ pub(crate) struct ConnectionOpts {
     #[structopt(long = "rpc-seed", env = "WASH_RPC_SEED", hide_env_values = true)]
     rpc_seed: Option<String>,
 
-    /// Credsfile for RPC authentication
+    /// Credsfile for RPC authentication. Combines rpc_seed and rpc_jwt.
+    /// See https://docs.nats.io/developing-with-nats/security/creds for details.
     #[structopt(long = "rpc-credsfile", env = "WASH_RPC_CREDS", hide_env_values = true)]
     rpc_credsfile: Option<String>,
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -136,7 +136,7 @@ pub(crate) fn extract_arg_value(arg: &str) -> Result<String> {
             f.read_to_string(&mut value)?;
             Ok(value)
         }
-        Err(_) => Ok(dbg!(arg).trim_end_matches(char::is_whitespace).to_string()),
+        Err(_) => Ok(arg.to_string()),
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,8 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+use std::fs::File;
+use std::io::Read;
 use std::str::FromStr;
 use structopt::StructOpt;
 use term_table::{Table, TableStyle};
@@ -124,6 +126,18 @@ pub(crate) fn format_ellipsis(id: String, max_width: usize) -> String {
 
 pub(crate) fn format_optional(value: Option<String>) -> String {
     value.unwrap_or_else(|| "N/A".into())
+}
+
+/// Returns value from an argument that may be a file path or the value itself
+pub(crate) fn extract_arg_value(arg: &str) -> Result<String> {
+    match File::open(arg) {
+        Ok(mut f) => {
+            let mut value = String::new();
+            f.read_to_string(&mut value)?;
+            Ok(value)
+        }
+        Err(_) => Ok(dbg!(arg).trim_end_matches(char::is_whitespace).to_string()),
+    }
 }
 
 /// Converts error from Send + Sync error to standard error


### PR DESCRIPTION
This is required if you want to use wash to control a cluster over NGS without using a leaf node.

It's mostly copy-paste from how wasmcloud does things.

I have not included the equivalent of wasmcloud's `--control-jwt` and `--control-seed` arguments, because I find .creds files easier to work with, and the jwt+seed separation was confusing to me in the beginning. I can add them if you want though.