### PR TITLE
add flags to call actor so it can call a test actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi",
 ]
@@ -1094,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1253,9 +1254,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1325,9 +1326,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -1402,13 +1403,14 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a9811e5da64c205de3fe3b21f3c365ba155dfe8247c2ea58664d9b220db015"
+checksum = "dddb0090aca6f217f525c1e20422b20881fc40baedfcd9f211fa3b08c3a1e1bb"
 dependencies = [
  "base64 0.13.0",
  "base64-url",
  "blocking",
+ "chrono",
  "crossbeam-channel",
  "fastrand",
  "itoa",
@@ -1423,6 +1425,8 @@ dependencies = [
  "regex",
  "rustls",
  "rustls-native-certs",
+ "serde",
+ "serde_json",
  "webpki",
  "winapi",
 ]
@@ -1508,9 +1512,9 @@ checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
 dependencies = [
  "memchr",
 ]
@@ -1555,9 +1559,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1575,9 +1579,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2868,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -3095,9 +3099,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3107,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3122,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3134,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -3144,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -3157,15 +3161,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasmbus-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1e72428deb16868da4a5993f9a42f1c605da6c08795ade44be815057297c4"
+checksum = "41934ad01e4f1561e7029fd3e488bf8539a56cab20cf16b6edfbef3d91d60b00"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
@@ -3175,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae50206ad3b7ca5d385874a5c4fe0e52d24bcd0796f6ae1405890c88d0429a02"
+checksum = "75db4891a09342d295aef408c4e730e61212028bc273f5e6d254e489e4646c39"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -3207,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.4.0"
-source = "git+https://github.com/wasmCloud/control-interface#e402b3c403bc696ac47aa9f383ae187d70306596"
+version = "0.4.1"
+source = "git+https://github.com/wasmCloud/control-interface#2e561095aaeac3bb5c48f4623312fd3220a3713a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3230,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-testing"
-version = "0.0.1"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31585b2fdc8691d092a3c918bdac696fdab2b8e3392da7821c88b4b9cacbc3ce"
+checksum = "fc12d465601a4c18749c98ce47b538042010ce7cb478b30e269c10b52c47c547"
 dependencies = [
  "async-trait",
  "regex",
@@ -3245,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a5e333ee7b529e3df6919faf8b447e2b273994c94fa5478ec7bdb2aa5bc203"
+checksum = "7242674c1132384b988959a024998e5b2cf5342e75ba812d5a7d8af44d2e444f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3255,6 +3259,7 @@ dependencies = [
  "futures",
  "log",
  "ratsio",
+ "regex",
  "serde",
  "serde_json",
  "termion",
@@ -3267,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3287,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "weld-codegen"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52a41599d82c2f0ad83b91ee6f6cb300722478b65983cab7e72c8b4e2daa559"
+checksum = "b44509002721d6309bddfc26b27c6d760976ecbc81ba8fbcd9612d7c313dd263"
 dependencies = [
  "Inflector",
  "atelier_assembler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8813b3a2f95c5138fe5925bfb8784175d88d6bff059ba8ce090aa891319754"
+dependencies = [
+ "num-traits",
+ "rmp",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,14 +3115,18 @@ dependencies = [
 name = "wash-cli"
 version = "0.6.0"
 dependencies = [
+ "bytes 1.0.1",
  "env_logger 0.9.0",
  "envmnt",
  "log",
  "nats",
  "nkeys",
  "oci-distribution",
+ "once_cell",
  "provider-archive",
  "reqwest",
+ "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,27 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f86cd6857c135e6e9fe57b1619a88d1f94a7df34c00e11fe13e64fd3438837"
-dependencies = [
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
-dependencies = [
- "actix-macros",
- "futures-core",
- "tokio",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +68,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "ascii_tree"
@@ -263,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -796,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1044,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259c65b04c7f45d8cb793c29dae7e4ed0022a70779f33bc8957950b33fc700d7"
+checksum = "fd85ecabdb47308d28d3a4113224fefcab2510ccb4e463aee0a1362eb84c756a"
 dependencies = [
  "log",
  "pest",
@@ -1310,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lock_api"
@@ -1340,9 +1319,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1405,9 +1384,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1520,6 +1499,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2177,6 +2162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",
@@ -2703,6 +2697,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
@@ -2768,9 +2774,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -2907,12 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -3058,7 +3061,6 @@ dependencies = [
 name = "wash-cli"
 version = "0.6.0"
 dependencies = [
- "actix-rt",
  "env_logger 0.9.0",
  "log",
  "nats",
@@ -3072,9 +3074,11 @@ dependencies = [
  "structopt",
  "term-table",
  "test_bin",
+ "tokio",
  "wascap",
  "wasmbus-rpc",
  "wasmcloud-control-interface",
+ "wasmcloud-test-util",
 ]
 
 [[package]]
@@ -3159,9 +3163,9 @@ checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasmbus-macros"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea1548473e58c73f2469e21059c95f1535893cac0039628fc9f16779abae841"
+checksum = "78b1e72428deb16868da4a5993f9a42f1c605da6c08795ade44be815057297c4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
@@ -3171,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c735547ccfa3c5770850359140f221643fac60a50c060592dd35f3e9a9a03a"
+checksum = "ae50206ad3b7ca5d385874a5c4fe0e52d24bcd0796f6ae1405890c88d0429a02"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -3225,6 +3229,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmcloud-interface-testing"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31585b2fdc8691d092a3c918bdac696fdab2b8e3392da7821c88b4b9cacbc3ce"
+dependencies = [
+ "async-trait",
+ "regex",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "wasmbus-rpc",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmcloud-test-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a5e333ee7b529e3df6919faf8b447e2b273994c94fa5478ec7bdb2aa5bc203"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.13.0",
+ "futures",
+ "log",
+ "ratsio",
+ "serde",
+ "serde_json",
+ "termion",
+ "tokio",
+ "toml",
+ "wascap",
+ "wasmbus-rpc",
+ "wasmcloud-interface-testing",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "weld-codegen"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53014cfec853892271df281674b4de027367def18647ab52e74580470430bd15"
+checksum = "c52a41599d82c2f0ad83b91ee6f6cb300722478b65983cab7e72c8b4e2daa559"
 dependencies = [
  "Inflector",
  "atelier_assembler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,18 @@ serde_json = { version = "1.0.62", features = ["raw_value"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4.14"
 env_logger = "0.9"
-actix-rt = "2.2.0"
 spinners = "1.2.0"
 nats = "0.11"
 term-table = "1.3.1"
 oci-distribution = "0.6.0"
+tokio = { version="1", features=["full"]}
 
 nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
 wasmbus-rpc = "0.3"
 wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.0" }
+wasmcloud-test-util = "0.1"
 
 [dev-dependencies]
 test_bin = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4.14"
 env_logger = "0.9"
 spinners = "1.2.0"
-nats = "0.11"
+nats = "0.13"
 term-table = "1.3.1"
 oci-distribution = "0.6.0"
 tokio = { version="1", features=["full"]}
@@ -32,7 +32,7 @@ nkeys = "0.1.0"
 wascap = "0.6.0"
 provider-archive = "0.4.0"
 wasmbus-rpc = "0.3"
-wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.0" }
+wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.1" }
 wasmcloud-test-util = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,25 @@ default = []
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-structopt = "0.3.21"
+bytes = "1.0"
+env_logger = "0.9"
+envmnt = "0.9.0"
+log = "0.4.14"
+nats = "0.13"
+nkeys = "0.1.0"
+oci-distribution = "0.6.0"
+once_cell = "1.8"
+provider-archive = "0.4.0"
+rmp-serde = "0.15"
+rmpv = "1.0"
 serde_json = { version = "1.0.62", features = ["raw_value"] }
 serde = { version = "1.0", features = ["derive"] }
-log = "0.4.14"
-env_logger = "0.9"
-spinners = "1.2.0"
-nats = "0.13"
-term-table = "1.3.1"
-oci-distribution = "0.6.0"
-tokio = { version="1", features=["full"]}
 serde_yaml = "0.8.17"
-envmnt = "0.9.0"
-
-nkeys = "0.1.0"
+spinners = "1.2.0"
+structopt = "0.3.21"
+term-table = "1.3.1"
+tokio = { version="1", features=["full"]}
 wascap = "0.6.0"
-provider-archive = "0.4.0"
 wasmbus-rpc = "0.3"
 wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.1" }
 wasmcloud-test-util = "0.1"

--- a/src/call.rs
+++ b/src/call.rs
@@ -232,11 +232,14 @@ pub(crate) fn call_output(
 mod test {
     use super::{CallCli, CallCommand};
     use crate::util::Result;
+    use std::path::PathBuf;
     use structopt::StructOpt;
 
     const RPC_HOST: &str = "0.0.0.0";
     const RPC_PORT: &str = "4222";
     const NS_PREFIX: &str = "default";
+    const SAVE_FNAME: &str = "/dev/null";
+    const DATA_FNAME: &str = "/tmp/data.json";
 
     const ACTOR_ID: &str = "MDPDJEYIAK6MACO67PRFGOSSLODBISK4SCEYDY3HEOY4P5CVJN6UCWUK";
 
@@ -248,7 +251,9 @@ mod test {
             "json",
             "--test",
             "--data",
-            "some_filename.json",
+            DATA_FNAME,
+            "--save",
+            SAVE_FNAME,
             "--ns-prefix",
             NS_PREFIX,
             "--rpc-host",
@@ -266,6 +271,7 @@ mod test {
                 opts,
                 output,
                 data,
+                save,
                 test,
                 actor_id,
                 operation,
@@ -276,7 +282,8 @@ mod test {
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.timeout, 0);
                 assert_eq!(output.kind, crate::util::OutputKind::Json);
-                assert_eq!(data, Some(PathBuf::from("some_filename.json")));
+                assert_eq!(data, Some(PathBuf::from(DATA_FNAME)));
+                assert_eq!(save, Some(PathBuf::from(SAVE_FNAME)));
                 assert_eq!(test, true);
                 assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(operation, "HandleOperation");

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ enum CliCommand {
     Reg(RegCli),
 }
 
-#[actix_rt::main]
+#[tokio::main]
 async fn main() {
     if env_logger::try_init().is_err() {}
     let cli = Cli::from_args();

--- a/src/util.rs
+++ b/src/util.rs
@@ -127,6 +127,12 @@ pub(crate) fn json_str_to_msgpack_bytes(payload: &str) -> Result<Vec<u8>> {
     Ok(payload)
 }
 
+/// transform msgpack bytes into a json string
+pub(crate) fn msgpack_to_json_val(msg: &[u8]) -> Result<serde_json::Value> {
+    let val: serde_json::Value = wasmbus_rpc::deserialize(msg)?;
+    Ok(val)
+}
+
 pub(crate) fn configure_table_style(table: &mut Table<'_>) {
     table.style = empty_table_style();
     table.separate_rows = false;

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,9 +120,9 @@ pub(crate) fn labels_vec_to_hashmap(constraints: Vec<String>) -> Result<HashMap<
     Ok(hm)
 }
 
-/// Transform a json str (e.g. "{"hello": "world"}") into msgpack bytes
-pub(crate) fn json_str_to_msgpack_bytes(payload: Vec<String>) -> Result<Vec<u8>> {
-    let json = serde_json::from_str::<serde_json::Value>(&payload.join(""))?;
+/// Transform a json string (e.g. "{"hello": "world"}") into msgpack bytes
+pub(crate) fn json_str_to_msgpack_bytes(payload: &str) -> Result<Vec<u8>> {
+    let json = serde_json::from_str::<serde_json::Value>(payload)?;
     let payload = wasmbus_rpc::serialize(&json)?;
     Ok(payload)
 }


### PR DESCRIPTION
Signed-off-by: steve <dev@somecool.net>

New options for `wash call actor`:

 `--data`  allows using a json file for the parameter instead of key-value. This flag isn't necessarily test-specific. It could be used for anyone that uses `wash call actor`.
 `--test`  enables attempting to interpret the results as a Vec<TestResult> (defined by the wasmcloud-test-utils crate).
(I initially tried to add a variant to OutputKind, adding `-o test` instead of `--test`, but it would have affected more than six files, since OutputKind is used everywhere, but TestResult only applies to call actor, so it seemed cleaner to not add an enum variant).
