### PR TITLE
Set permissions on generated keys to be user-only on Unix systems

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,6 +1,6 @@
 use crate::{
     cfg::cfg_dir,
-    util::{CommandOutput, OutputKind},
+    util::{set_permissions_keys, CommandOutput, OutputKind},
 };
 use anyhow::{bail, Context, Result};
 use nkeys::{KeyPair, KeyPairType};
@@ -206,9 +206,12 @@ pub(crate) fn extract_keypair(
 
                 let kp = KeyPair::new(keygen_type);
                 let seed = kp.seed()?;
-                fs::create_dir_all(Path::new(&path).parent().unwrap())?;
-                let mut f = File::create(path)?;
+                let key_path = Path::new(&path).parent().unwrap();
+                fs::create_dir_all(key_path)?;
+                set_permissions_keys(key_path)?;
+                let mut f = File::create(path.clone())?;
                 f.write_all(seed.as_bytes())?;
+                set_permissions_keys(&path)?;
                 seed
             }
             _ => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,13 @@ use anyhow::{anyhow, bail, Result};
 use nats::asynk::Connection;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap, env::temp_dir, error::Error, fmt, fs::File, io::Read, path::PathBuf,
+    collections::HashMap,
+    env::temp_dir,
+    error::Error,
+    fmt, fs,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
     str::FromStr,
 };
 use term_table::{Table, TableStyle};
@@ -285,4 +291,22 @@ pub fn validate_contract_id(contract_id: &str) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+#[cfg(all(unix))]
+/// Set file and folder permissions for keys.
+pub(crate) fn set_permissions_keys(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = path.metadata()?;
+    match metadata.file_type().is_dir() {
+        true => fs::set_permissions(path, fs::Permissions::from_mode(0o700))?,
+        false => fs::set_permissions(path, fs::Permissions::from_mode(0o600))?,
+    };
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn set_permissions(path: &PathBuf) -> Result<()> {
+    Ok(())
 }


### PR DESCRIPTION
Set the permissions on generated keys to `0600` and the directory to
`0700` on Unix systems. Windows permissions are a no-op due to having to
call the Windows APIs directly which is not very straightforward in
Rust.

Partial fix for #218.