### PR TITLE
Public key CLI args validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,6 +4072,7 @@ dependencies = [
  "cargo",
  "cargo_atelier",
  "console 0.14.1",
+ "derive_more",
  "dialoguer",
  "dirs 4.0.0",
  "env_logger 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "wash-cli"
-version = "0.7.0"
 authors = ["wasmCloud Team"]
-edition = "2018"
-repository = "https://github.com/wasmcloud/wash"
-description = "wasmcloud Shell (wash) CLI tool"
-license = "Apache-2.0"
-readme = "README.md"
-keywords = ["webassembly", "wasmcloud", "wash", "cli"]
 categories = ["wasm", "command-line-utilities"]
+description = "wasmcloud Shell (wash) CLI tool"
+edition = "2018"
+keywords = ["webassembly", "wasmcloud", "wash", "cli"]
+license = "Apache-2.0"
+name = "wash-cli"
+readme = "README.md"
+repository = "https://github.com/wasmcloud/wash"
+version = "0.7.0"
 
 [features]
 default = []
 
 [badges]
-maintenance = { status = "actively-developed" }
+maintenance = {status = "actively-developed"}
 
 [dependencies]
 anyhow = "1.0"
@@ -23,11 +23,12 @@ bytes = "1.0"
 cargo = "0.56"
 cargo_atelier = "0.2"
 console = "0.14"
+derive_more = {version = "0.99.16", default_features = false, features = ["display", "from", "into"]}
 dialoguer = "0.8"
 dirs = "4.0"
 env_logger = "0.9"
 envmnt = "0.9.0"
-git2 = { version="0.13.22", features=["vendored-libgit2"] }
+git2 = {version = "0.13.22", features = ["vendored-libgit2"]}
 heck = "0.3"
 ignore = "0.4"
 indicatif = "0.16"
@@ -36,7 +37,7 @@ nats = "0.16"
 nkeys = "0.1.0"
 oci-distribution = "0.7.0"
 once_cell = "1.8"
-path-absolutize = { version = "3.0", features=["once_cell_cache"]}
+path-absolutize = {version = "3.0", features = ["once_cell_cache"]}
 provider-archive = "0.4.0"
 regex = "1.5"
 remove_dir_all = "0.7"
@@ -44,16 +45,16 @@ rmp-serde = "0.15"
 rmpv = "1.0"
 sanitize-filename = "0.3.0"
 semver = "1.0"
-serde_json = { version = "1.0", features = ["raw_value"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8.17"
+serde = {version = "1.0", features = ["derive"]}
+serde_json = {version = "1.0", features = ["raw_value"]}
 serde_with = "1.11.0"
+serde_yaml = "0.8.17"
 spinners = "2.0"
 structopt = "0.3.21"
 tempfile = "3.2"
 term-table = "1.3.1"
 thiserror = "1.0"
-tokio = { version="1", features=["full"]}
+tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 walkdir = "2.3"
 wascap = "0.6.0"
@@ -64,12 +65,12 @@ weld-codegen = "0.1.17"
 which = "4.2.2"
 
 [dev-dependencies]
-test_bin = "0.3.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = {version = "0.11", features = ["json"]}
 tempfile = "3"
+test_bin = "0.3.0"
 
 [[bin]]
+bench = true
 name = "wash"
 path = "src/main.rs"
 test = true
-bench = true

--- a/src/ctl/id.rs
+++ b/src/ctl/id.rs
@@ -1,0 +1,42 @@
+use derive_more::{Display, From, Into};
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum IdParseError {
+    #[error(r#"found the prefix "{found}", but expected "{expected}""#)]
+    WrongKeyType { found: char, expected: char },
+    #[error("found length {0}, but should be 56 chars")]
+    WrongLength(usize),
+    #[error("unknown parse error")]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Display, PartialEq, From, Into)]
+pub struct Id<const PREFIX: char>(String);
+
+impl<const PREFIX: char> FromStr for Id<PREFIX> {
+    type Err = IdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let count = s.chars().count();
+        if count != 56 {
+            return Err(IdParseError::WrongLength(count));
+        }
+        let prefix = s
+            .chars()
+            .next()
+            .expect("we already know it's the right length");
+
+        if s.starts_with(PREFIX) {
+            Ok(Self(s.to_string()))
+        } else {
+            Err(IdParseError::WrongKeyType {
+                found: prefix,
+                expected: PREFIX,
+            })
+        }
+    }
+}
+
+pub type HostId = Id<'N'>;

--- a/src/ctl/id.rs
+++ b/src/ctl/id.rs
@@ -24,14 +24,14 @@ impl<const PREFIX: char> FromStr for Id<PREFIX> {
         if count != 56 {
             return Err(IdParseError::WrongLength(count));
         }
-        let prefix = s
-            .chars()
-            .next()
-            .expect("we already know it's the right length");
 
         if s.starts_with(PREFIX) {
             Ok(Self(s.to_string()))
         } else {
+            let prefix = s
+                .chars()
+                .next()
+                .expect("we already know it's the right length");
             Err(IdParseError::WrongKeyType {
                 found: prefix,
                 expected: PREFIX,

--- a/src/ctl/id.rs
+++ b/src/ctl/id.rs
@@ -1,4 +1,5 @@
 use derive_more::{Display, From, Into};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -12,7 +13,7 @@ pub enum IdParseError {
     Unknown,
 }
 
-#[derive(Clone, Debug, Display, PartialEq, From, Into)]
+#[derive(Clone, Debug, Display, PartialEq, From, Into, Serialize, Deserialize)]
 pub struct Id<const PREFIX: char>(String);
 
 impl<const PREFIX: char> FromStr for Id<PREFIX> {
@@ -39,4 +40,6 @@ impl<const PREFIX: char> FromStr for Id<PREFIX> {
     }
 }
 
-pub type HostId = Id<'N'>;
+pub type ModuleId = Id<'M'>;
+pub type ServerId = Id<'N'>;
+pub type ServiceId = Id<'V'>;

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -7,6 +7,8 @@ use crate::{
         DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT,
     },
 };
+use id::HostId;
+pub(crate) use output::*;
 use spinners::{Spinner, Spinners};
 use std::{
     path::{Path, PathBuf},
@@ -17,9 +19,11 @@ use wasmcloud_control_interface::{
     Client as CtlClient, CtlOperationAck, GetClaimsResponse, Host, HostInventory,
     LinkDefinitionList,
 };
+
+mod id;
 mod manifest;
 mod output;
-pub(crate) use output::*;
+
 #[derive(Debug, Clone, StructOpt)]
 pub(crate) struct CtlCli {
     #[structopt(flatten)]
@@ -105,7 +109,7 @@ pub(crate) enum CtlCliCommand {
     #[structopt(name = "update")]
     Update(UpdateCommand),
 
-    /// Apply a manifest file to a target hsot
+    /// Apply a manifest file to a target host
     #[structopt(name = "apply")]
     Apply(ApplyCommand),
 }
@@ -271,8 +275,8 @@ pub(crate) struct GetHostInventoryCommand {
     pub(crate) output: Output,
 
     /// Id of host
-    #[structopt(name = "host-id")]
-    pub(crate) host_id: String,
+    #[structopt(name = "host-id", parse(try_from_str))]
+    pub(crate) host_id: HostId,
 }
 
 #[derive(Debug, Clone, StructOpt)]
@@ -603,7 +607,7 @@ pub(crate) async fn get_hosts(cmd: GetHostsCommand) -> Result<Vec<Host>> {
 pub(crate) async fn get_host_inventory(cmd: GetHostInventoryCommand) -> Result<HostInventory> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
-        .get_host_inventory(&cmd.host_id)
+        .get_host_inventory(&cmd.host_id.to_string())
         .await
         .map_err(convert_error)
 }
@@ -1188,7 +1192,7 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(host_id, HOST_ID.to_string());
+                assert_eq!(host_id, HOST_ID.parse()?);
             }
             cmd => panic!("ctl get inventory constructed incorrect command {:?}", cmd),
         }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT,
     },
 };
-use id::HostId;
+use id::{ModuleId, ServerId, ServiceId};
 pub(crate) use output::*;
 use spinners::{Spinner, Spinners};
 use std::{
@@ -117,8 +117,8 @@ pub(crate) enum CtlCliCommand {
 #[derive(StructOpt, Debug, Clone)]
 pub(crate) struct ApplyCommand {
     /// Public key of the target host for the manifest application
-    #[structopt(name = "host-key")]
-    pub(crate) host_key: String,
+    #[structopt(name = "host-key", parse(try_from_str))]
+    pub(crate) host_key: ServerId,
 
     /// Path to the manifest file. Note that all the entries in this file are imperative instructions, and all actor and provider references MUST be valid OCI references.
     #[structopt(name = "path")]
@@ -183,8 +183,8 @@ pub(crate) struct LinkDelCommand {
     pub(crate) output: Output,
 
     /// Public key ID of actor
-    #[structopt(name = "actor-id")]
-    pub(crate) actor_id: String,
+    #[structopt(name = "actor-id", parse(try_from_str))]
+    pub(crate) actor_id: ModuleId,
 
     /// Capability contract ID between actor and provider
     #[structopt(name = "contract-id")]
@@ -204,12 +204,12 @@ pub(crate) struct LinkPutCommand {
     pub(crate) output: Output,
 
     /// Public key ID of actor
-    #[structopt(name = "actor-id")]
-    pub(crate) actor_id: String,
+    #[structopt(name = "actor-id", parse(try_from_str))]
+    pub(crate) actor_id: ModuleId,
 
     /// Public key ID of provider
-    #[structopt(name = "provider-id")]
-    pub(crate) provider_id: String,
+    #[structopt(name = "provider-id", parse(try_from_str))]
+    pub(crate) provider_id: ServiceId,
 
     /// Capability contract ID between actor and provider
     #[structopt(name = "contract-id")]
@@ -276,7 +276,7 @@ pub(crate) struct GetHostInventoryCommand {
 
     /// Id of host
     #[structopt(name = "host-id", parse(try_from_str))]
-    pub(crate) host_id: HostId,
+    pub(crate) host_id: ServerId,
 }
 
 #[derive(Debug, Clone, StructOpt)]
@@ -297,8 +297,8 @@ pub(crate) struct StartActorCommand {
     pub(crate) output: Output,
 
     /// Id of host, if omitted the actor will be auctioned in the lattice to find a suitable host
-    #[structopt(short = "h", long = "host-id", name = "host-id")]
-    pub(crate) host_id: Option<String>,
+    #[structopt(short = "h", long = "host-id", name = "host-id", parse(try_from_str))]
+    pub(crate) host_id: Option<ServerId>,
 
     /// Actor reference, e.g. the OCI URL for the actor.
     #[structopt(name = "actor-ref")]
@@ -322,8 +322,8 @@ pub(crate) struct StartProviderCommand {
     pub(crate) output: Output,
 
     /// Id of host, if omitted the provider will be auctioned in the lattice to find a suitable host
-    #[structopt(short = "h", long = "host-id", name = "host-id")]
-    host_id: Option<String>,
+    #[structopt(short = "h", long = "host-id", name = "host-id", parse(try_from_str))]
+    host_id: Option<ServerId>,
 
     /// Provider reference, e.g. the OCI URL for the provider
     #[structopt(name = "provider-ref")]
@@ -351,12 +351,12 @@ pub(crate) struct StopActorCommand {
     pub(crate) output: Output,
 
     /// Id of host
-    #[structopt(name = "host-id")]
-    pub(crate) host_id: String,
+    #[structopt(name = "host-id", parse(try_from_str))]
+    pub(crate) host_id: ServerId,
 
     /// Actor Id, e.g. the public key for the actor
-    #[structopt(name = "actor-id")]
-    pub(crate) actor_id: String,
+    #[structopt(name = "actor-id", parse(try_from_str))]
+    pub(crate) actor_id: ModuleId,
 
     /// Number of actors to stop
     #[structopt(long = "count", default_value = "1")]
@@ -372,12 +372,12 @@ pub(crate) struct StopProviderCommand {
     pub(crate) output: Output,
 
     /// Id of host
-    #[structopt(name = "host-id")]
-    host_id: String,
+    #[structopt(name = "host-id", parse(try_from_str))]
+    host_id: ServerId,
 
     /// Provider Id, e.g. the public key for the provider
-    #[structopt(name = "provider-id")]
-    pub(crate) provider_id: String,
+    #[structopt(name = "provider-id", parse(try_from_str))]
+    pub(crate) provider_id: ServiceId,
 
     /// Link name of provider
     #[structopt(name = "link-name")]
@@ -397,8 +397,8 @@ pub(crate) struct StopHostCommand {
     pub(crate) output: Output,
 
     /// Id of host
-    #[structopt(name = "host-id")]
-    host_id: String,
+    #[structopt(name = "host-id", parse(try_from_str))]
+    host_id: ServerId,
 
     /// The timeout in ms for how much time to give the host for graceful shutdown
     #[structopt(short = "h", long = "host-timeout")]
@@ -414,12 +414,12 @@ pub(crate) struct UpdateActorCommand {
     pub(crate) output: Output,
 
     /// Id of host
-    #[structopt(name = "host-id")]
-    pub(crate) host_id: String,
+    #[structopt(name = "host-id", parse(try_from_str))]
+    pub(crate) host_id: ServerId,
 
     /// Actor Id, e.g. the public key for the actor
-    #[structopt(name = "actor-id")]
-    pub(crate) actor_id: String,
+    #[structopt(name = "actor-id", parse(try_from_str))]
+    pub(crate) actor_id: ModuleId,
 
     /// Actor reference, e.g. the OCI URL for the actor.
     #[structopt(name = "new-actor-ref")]
@@ -621,7 +621,7 @@ pub(crate) async fn link_del(cmd: LinkDelCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
         .remove_link(
-            &cmd.actor_id,
+            &cmd.actor_id.to_string(),
             &cmd.contract_id,
             &cmd.link_name.unwrap_or_else(|| "default".to_string()),
         )
@@ -633,8 +633,8 @@ pub(crate) async fn link_put(cmd: LinkPutCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
         .advertise_link(
-            &cmd.actor_id,
-            &cmd.provider_id,
+            &cmd.actor_id.to_string(),
+            &cmd.provider_id.to_string(),
             &cmd.contract_id,
             &cmd.link_name.unwrap_or_else(|| "default".to_string()),
             labels_vec_to_hashmap(cmd.values)?,
@@ -675,13 +675,13 @@ pub(crate) async fn start_actor(cmd: StartActorCommand) -> Result<CtlOperationAc
             if suitable_hosts.is_empty() {
                 return Err(format!("No suitable hosts found for actor {}", cmd.actor_ref).into());
             } else {
-                suitable_hosts[0].host_id.to_string()
+                suitable_hosts[0].host_id.parse()?
             }
         }
     };
 
     client
-        .start_actor(&host, &cmd.actor_ref, None)
+        .start_actor(&host.to_string(), &cmd.actor_ref, None)
         .await
         .map_err(convert_error)
 }
@@ -716,13 +716,19 @@ pub(crate) async fn start_provider(cmd: StartProviderCommand) -> Result<CtlOpera
                     format!("No suitable hosts found for provider {}", cmd.provider_ref).into(),
                 );
             } else {
-                suitable_hosts[0].host_id.to_string()
+                suitable_hosts[0].host_id.parse()?
             }
         }
     };
 
     client
-        .start_provider(&host, &cmd.provider_ref, Some(cmd.link_name), None, None)
+        .start_provider(
+            &host.to_string(),
+            &cmd.provider_ref,
+            Some(cmd.link_name),
+            None,
+            None,
+        )
         .await
         .map_err(convert_error)
 }
@@ -731,8 +737,8 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CtlOperati
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
         .stop_provider(
-            &cmd.host_id,
-            &cmd.provider_id,
+            &cmd.host_id.to_string(),
+            &cmd.provider_id.to_string(),
             &cmd.link_name,
             &cmd.contract_id,
             None,
@@ -744,7 +750,12 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CtlOperati
 pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
-        .stop_actor(&cmd.host_id, &cmd.actor_id, cmd.count, None)
+        .stop_actor(
+            &cmd.host_id.to_string(),
+            &cmd.actor_id.to_string(),
+            cmd.count,
+            None,
+        )
         .await
         .map_err(convert_error)
 }
@@ -752,7 +763,7 @@ pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CtlOperationAck>
 pub(crate) async fn stop_host(cmd: StopHostCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
-        .stop_host(&cmd.host_id, cmd.host_shutdown_timeout)
+        .stop_host(&cmd.host_id.to_string(), cmd.host_shutdown_timeout)
         .await
         .map_err(convert_error)
 }
@@ -760,7 +771,12 @@ pub(crate) async fn stop_host(cmd: StopHostCommand) -> Result<CtlOperationAck> {
 pub(crate) async fn update_actor(cmd: UpdateActorCommand) -> Result<CtlOperationAck> {
     let client = ctl_client_from_opts(cmd.opts).await?;
     client
-        .update_actor(&cmd.host_id, &cmd.actor_id, &cmd.new_actor_ref, None)
+        .update_actor(
+            &cmd.host_id.to_string(),
+            &cmd.actor_id.to_string(),
+            &cmd.new_actor_ref,
+            None,
+        )
         .await
         .map_err(convert_error)
 }
@@ -779,14 +795,14 @@ pub(crate) async fn apply_manifest(cmd: ApplyCommand) -> Result<Vec<String>> {
 }
 
 async fn apply_manifest_actors(
-    host_id: &str,
+    host_id: &ServerId,
     client: &CtlClient,
     hm: &HostManifest,
 ) -> Result<Vec<String>> {
     let mut results = vec![];
 
     for actor in hm.actors.iter() {
-        match client.start_actor(host_id, actor, None).await {
+        match client.start_actor(&host_id.to_string(), actor, None).await {
             Ok(ack) => {
                 if ack.accepted {
                     results.push(format!(
@@ -842,7 +858,7 @@ async fn apply_manifest_linkdefs(client: &CtlClient, hm: &HostManifest) -> Resul
 }
 
 async fn apply_manifest_providers(
-    host_id: &str,
+    host_id: &ServerId,
     client: &CtlClient,
     hm: &HostManifest,
 ) -> Result<Vec<String>> {
@@ -850,7 +866,13 @@ async fn apply_manifest_providers(
 
     for cap in hm.capabilities.iter() {
         match client
-            .start_provider(host_id, &cap.image_ref, cap.link_name.clone(), None, None)
+            .start_provider(
+                &host_id.to_string(),
+                &cap.image_ref,
+                cap.link_name.clone(),
+                None,
+                None,
+            )
             .await
         {
             Ok(ack) => {
@@ -1009,7 +1031,7 @@ mod test {
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(auction_timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(host_id.unwrap(), HOST_ID.to_string());
+                assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v1".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
             }
@@ -1057,7 +1079,7 @@ mod test {
                 assert_eq!(output.kind, OutputKind::Json);
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
-                assert_eq!(host_id.unwrap(), HOST_ID.to_string());
+                assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
                 assert_eq!(provider_ref, "wasmcloud.azurecr.io/provider:v1".to_string());
             }
             cmd => panic!("ctl start provider constructed incorrect command {:?}", cmd),
@@ -1094,8 +1116,8 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(host_id, HOST_ID.to_string());
-                assert_eq!(actor_id, ACTOR_ID.to_string());
+                assert_eq!(host_id, HOST_ID.parse()?);
+                assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(count, 2);
             }
             cmd => panic!("ctl stop actor constructed incorrect command {:?}", cmd),
@@ -1133,8 +1155,8 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(host_id, HOST_ID.to_string());
-                assert_eq!(provider_id, PROVIDER_ID.to_string());
+                assert_eq!(host_id, HOST_ID.parse()?);
+                assert_eq!(provider_id, PROVIDER_ID.parse()?);
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
             }
@@ -1257,8 +1279,8 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(actor_id, ACTOR_ID.to_string());
-                assert_eq!(provider_id, PROVIDER_ID.to_string());
+                assert_eq!(actor_id, ACTOR_ID.parse()?);
+                assert_eq!(provider_id, PROVIDER_ID.parse()?);
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
                 assert_eq!(link_name.unwrap(), "default".to_string());
                 assert_eq!(values, vec!["THING=foo".to_string()]);
@@ -1296,8 +1318,8 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms.unwrap(), 2000);
                 assert_eq!(output.kind, OutputKind::Json);
-                assert_eq!(host_id, HOST_ID.to_string());
-                assert_eq!(actor_id, ACTOR_ID.to_string());
+                assert_eq!(host_id, HOST_ID.parse()?);
+                assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(new_actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());
             }
             cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -4,6 +4,8 @@ use serde_json::json;
 use term_table::{row::Row, table_cell::*, Table};
 use wasmcloud_control_interface::*;
 
+use super::id::{ModuleId, ServiceId};
+
 pub(crate) fn get_hosts_output(hosts: Vec<Host>, output_kind: &OutputKind) -> String {
     match *output_kind {
         OutputKind::Text => hosts_table(hosts),
@@ -26,7 +28,7 @@ pub(crate) fn get_claims_output(claims: GetClaimsResponse, output_kind: &OutputK
 }
 
 pub(crate) fn link_del_output(
-    actor_id: &str,
+    actor_id: &ModuleId,
     contract_id: &str,
     link_name: &str,
     failure: Option<String>,
@@ -50,8 +52,8 @@ pub(crate) fn link_del_output(
 }
 
 pub(crate) fn link_put_output(
-    actor_id: &str,
-    provider_id: &str,
+    actor_id: &ModuleId,
+    provider_id: &ServiceId,
     failure: Option<String>,
     output_kind: &OutputKind,
 ) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,17 +23,16 @@ mod ctx;
 use ctx::CtxCli;
 mod util;
 
-/// This renders appropriately with escape characters
-const ASCII: &str = "
+const ASCII: &str = r#"
                                _____ _                 _    _____ _          _ _
                               / ____| |               | |  / ____| |        | | |
  __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
- \\ \\ /\\ / / _` / __| '_ ` _ \\| |    | |/ _ \\| | | |/ _` |  \\___ \\| '_ \\ / _ \\ | |
-  \\ V  V / (_| \\__ \\ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
-   \\_/\\_/ \\__,_|___/_| |_| |_|\\_____|_|\\___/ \\__,_|\\__,_| |_____/|_| |_|\\___|_|_|
+ \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
+  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
+   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
 
 A single CLI to handle all of your wasmCloud tooling needs
-";
+"#;
 
 #[derive(Debug, Clone, StructOpt)]
 #[structopt(global_settings(&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands, AppSettings::DisableHelpSubcommand]),
@@ -91,16 +90,16 @@ async fn main() {
     let cli = Cli::from_args();
 
     let res = match cli.command {
-        CliCommand::Call(callcli) => call::handle_command(callcli.command()).await,
-        CliCommand::Claims(claimscli) => claims::handle_command(claimscli.command()).await,
-        CliCommand::Ctl(ctlcli) => ctl::handle_command(ctlcli.command()).await,
-        CliCommand::Ctx(ctxcli) => ctx::handle_command(ctxcli.command()).await,
-        CliCommand::Drain(draincmd) => drain::handle_command(draincmd.command()),
+        CliCommand::Call(call_cli) => call::handle_command(call_cli.command()).await,
+        CliCommand::Claims(claims_cli) => claims::handle_command(claims_cli.command()).await,
+        CliCommand::Ctl(ctl_cli) => ctl::handle_command(ctl_cli.command()).await,
+        CliCommand::Ctx(ctx_cli) => ctx::handle_command(ctx_cli.command()).await,
+        CliCommand::Drain(drain_cmd) => drain::handle_command(drain_cmd.command()),
         CliCommand::Gen(generate_cli) => smithy::handle_gen_command(generate_cli),
-        CliCommand::Keys(keyscli) => keys::handle_command(keyscli.command()),
-        CliCommand::New(newcli) => generate::handle_command(newcli.command()),
-        CliCommand::Par(parcli) => par::handle_command(parcli.command()).await,
-        CliCommand::Reg(regcli) => reg::handle_command(regcli.command()).await,
+        CliCommand::Keys(keys_cli) => keys::handle_command(keys_cli.command()),
+        CliCommand::New(new_cli) => generate::handle_command(new_cli.command()),
+        CliCommand::Par(par_cli) => par::handle_command(par_cli.command()).await,
+        CliCommand::Reg(reg_cli) => reg::handle_command(reg_cli.command()).await,
         CliCommand::Lint(lint_cli) => smithy::handle_lint_command(lint_cli).await,
         CliCommand::Validate(validate_cli) => smithy::handle_validate_command(validate_cli).await,
     };


### PR DESCRIPTION
This PR partially implements https://github.com/wasmCloud/wash/issues/192

- [x] create a const generic tuple struct `Id` that can represent public keys with a const `PREFIX`
- [x] alias this as `ServerId`, with generic parameter `'N'`
- [x] implement `FromStr` for parsing
- [x] hook into `StructOpt` to display error when input is invalid
- [x] add the other public key types (`ModuleId` and `ServiceId`, with `'M'` and `'V'` respectively)
- [x] a few tidy ups and clippy fixes