### PR TITLE
Added support for oci manifest annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3815,6 +3815,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "term-table",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -32,7 +32,7 @@ ignore = "0.4"
 indicatif = "0.16"
 log = "0.4"
 nkeys = "0.2.0"
-oci-distribution = "0.8.0"
+oci-distribution = "0.8.1"
 once_cell = "1.8"
 path-absolutize = {version = "3.0", features = ["once_cell_cache"]}
 provider-archive = "0.5.0"
@@ -46,6 +46,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", features = ["raw_value"]}
 serde_with = "1.11.0"
 serde_yaml = "0.8.17"
+sha2 = "0.9.2"
 tempfile = "3.2"
 term-table = "1.3.1"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.10.1"
+version = "0.11.0-alpha.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"


### PR DESCRIPTION
Certain registries, like [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) depend on OCI manifest annotations in order to perform special actions. In Github's case, adding an annotation of `org.opencontainers.image.source=<your_repo>` will automatically associate a package (actor/provider) with a github repository.

I think this is _technically_ a minor bump but I left it as a patch since it's so small. Feel free to request that I change that, and I can change to `0.11.0-alpha.1` instead to indicate new features

Signed-off-by: Brooks Townsend <brooks@cosmonic.com>