### PR TITLE
Support querying, deleting link definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -393,6 +399,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "cloudevents-sdk"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f86076fd3d8c3c3449f29cc8f41d5831504870620077307c1dcbae9f7861fa0"
+dependencies = [
+ "base64 0.12.3",
+ "bitflags",
+ "chrono",
+ "delegate-attr",
+ "hostname",
+ "serde",
+ "serde_json",
+ "snafu",
+ "url 2.2.2",
+ "uuid",
+ "web-sys",
 ]
 
 [[package]]
@@ -571,6 +596,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "delegate-attr"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee7e7ea0dba407429d816e8e38dda1a467cd74737722f2ccc8eae60429a1a3ab"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +684,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downloader"
@@ -1015,8 +1057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1080,6 +1124,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1345,6 +1400,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -2540,6 +2601,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3119,7 @@ dependencies = [
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
+ "serde",
 ]
 
 [[package]]
@@ -3267,11 +3350,11 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.4.1"
-source = "git+https://github.com/wasmCloud/control-interface#2e561095aaeac3bb5c48f4623312fd3220a3713a"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
+ "cloudevents-sdk",
  "crossbeam-channel",
  "data-encoding",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ term-table = "1.3.1"
 tokio = { version="1", features=["full"]}
 wascap = "0.6.0"
 wasmbus-rpc = "0.3"
-wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.1" }
+#wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.1" }
+wasmcloud-control-interface = { path = "../control-interface/rust", version = "0.4.2" }
 wasmcloud-test-util = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,7 @@ term-table = "1.3.1"
 tokio = { version="1", features=["full"]}
 wascap = "0.6.0"
 wasmbus-rpc = "0.3"
-#wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.1" }
-wasmcloud-control-interface = { path = "../control-interface/rust", version = "0.4.2" }
+wasmcloud-control-interface = { git = "https://github.com/wasmCloud/control-interface", version = "0.4.2" }
 wasmcloud-test-util = "0.1"
 
 [dev-dependencies]

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -8,6 +8,7 @@ use std::{path::Path, time::Duration};
 use structopt::StructOpt;
 use wasmcloud_control_interface::{
     Client as CtlClient, CtlOperationAck, GetClaimsResponse, Host, HostInventory,
+    LinkDefinitionList,
 };
 mod manifest;
 mod output;
