### PR TITLE
Require cluster seed for rpc invocations

### DIFF
--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -29,7 +29,7 @@ jobs:
           args: --all-features
 
   snap_release:
-    depends_on: [cargo_check, clippy_check]
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3950,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "atelier_core 0.2.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/src/call.rs
+++ b/src/call.rs
@@ -274,6 +274,8 @@ mod test {
             SAVE_FNAME,
             "--bin",
             "2",
+            "--cluster-seed",
+            "SCASDASDASD",
             "--ns-prefix",
             NS_PREFIX,
             "--rpc-host",
@@ -297,6 +299,7 @@ mod test {
                 actor_id,
                 operation,
                 payload,
+                cluster_seed,
             } => {
                 assert_eq!(opts.rpc_host, RPC_HOST);
                 assert_eq!(opts.rpc_port, RPC_PORT);
@@ -305,6 +308,7 @@ mod test {
                 assert_eq!(output.kind, crate::util::OutputKind::Json);
                 assert_eq!(data, Some(PathBuf::from(DATA_FNAME)));
                 assert_eq!(save, Some(PathBuf::from(SAVE_FNAME)));
+                assert_eq!(cluster_seed, "SCASDASDASD");
                 assert_eq!(test, true);
                 assert_eq!(bin, '2');
                 assert_eq!(actor_id, ACTOR_ID);

--- a/src/call.rs
+++ b/src/call.rs
@@ -115,7 +115,7 @@ pub(crate) struct CallCommand {
     #[structopt(long)]
     pub(crate) test: bool,
 
-    /// wasmCloud host cluster seed. This cluster seed must match the cluster seed used to 
+    /// wasmCloud host cluster seed. This cluster seed must match the cluster seed used to
     /// launch the wasmCloud host in order to pass antiforgery checks made by the host
     #[structopt(short = "c", long = "cluster-seed", env = "WASMCLOUD_CLUSTER_SEED")]
     pub(crate) cluster_seed: String,

--- a/src/call.rs
+++ b/src/call.rs
@@ -36,7 +36,6 @@ pub(crate) async fn handle_command(cmd: CallCommand) -> Result<String> {
     let save_output = cmd.save.clone();
     let bin = cmd.bin;
     let res = handle_call(cmd).await;
-    //TODO: Evaluate from_utf8_lossy and use of format here
     Ok(call_output(res, save_output, bin, is_test, &output_kind))
 }
 
@@ -116,6 +115,11 @@ pub(crate) struct CallCommand {
     #[structopt(long)]
     pub(crate) test: bool,
 
+    /// wasmCloud host cluster seed. This cluster seed must match the cluster seed used to 
+    /// launch the wasmCloud host in order to pass antiforgery checks made by the host
+    #[structopt(short = "c", long = "cluster-seed", env = "WASMCLOUD_CLUSTER_SEED")]
+    pub(crate) cluster_seed: String,
+
     /// Public key or OCI reference of actor
     #[structopt(name = "actor-id")]
     pub(crate) actor_id: String,
@@ -176,7 +180,7 @@ pub(crate) async fn handle_call(cmd: CallCommand) -> Result<Vec<u8>> {
     let client = RpcClient::new_asynk(
         nc,
         &cmd.opts.ns_prefix,
-        nkeys::KeyPair::from_seed(&extract_arg_value(&seed)?)?,
+        nkeys::KeyPair::from_seed(&extract_arg_value(&cmd.cluster_seed)?)?,
         WASH_HOST_ID.to_string(),
     );
     client


### PR DESCRIPTION
Fixes #176 
Tested this using the latest built tarball, works great. One caveat is for the Host, you need to supply both the `WASMCLOUD_CLUSTER_SEED` environment variable and the `WASMCLOUD_CLUSTER_ISSUERS` which is just the issuer that matches the seed. I'm going to file an issue for this if this is required and we can discuss there on the OTP repo https://github.com/wasmCloud/wasmcloud-otp/issues/224