### PR TITLE
[FEATURE] overriding usage to add link_name to wash ctl link put

### DIFF
--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -195,6 +195,9 @@ pub(crate) struct LinkDelCommand {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[clap(
+    override_usage = "wash ctl link put --link-name <LINK_NAME> [OPTIONS] <actor-id> <provider-id> <contract-id> [values]..."
+)]
 pub(crate) struct LinkPutCommand {
     #[clap(flatten)]
     opts: ConnectionOpts,


### PR DESCRIPTION
Addresses #247 

This is the current way I've seen to override the usage string for a specific command. I was unable to find a way to make certain [OPTIONS] come out for visibility (like a must_show_usage kind of attribute to add to an option).

Probably need to wrap the link-name option in [] too, but we can review that.