@@ -205,6 +206,10 @@ pub(crate) struct LinkPutCommand {
     #[structopt(name = "actor-id")]
     pub(crate) actor_id: String,
 
+    /// Public key ID of provider
+    #[structopt(name = "provider-id")]
+    pub(crate) provider_id: String,
+
     /// Capability contract ID between actor and provider
     #[structopt(name = "contract-id")]
     pub(crate) contract_id: String,
@@ -212,10 +217,6 @@ pub(crate) struct LinkPutCommand {
     /// Link name, defaults to "default"
     #[structopt(short = "l", long = "link-name")]
     pub(crate) link_name: Option<String>,
-
-    /// Public key ID of provider
-    #[structopt(name = "provider-id")]
-    pub(crate) provider_id: String,
 
     /// Environment values to provide alongside link
     #[structopt(name = "values")]
@@ -428,34 +429,47 @@ pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {
             get_claims_output(claims, &output.kind)
         }
         Link(LinkCommand::Del(cmd)) => {
-            println!("del");
-        }
-        Link(LinkCommand::Put(cmd)) => {
-            println!("del");
-        }
-
-        Link(LinkCommand::Query(cmd)) => {
-            println!("del");
-        }
-        Link(cmd) => {
+            let link_name = &cmd
+                .link_name
+                .clone()
+                .unwrap_or_else(|| "default".to_string());
             sp = update_spinner_message(
                 sp,
                 format!(
-                    " Link {} between {} and {} ... ",
-                    cmd.operation, cmd.actor_id, cmd.provider_id
+                    "Deleting link for {} on {} ({}) ... ",
+                    cmd.actor_id, cmd.contract_id, link_name,
                 ),
                 &cmd.output,
             );
-            let failure = link_operation(cmd.clone())
+            let failure = link_del(cmd.clone())
                 .await
                 .map_or_else(|e| Some(format!("{}", e)), |_| None);
-            link_output(
-                &cmd.operation,
+            link_del_output(
                 &cmd.actor_id,
-                &cmd.provider_id,
+                &cmd.contract_id,
+                link_name,
                 failure,
                 &cmd.output.kind,
             )
+        }
+        Link(LinkCommand::Put(cmd)) => {
+            sp = update_spinner_message(
+                sp,
+                format!(
+                    "Defining link between {} and {} ... ",
+                    cmd.actor_id, cmd.provider_id
+                ),
+                &cmd.output,
+            );
+            let failure = link_put(cmd.clone())
+                .await
+                .map_or_else(|e| Some(format!("{}", e)), |_| None);
+            link_put_output(&cmd.actor_id, &cmd.provider_id, failure, &cmd.output.kind)
+        }
+        Link(LinkCommand::Query(cmd)) => {
+            sp = update_spinner_message(sp, "Querying Links ... ".to_string(), &cmd.output);
+            let result = link_query(cmd.clone()).await?;
+            link_query_output(result, &cmd.output.kind)
         }
         Start(StartCommand::Actor(cmd)) => {
             let output = cmd.output;
@@ -561,29 +575,35 @@ pub(crate) async fn get_claims(cmd: GetClaimsCommand) -> Result<GetClaimsRespons
     client.get_claims().await.map_err(convert_error)
 }
 
-pub(crate) async fn link_operation(cmd: LinkCommand) -> Result<CtlOperationAck> {
+pub(crate) async fn link_del(cmd: LinkDelCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
-    match &*cmd.operation {
-        "put" => client
-            .advertise_link(
-                &cmd.actor_id,
-                &cmd.provider_id,
-                &cmd.contract_id,
-                &cmd.link_name.unwrap_or_else(|| "default".to_string()),
-                labels_vec_to_hashmap(cmd.values)?,
-            )
-            .await
-            .map_err(convert_error),
-        "del" => client
-            .remove_link(
-                &cmd.actor_id,
-                &cmd.contract_id,
-                &cmd.link_name.unwrap_or_else(|| "default".to_string()),
-            )
-            .await
-            .map_err(convert_error),
-        _ => Err(format!("Unsupported link operation {}", cmd.operation).into()),
-    }
+    client
+        .remove_link(
+            &cmd.actor_id,
+            &cmd.contract_id,
+            &cmd.link_name.unwrap_or_else(|| "default".to_string()),
+        )
+        .await
+        .map_err(convert_error)
+}
+
+pub(crate) async fn link_put(cmd: LinkPutCommand) -> Result<CtlOperationAck> {
+    let client = ctl_client_from_opts(cmd.opts).await?;
+    client
+        .advertise_link(
+            &cmd.actor_id,
+            &cmd.provider_id,
+            &cmd.contract_id,
+            &cmd.link_name.unwrap_or_else(|| "default".to_string()),
+            labels_vec_to_hashmap(cmd.values)?,
+        )
+        .await
+        .map_err(convert_error)
+}
+
+pub(crate) async fn link_query(cmd: LinkQueryCommand) -> Result<LinkDefinitionList> {
+    let client = ctl_client_from_opts(cmd.opts).await?;
+    client.query_links().await.map_err(convert_error)
 }
 
 pub(crate) async fn start_actor(cmd: StartActorCommand) -> Result<CtlOperationAck> {

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -148,8 +148,32 @@ pub(crate) enum GetCommand {
     Claims(GetClaimsCommand),
 }
 
+#[derive(Debug, Clone, StructOpt)]
+pub(crate) enum LinkCommand {
+    /// Query established links
+    #[structopt(name = "query")]
+    Query(LinkQueryCommand),
+
+    /// Establish a link definition
+    #[structopt(name = "put")]
+    Put(LinkPutCommand),
+
+    /// Delete a link definition
+    #[structopt(name = "del")]
+    Del(LinkDelCommand),
+}
+
 #[derive(StructOpt, Debug, Clone)]
-pub(crate) struct LinkCommand {
+pub(crate) struct LinkQueryCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    #[structopt(flatten)]
+    pub(crate) output: Output,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub(crate) struct LinkDelCommand {
     #[structopt(flatten)]
     opts: ConnectionOpts,
 
@@ -160,9 +184,26 @@ pub(crate) struct LinkCommand {
     #[structopt(name = "actor-id")]
     pub(crate) actor_id: String,
 
-    /// Public key ID of provider
-    #[structopt(name = "provider-id")]
-    pub(crate) provider_id: String,
+    /// Capability contract ID between actor and provider
+    #[structopt(name = "contract-id")]
+    pub(crate) contract_id: String,
+
+    /// Link name, defaults to "default"
+    #[structopt(short = "l", long = "link-name")]
+    pub(crate) link_name: Option<String>,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub(crate) struct LinkPutCommand {
+    #[structopt(flatten)]
+    opts: ConnectionOpts,
+
+    #[structopt(flatten)]
+    pub(crate) output: Output,
+
+    /// Public key ID of actor
+    #[structopt(name = "actor-id")]
+    pub(crate) actor_id: String,
 
     /// Capability contract ID between actor and provider
     #[structopt(name = "contract-id")]
@@ -171,6 +212,10 @@ pub(crate) struct LinkCommand {
     /// Link name, defaults to "default"
     #[structopt(short = "l", long = "link-name")]
     pub(crate) link_name: Option<String>,
+
+    /// Public key ID of provider
+    #[structopt(name = "provider-id")]
+    pub(crate) provider_id: String,
 
     /// Environment values to provide alongside link
     #[structopt(name = "values")]
@@ -382,19 +427,35 @@ pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {
             let claims = get_claims(cmd).await?;
             get_claims_output(claims, &output.kind)
         }
+        Link(LinkCommand::Del(cmd)) => {
+            println!("del");
+        }
+        Link(LinkCommand::Put(cmd)) => {
+            println!("del");
+        }
+
+        Link(LinkCommand::Query(cmd)) => {
+            println!("del");
+        }
         Link(cmd) => {
             sp = update_spinner_message(
                 sp,
                 format!(
-                    " Advertising link between {} and {} ... ",
-                    cmd.actor_id, cmd.provider_id
+                    " Link {} between {} and {} ... ",
+                    cmd.operation, cmd.actor_id, cmd.provider_id
                 ),
                 &cmd.output,
             );
-            let failure = advertise_link(cmd.clone())
+            let failure = link_operation(cmd.clone())
                 .await
                 .map_or_else(|e| Some(format!("{}", e)), |_| None);
-            link_output(&cmd.actor_id, &cmd.provider_id, failure, &cmd.output.kind)
+            link_output(
+                &cmd.operation,
+                &cmd.actor_id,
+                &cmd.provider_id,
+                failure,
+                &cmd.output.kind,
+            )
         }
         Start(StartCommand::Actor(cmd)) => {
             let output = cmd.output;
@@ -500,18 +561,29 @@ pub(crate) async fn get_claims(cmd: GetClaimsCommand) -> Result<GetClaimsRespons
     client.get_claims().await.map_err(convert_error)
 }
 
-pub(crate) async fn advertise_link(cmd: LinkCommand) -> Result<CtlOperationAck> {
+pub(crate) async fn link_operation(cmd: LinkCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
-    client
-        .advertise_link(
-            &cmd.actor_id,
-            &cmd.provider_id,
-            &cmd.contract_id,
-            &cmd.link_name.unwrap_or_else(|| "default".to_string()),
-            labels_vec_to_hashmap(cmd.values)?,
-        )
-        .await
-        .map_err(convert_error)
+    match &*cmd.operation {
+        "put" => client
+            .advertise_link(
+                &cmd.actor_id,
+                &cmd.provider_id,
+                &cmd.contract_id,
+                &cmd.link_name.unwrap_or_else(|| "default".to_string()),
+                labels_vec_to_hashmap(cmd.values)?,
+            )
+            .await
+            .map_err(convert_error),
+        "del" => client
+            .remove_link(
+                &cmd.actor_id,
+                &cmd.contract_id,
+                &cmd.link_name.unwrap_or_else(|| "default".to_string()),
+            )
+            .await
+            .map_err(convert_error),
+        _ => Err(format!("Unsupported link operation {}", cmd.operation).into()),
+    }
 }
 
 pub(crate) async fn start_actor(cmd: StartActorCommand) -> Result<CtlOperationAck> {
@@ -1005,6 +1077,7 @@ mod test {
         let link_all = CtlCli::from_iter_safe(&[
             "ctl",
             "link",
+            "put",
             "-o",
             "json",
             "--ns-prefix",
@@ -1026,6 +1099,7 @@ mod test {
             CtlCliCommand::Link(LinkCommand {
                 opts,
                 output,
+                operation,
                 actor_id,
                 provider_id,
                 contract_id,
@@ -1037,6 +1111,7 @@ mod test {
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.timeout, 1);
                 assert_eq!(output.kind, OutputKind::Json);
+                assert_eq!(operation, "put".to_string());
                 assert_eq!(actor_id, ACTOR_ID.to_string());
                 assert_eq!(provider_id, PROVIDER_ID.to_string());
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1116,29 +1116,27 @@ mod test {
             "THING=foo",
         ])?;
         match link_all.command {
-            CtlCliCommand::Link(LinkCommand {
+            CtlCliCommand::Link(LinkCommand::Put(LinkPutCommand {
                 opts,
                 output,
-                operation,
                 actor_id,
                 provider_id,
                 contract_id,
                 link_name,
                 values,
-            }) => {
+            })) => {
                 assert_eq!(opts.ctl_host, CTL_HOST);
                 assert_eq!(opts.ctl_port, CTL_PORT);
                 assert_eq!(opts.ns_prefix, NS_PREFIX);
                 assert_eq!(opts.timeout, 1);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(operation, "put".to_string());
                 assert_eq!(actor_id, ACTOR_ID.to_string());
                 assert_eq!(provider_id, PROVIDER_ID.to_string());
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
                 assert_eq!(link_name.unwrap(), "default".to_string());
                 assert_eq!(values, vec!["THING=foo".to_string()]);
             }
-            cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),
+            cmd => panic!("ctl link put constructed incorrect command {:?}", cmd),
         }
         let update_all = CtlCli::from_iter_safe(&[
             "ctl",

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -10,20 +10,46 @@ pub(crate) fn get_hosts_output(hosts: Vec<Host>, output_kind: &OutputKind) -> St
         OutputKind::Json => format!("{}", json!({ "hosts": hosts })),
     }
 }
+
 pub(crate) fn get_host_inventory_output(inv: HostInventory, output_kind: &OutputKind) -> String {
     match *output_kind {
         OutputKind::Text => host_inventory_table(inv),
         OutputKind::Json => format!("{}", json!({ "inventory": inv })),
     }
 }
+
 pub(crate) fn get_claims_output(claims: GetClaimsResponse, output_kind: &OutputKind) -> String {
     match *output_kind {
         OutputKind::Text => claims_table(claims),
         OutputKind::Json => format!("{}", json!({ "claims": claims })),
     }
 }
-pub(crate) fn link_output(
-    operation: &str,
+
+pub(crate) fn link_del_output(
+    actor_id: &str,
+    contract_id: &str,
+    link_name: &str,
+    failure: Option<String>,
+    output_kind: &OutputKind,
+) -> String {
+    match failure {
+        None => format_output(
+            format!(
+                "\nDeleted link for {} on {} ({}) successfully",
+                actor_id, contract_id, link_name
+            ),
+            json!({"actor_id": actor_id, "contract_id": contract_id, "link_name": link_name, "result": "published"}),
+            output_kind,
+        ),
+        Some(f) => format_output(
+            format!("\nError deleting link: {}", f),
+            json!({ "error": f }),
+            output_kind,
+        ),
+    }
+}
+
+pub(crate) fn link_put_output(
     actor_id: &str,
     provider_id: &str,
     failure: Option<String>,
@@ -32,8 +58,8 @@ pub(crate) fn link_output(
     match failure {
         None => format_output(
             format!(
-                "\nLink {} ({}) <-> ({}) successfully",
-                operation, actor_id, provider_id
+                "\nPublished link ({}) <-> ({}) successfully",
+                actor_id, provider_id
             ),
             json!({"actor_id": actor_id, "provider_id": provider_id, "result": "published"}),
             output_kind,
@@ -43,6 +69,13 @@ pub(crate) fn link_output(
             json!({ "error": f }),
             output_kind,
         ),
+    }
+}
+
+pub(crate) fn link_query_output(list: LinkDefinitionList, output_kind: &OutputKind) -> String {
+    match *output_kind {
+        OutputKind::Text => links_table(list),
+        OutputKind::Json => format!("{}", json!({ "links": list.links })),
     }
 }
 
@@ -75,7 +108,31 @@ pub(crate) fn ctl_operation_output(
     }
 }
 
-/// Helper function to print a Host list to stdout as a table
+/// Helper function to transform a LinkDefinitionList into a table string for printing
+pub(crate) fn links_table(list: LinkDefinitionList) -> String {
+    let mut table = Table::new();
+    crate::util::configure_table_style(&mut table);
+
+    table.add_row(Row::new(vec![
+        TableCell::new_with_alignment("Actor ID", 1, Alignment::Left),
+        TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),
+        TableCell::new_with_alignment("Contract ID", 1, Alignment::Left),
+        TableCell::new_with_alignment("Link Name", 1, Alignment::Left),
+    ]));
+
+    list.links.iter().for_each(|l| {
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment(l.actor_id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(l.provider_id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(l.contract_id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(l.link_name.clone(), 1, Alignment::Left),
+        ]))
+    });
+
+    table.render()
+}
+
+/// Helper function to transform a Host list into a table string for printing
 pub(crate) fn hosts_table(hosts: Vec<Host>) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table);
@@ -94,7 +151,7 @@ pub(crate) fn hosts_table(hosts: Vec<Host>) -> String {
     table.render()
 }
 
-/// Helper function to print a HostInventory to stdout as a table
+/// Helper function to transform a HostInventory into a table string for printing
 pub(crate) fn host_inventory_table(inv: HostInventory) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table);
@@ -183,7 +240,7 @@ pub(crate) fn host_inventory_table(inv: HostInventory) -> String {
     table.render()
 }
 
-/// Helper function to print a ClaimsList to stdout as a table
+/// Helper function to transform a ClaimsList into a table string for printing
 pub(crate) fn claims_table(list: GetClaimsResponse) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table);

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -23,6 +23,7 @@ pub(crate) fn get_claims_output(claims: GetClaimsResponse, output_kind: &OutputK
     }
 }
 pub(crate) fn link_output(
+    operation: &str,
     actor_id: &str,
     provider_id: &str,
     failure: Option<String>,
@@ -31,8 +32,8 @@ pub(crate) fn link_output(
     match failure {
         None => format_output(
             format!(
-                "\nAdvertised link ({}) <-> ({}) successfully",
-                actor_id, provider_id
+                "\nLink {} ({}) <-> ({}) successfully",
+                operation, actor_id, provider_id
             ),
             json!({"actor_id": actor_id, "provider_id": provider_id, "result": "published"}),
             output_kind,


### PR DESCRIPTION
Depends on https://github.com/wasmCloud/control-interface/pull/9

This PR includes support for the following commands, and breaks the API for `ctl link` (we have not published `0.6.0` yet, so this is okay)
1. `wash ctl link put <args>` to put a link definition
2. `wash ctl link del <args>` to delete a link definition
3. `wash ctl link query` to retrieve the list of current link definitions

Tests will fail as the control interface is not available yet, the above PR must be merged and then tests can be re-run