### PR TITLE
Reorders docker and azurecr logins

### DIFF
--- a/.github/workflows/wash_docker.yml
+++ b/.github/workflows/wash_docker.yml
@@ -21,18 +21,18 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        uses: docker/login-action@v1
-        if: github.repository == 'wasmCloud/wash'
-        with:
-          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
-          password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
-      -
         uses: azure/docker-login@v1
         if: github.repository == 'wasmCloud/wash'
         with:
           login-server: ${{ secrets.AZURECR_PUSH_URL }}
           username: ${{ secrets.AZURECR_PUSH_USER }}
           password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
+      -
+        uses: docker/login-action@v1
+        if: github.repository == 'wasmCloud/wash'
+        with:
+          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
+          password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
       -
         name: Docker metadata
         id: meta


### PR DESCRIPTION
We have reason to believe that AzureCR overwrites docker credentials per https://github.com/wasmCloud/wash/issues/241