### PR TITLE
0.10.0 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.10.0-alpha.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.10.0-alpha.3"
+version = "0.10.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Latest Release](https://img.shields.io/github/v/release/wasmcloud/wash?color=success&include_prereleases)](https://github.com/wasmCloud/wash/releases)
 [![Rust Build](https://img.shields.io/github/workflow/status/wasmcloud/wash/Rust/main)](https://github.com/wasmCloud/wash/actions/workflows/rust.yml)
-[![Rust Version](https://img.shields.io/badge/rustc-1.57.0-orange.svg)](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html) 
+[![Rust Version](https://img.shields.io/badge/rustc-1.60.0-orange.svg)](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html) 
 [![Contributors](https://img.shields.io/github/contributors/wasmcloud/wash)](https://github.com/wasmCloud/wash/graphs/contributors)
 [![Good first issues](https://img.shields.io/github/issues/wasmcloud/wash/good%20first%20issue?label=good%20first%20issues)](https://github.com/wasmCloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 [![wash-cli](https://img.shields.io/crates/v/wash-cli)](https://crates.io/crates/wash-cli) 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: wash
 base: core20 # the base snap is the execution environment for this snap
-version: '0.8.0'
+version: '0.10.0'
 summary: WAsmcloud SHell - A multi-tool for wasmCloud development.
 icon: snap/local/icon.png
 description: |


### PR DESCRIPTION
Release notes, looking for feedback on these as well:
### Breaking Changes
- ⚠️ The default behavior for `ctl` commands is now to wait for a successful event to occur for the corresponding command. For example, `wash ctl start actor [wasmcloud.azurecr.io/echo:0.3.4](http://wasmcloud.azurecr.io/echo:0.3.4)` will now wait for an `ActorStarted` event to be published by a host. This can be ignored in favor of finishing on the early ack by passing the `--skip-wait` flag. This is marked with a caution sign as it may affect existing scripts where timeouts are set to a short value expecting an early ack. Big thanks to @mattwilkinsonn for this massive PR #245
- Removed short `-h` flags from all commands so that `--help` can always be used for context in #255

### New Features
- `wash ctl scale actor` in #238 from @mattwilkinsonn to declaratively scale an actor to a number of replicas
- `--no-git-init` flag to `wash gen` to allow user to initialize their own git repository in #240 from @mattwilkinsonn
- Use `indicatif` instead of `spinners` for long-running operations, this also fixed a harmless panic that would occur in non-interactive TTY sessions (Windows Powershell, Github Actions) in #246 by @byblakeorriver

### Fixes and Misc
- Custom help text for `wash ctl link put` for command clarity in #254 by @emattiza
- Docker deployments to use an alpine image for better support in #239 by @jordan-rash
- Fixed a bug where base64 values with padding in link definitions would be incorrectly parsed in #250 by @emattiza

I'll note it in the release notes as well, but huge thanks to our community members for the features that went into this version! 