### PR TITLE
ref(link): Return better errors when provider id is given

### DIFF
--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -463,6 +463,20 @@ pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {
                 .link_name
                 .clone()
                 .unwrap_or_else(|| "default".to_string());
+            // Check if the contract ID parameter is a 56 character key and suggest that the user
+            // give the contract ID instead
+            //
+            // NOTE: `len` is ok here because keys are only ascii characters that take up a single
+            // byte.
+            if cmd.contract_id.len() == 56 && cmd.contract_id.starts_with('V') {
+                link_del_output(
+                    &cmd.actor_id,
+                    &cmd.contract_id,
+                    link_name,
+                    Some("It looks like you used a Provider ID (e.g. VABC...) instead of a contract ID (e.g. wasmcloud:httpserver)".into()),
+                    &cmd.output.kind,
+                )?;
+            }
             sp = update_spinner_message(
                 sp,
                 format!(
@@ -480,7 +494,7 @@ pub(crate) async fn handle_command(command: CtlCliCommand) -> Result<String> {
                 link_name,
                 failure,
                 &cmd.output.kind,
-            )
+            )?
         }
         Link(LinkCommand::Put(cmd)) => {
             sp = update_spinner_message(

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -33,21 +33,21 @@ pub(crate) fn link_del_output(
     link_name: &str,
     failure: Option<String>,
     output_kind: &OutputKind,
-) -> String {
+) -> std::result::Result<String, String> {
     match failure {
-        None => format_output(
+        None => Ok(format_output(
             format!(
                 "\nDeleted link for {} on {} ({}) successfully",
                 actor_id, contract_id, link_name
             ),
             json!({"actor_id": actor_id, "contract_id": contract_id, "link_name": link_name, "result": "published"}),
             output_kind,
-        ),
-        Some(f) => format_output(
+        )),
+        Some(f) => Err(format_output(
             format!("\nError deleting link: {}", f),
             json!({ "error": f }),
             output_kind,
-        ),
+        )),
     }
 }
 


### PR DESCRIPTION
It is relatively common for first time users to pass the provider id rather
than the contract ID when doing `wash ctl link del`. This adds a block
that tests if it is a provider ID and returns a hint to the user. I also
noticed we weren't returning an error code on link commands if they failed,
so I added some logic to fix it