### PR TITLE
chore(*): Bumps version to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "atelier_core 0.2.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/wash"

--- a/src/call.rs
+++ b/src/call.rs
@@ -310,7 +310,7 @@ mod test {
                 assert_eq!(data, Some(PathBuf::from(DATA_FNAME)));
                 assert_eq!(save, Some(PathBuf::from(SAVE_FNAME)));
                 assert_eq!(cluster_seed, "SCASDASDASD");
-                assert_eq!(test, true);
+                assert!(test);
                 assert_eq!(bin, '2');
                 assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(operation, "HandleOperation");

--- a/src/generate/template.rs
+++ b/src/generate/template.rs
@@ -245,9 +245,8 @@ mod test {
         };
 
         let matcher = Matcher::new("/target", &template_config).unwrap();
-
-        assert_eq!(matcher.should_include(&PathBuf::from("a.txt")), false);
-        assert_eq!(matcher.should_include(&PathBuf::from("a.txt.html")), true);
+        assert!(!matcher.should_include(&PathBuf::from("a.txt")));
+        assert!(matcher.should_include(&PathBuf::from("a.txt.html")));
     }
 
     #[test]
@@ -263,8 +262,8 @@ mod test {
 
         let matcher = Matcher::new("/target", &template_config).unwrap();
 
-        assert_eq!(matcher.is_raw(&PathBuf::from("a.bin")), true);
-        assert_eq!(matcher.is_raw(&PathBuf::from("x.bin")), true);
-        assert_eq!(matcher.is_raw(&PathBuf::from("b.dat")), true);
+        assert!(matcher.is_raw(&PathBuf::from("a.bin")));
+        assert!(matcher.is_raw(&PathBuf::from("x.bin")));
+        assert!(matcher.is_raw(&PathBuf::from("b.dat")));
     }
 }

--- a/tests/integration_drain.rs
+++ b/tests/integration_drain.rs
@@ -1,7 +1,10 @@
 mod common;
 use common::{output_to_string, test_dir_file, test_dir_with_subfolder, wash};
-use std::fs::{create_dir_all, remove_dir_all, File};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::fs::create_dir_all;
+use std::fs::{remove_dir_all, File};
 use std::io::prelude::*;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::path::PathBuf;
 
 const LIB: &str = "wasmcloudcache";
@@ -151,6 +154,7 @@ fn integration_drain_all() {
     remove_dir_all(test_dir).unwrap();
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn path_to_test_file(smithy_cache_dir: &str) -> PathBuf {
     PathBuf::from(&format!("{}/junk.txt", &smithy_cache_dir))
 }


### PR DESCRIPTION
Also, I couldn't help myself and fixed the remaining clippy warnings
