### PR TITLE
Issue warning message for 'wash reg push' to localhost without --insecure

### DIFF
--- a/src/reg.rs
+++ b/src/reg.rs
@@ -1,6 +1,6 @@
 extern crate oci_distribution;
 use crate::util::{format_output, Output, OutputKind};
-use log::{debug, info};
+use log::{debug, info, warn};
 use oci_distribution::client::*;
 use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::Reference;
@@ -304,6 +304,10 @@ fn validate_provider_archive(
 }
 
 pub(crate) async fn handle_push(cmd: PushCommand) -> Result<String, Box<dyn ::std::error::Error>> {
+    if cmd.url.starts_with("localhost:") && !cmd.opts.insecure {
+        warn!(" Unless an SSL certificate has been installed, pushing to localhost without the --insecure option will fail")
+    }
+
     let spinner = match cmd.output.kind {
         OutputKind::Text => Some(Spinner::new(
             &Spinners::Dots12,


### PR DESCRIPTION
Signed-off-by: Chris Whealy <chris.whealy@red-badger.com>

If the `wash reg push localhost:nnnn ...` command is issued without the `--insecure` option, then the following, somewhat cryptic, error message is received
```
Error: error sending request for url (https://localhost:5000/v2/): error trying to connect: record overflow
```
This PR simply adds an explanatory warning message in such cases