### PR TITLE
Refactor to use async-nats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,7 +3737,6 @@ dependencies = [
  "clap 3.2.12",
  "cloudevents-sdk",
  "console",
- "crossbeam-channel",
  "derive_more",
  "dialoguer",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "ascii_tree"
@@ -65,9 +65,9 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "assert-json-diff"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,6 +82,35 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7a978fbbf815c3dc2e36be3af06eadd69182c299a71eacfed7529c7c5b0778"
+dependencies = [
+ "base64-url",
+ "bytes",
+ "futures 0.3.21",
+ "http",
+ "itoa",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "regex",
+ "rustls-native-certs 0.6.2",
+ "rustls-pemfile 0.3.0",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "subslice",
+ "time 0.3.11",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.3",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -107,15 +136,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -253,9 +282,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -340,6 +369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byte-tools"
@@ -444,7 +482,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -465,16 +503,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -482,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -495,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -598,12 +636,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.10",
 ]
 
 [[package]]
@@ -614,20 +652,20 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.10",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.8",
- "lazy_static",
+ "crossbeam-utils 0.8.10",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
@@ -644,12 +682,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -771,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -791,6 +839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -835,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074093edfa907e8203c17c5111b04e114e03bde5ccdfa21a388fa4f34dabad96"
 dependencies = [
  "futures 0.3.21",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "thiserror",
  "tokio",
@@ -864,15 +922,15 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encode_unicode"
@@ -964,25 +1022,29 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.23"
+name = "fixedbitset"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -1142,25 +1204,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1187,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1213,15 +1264,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
 [[package]]
 name = "handlebars"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d113a9853e5accd30f43003560b5563ffbb007e3f325e8b103fa0d0029c6e6df"
+checksum = "36641a8b9deb60e23fb9bb47ac631d664a780b088909b89179a4eab5618b076b"
 dependencies = [
  "log",
  "pest",
@@ -1233,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "heck"
@@ -1284,13 +1335,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa",
 ]
 
 [[package]]
@@ -1324,9 +1375,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.18"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1337,7 +1388,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1357,6 +1408,18 @@ dependencies = [
  "rustls 0.20.6",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1409,7 +1472,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.10",
  "globset",
  "lazy_static",
  "log",
@@ -1423,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1459,10 +1522,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
-name = "itoa"
-version = "0.4.8"
+name = "itertools"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1481,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1506,7 +1572,7 @@ dependencies = [
  "hmac",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -1566,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.6"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
  "libc",
@@ -1578,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1657,9 +1723,9 @@ checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
 
 [[package]]
 name = "minicbor"
-version = "0.13.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124d887cb82f0b1469bdac3d1b65764a381eed1a54fdab0070e5772b13114521"
+checksum = "a5e575910763b21a0db7df5e142907fe944bff84d1dfc78e2ba92e7f3bdfd36b"
 
 [[package]]
 name = "minicbor-ser"
@@ -1673,18 +1739,18 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1693,26 +1759,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "nats"
-version = "0.18.1"
+name = "multimap"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603b57313fd7ff9ddf81b833923ee872264bec6426bff89b3c8c90c0de2267cb"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nats"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f42b51fc2560ec17f242ca715a3ece4e97704e6d798162b91f99c3cabef8980"
 dependencies = [
  "base64 0.13.0",
  "base64-url",
  "blocking",
  "crossbeam-channel",
  "fastrand",
- "itoa 0.4.8",
+ "itoa",
  "json",
  "lazy_static",
  "libc",
  "log",
  "memchr",
- "nkeys 0.1.0",
+ "nkeys",
  "nuid",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "regex",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
@@ -1721,65 +1793,10 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "time 0.3.9",
+ "time 0.3.11",
  "url 2.2.2",
  "webpki 0.21.4",
  "winapi",
-]
-
-[[package]]
-name = "nats-aflowt"
-version = "0.16.105"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5555762b3f169e3ea1d059de1cac345808036dce5c9a986613d5ae0b60b49d7c"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.0",
- "base64-url",
- "blocking",
- "fastrand",
- "futures 0.3.21",
- "itoa 1.0.2",
- "json",
- "lazy_static",
- "libc",
- "log",
- "memchr",
- "nkeys 0.2.0",
- "nuid",
- "once_cell",
- "parking_lot 0.12.0",
- "pin-project",
- "pin-utils",
- "regex",
- "rustls-native-certs 0.6.2",
- "rustls-pemfile 0.3.0",
- "serde",
- "serde_json",
- "serde_nanos",
- "serde_repr",
- "time 0.3.9",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "url 2.2.2",
- "webpki 0.22.0",
- "winapi",
-]
-
-[[package]]
-name = "nkeys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a98f0a974ff737974b57ba1c71d2e0fe7ec18e5a828d4b8e02683171349dfa"
-dependencies = [
- "byteorder",
- "data-encoding",
- "ed25519-dalek",
- "log",
- "rand 0.7.3",
- "signatory 0.21.0",
 ]
 
 [[package]]
@@ -1791,10 +1808,10 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "ed25519-dalek",
- "getrandom 0.2.6",
+ "getrandom",
  "log",
- "rand 0.8.5",
- "signatory 0.23.2",
+ "rand",
+ "signatory",
 ]
 
 [[package]]
@@ -1804,7 +1821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c1bb65186718d348306bf1afdeb20d9ab45b2ab80fb793c0fdcf59ffbb4f38"
 dependencies = [
  "lazy_static",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1853,18 +1870,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oci-distribution"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1c4c4929b9d4c5c332ae02c5893e570640a8320ae68b43c9b661e5e32b8088"
+checksum = "041f69213c79239ee261d70755c14902f26d9efb322b42f8b0cd4a315fde91fe"
 dependencies = [
  "futures-util",
  "hyperx",
@@ -1875,7 +1892,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "tokio",
  "tracing",
@@ -1897,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1921,15 +1938,70 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures 0.3.21",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "prost",
+ "prost-build",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1961,37 +2033,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2108,19 +2155,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.0.10"
+name = "petgraph"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2201,11 +2258,64 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2223,24 +2333,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
 ]
 
 [[package]]
@@ -2250,18 +2347,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2279,9 +2366,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -2289,16 +2373,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -2321,7 +2396,7 @@ checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.10",
  "num_cpus",
 ]
 
@@ -2340,16 +2415,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2367,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -2395,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -2417,13 +2492,14 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls 0.20.6",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.3",
+ "tower-service",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2579,12 +2655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,15 +2740,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -2694,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2705,11 +2775,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2741,18 +2811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b827f2113224f3f19a665136f006709194bdfdcb1fdc1e4b2b5cbac8e0cced54"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
- "rustversion",
  "serde",
  "serde_with_macros",
 ]
@@ -2771,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
@@ -2807,6 +2876,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,18 +2902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "signatory"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaebd4be561a7d8148803baa108092f85090189c4b8c3ffb81602b15b5c1771"
-dependencies = [
- "getrandom 0.1.16",
- "signature",
- "subtle-encoding",
- "zeroize",
 ]
 
 [[package]]
@@ -2862,9 +2930,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "snafu"
@@ -2963,25 +3031,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "subslice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3120,21 +3188,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "libc",
  "num_threads",
  "serde",
@@ -3157,17 +3226,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3186,10 +3256,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "1.7.0"
+name = "tokio-io-timeout"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3246,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3268,16 +3348,85 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -3288,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3299,11 +3448,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -3329,21 +3478,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.11"
+name = "tracing-opentelemetry"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3360,9 +3536,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicase"
@@ -3390,15 +3566,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -3457,17 +3633,16 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.6",
- "serde",
+ "getrandom",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "serde",
 ]
 
@@ -3540,7 +3715,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "log",
- "nkeys 0.2.0",
+ "nkeys",
  "nuid",
  "parity-wasm",
  "ring",
@@ -3551,14 +3726,15 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
+ "async-nats",
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
- "clap 3.1.18",
+ "clap 3.2.12",
  "cloudevents-sdk",
  "console",
  "crossbeam-channel",
@@ -3572,7 +3748,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "log",
- "nkeys 0.2.0",
+ "nkeys",
  "oci-distribution",
  "once_cell",
  "path-absolutize",
@@ -3588,7 +3764,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sha2",
+ "sha2 0.9.9",
  "tempfile",
  "term-table",
  "test-case",
@@ -3607,15 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3625,9 +3795,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3635,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3650,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3662,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3672,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3685,15 +3855,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasmbus-macros"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4546364f1055f1dd0bcff8f3de216df725e3ad8876a67c4aadbf731d9dfc14"
+checksum = "302b6c170bb936b14fdcc8dd8efd3023258865e093293c4edbb110bd94cdb276"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3703,36 +3873,42 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7eba98271f7d5945410ef60d074a1c37e37ccaf340540dc341300b9716a1c1"
+checksum = "7b9100d3016021468b0687561010f666679c1364e9367889b0b118827e46685e"
 dependencies = [
+ "anyhow",
+ "async-nats",
  "async-trait",
  "atty",
  "base64 0.13.0",
+ "bytes",
  "cfg-if 1.0.0",
  "data-encoding",
  "futures 0.3.21",
- "minicbor 0.13.2",
+ "lazy_static",
+ "minicbor 0.17.1",
  "minicbor-ser",
  "nats",
- "nats-aflowt",
- "nkeys 0.2.0",
+ "nkeys",
  "once_cell",
- "ring",
- "rmp-serde 0.15.5",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "rmp-serde 1.1.0",
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2 0.10.2",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tokio-timer",
  "toml",
  "tracing",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid 0.8.2",
+ "uuid 1.1.2",
  "wascap",
  "wasmbus-macros",
  "weld-codegen",
@@ -3740,22 +3916,23 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.14.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5640fa1e849a6105b1be790c38ab57b752327dd734185bd01b5ed3e3c2cd32"
+checksum = "9cb948e71c3990936c4052934f15995619f31c4e05df2d78f152521f501cad4f"
 dependencies = [
+ "async-nats",
  "async-trait",
  "cloudevents-sdk",
- "crossbeam-channel",
  "data-encoding",
  "futures 0.3.21",
- "log",
  "ring",
  "rmp-serde 1.1.0",
  "serde",
  "serde_json",
  "tokio",
- "uuid 1.1.0",
+ "tracing",
+ "tracing-futures",
+ "uuid 1.1.2",
  "wascap",
  "wasmbus-rpc",
  "wasmcloud-interface-lattice-control",
@@ -3763,15 +3940,14 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-lattice-control"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796274eabb968baafaedfd323ec4df048366064a3ea3dae0808e181efd057ddd"
+checksum = "efabb0277fca7ef91b340ec0a2de0b7208645747f91951000c3f8ecd89d27ce3"
 dependencies = [
  "async-trait",
  "data-encoding",
  "futures 0.3.21",
  "log",
- "ring",
  "rmp-serde 1.1.0",
  "serde",
  "wasmbus-rpc",
@@ -3780,12 +3956,13 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-testing"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb1a68056cf676059ef8e9b941291c6d0c9cf07b11586b2478a89692b133bdd"
+checksum = "099f02466c92a4609100d0ba55eb55b100d5eeca157a80b75c8bab26660546cc"
 dependencies = [
  "async-trait",
  "regex",
+ "rmp-serde 0.15.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3795,11 +3972,11 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeab150b058efd214868a73f1ffc4fb38222dc8ea47a70f2465d839a21299f0"
+version = "0.4.1"
+source = "git+https://github.com/wasmcloud/wasmcloud-test?branch=fix/async-nats-bug#4e9b0c902d5e5b80cd49073c59fb594d62e1fddb"
 dependencies = [
  "anyhow",
+ "async-nats",
  "async-trait",
  "base64 0.13.0",
  "futures 0.3.21",
@@ -3810,16 +3987,15 @@ dependencies = [
  "termcolor",
  "tokio",
  "toml",
- "wascap",
  "wasmbus-rpc",
  "wasmcloud-interface-testing",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3847,18 +4023,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "weld-codegen"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8864b569daa146f8b42ac540dfb956eb5c33f34fc527c78ddcbb93d6fe67c9"
+checksum = "e60907625a6f1a53c2b4b26b4bf381d2335ea1ae5bd2e82263034bdaddfe4638"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -3868,7 +4044,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if 1.0.0",
- "clap 3.1.18",
+ "clap 3.2.12",
  "directories",
  "downloader",
  "handlebars",
@@ -4009,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,8 @@ dependencies = [
 [[package]]
 name = "wasmcloud-test-util"
 version = "0.4.1"
-source = "git+https://github.com/wasmcloud/wasmcloud-test?branch=fix/async-nats-bug#4e9b0c902d5e5b80cd49073c59fb594d62e1fddb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd40034ec8efead88765601b57ae04430289a8ba2c1bb4d4208daea5a99a2337"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,7 @@ wascap = "0.8.0"
 weld-codegen = "0.4.6"
 wasmcloud-control-interface = "0.16.2"
 wasmbus-rpc = "0.9"
-# wasmcloud-test-util = "0.4.1"
-wasmcloud-test-util = { git = "https://github.com/wasmcloud/wasmcloud-test", branch = "fix/async-nats-bug" }
+wasmcloud-test-util = "0.4.1"
 
 [dev-dependencies]
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 walkdir = "2.3"
 which = "4.2.2"
-crossbeam-channel = "0.5.2"
 cloudevents-sdk = "0.4.0"
 
 wascap = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -15,6 +15,7 @@ maintenance = {status = "actively-developed"}
 
 [dependencies]
 anyhow = "1.0.51"
+async-nats = "0.17.0"
 atelier_core = "0.2"
 bytes = "1.0"
 cargo_atelier = "0.2"
@@ -52,15 +53,16 @@ thiserror = "1.0"
 tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 walkdir = "2.3"
-wascap = "0.8.0"
-wasmcloud-control-interface = "0.14.0"
-wasmbus-rpc = "0.8.5"
-
-wasmcloud-test-util = "0.3.3"
-weld-codegen = "0.4.5"
 which = "4.2.2"
 crossbeam-channel = "0.5.2"
 cloudevents-sdk = "0.4.0"
+
+wascap = "0.8.0"
+weld-codegen = "0.4.6"
+wasmcloud-control-interface = "0.16.2"
+wasmbus-rpc = "0.9"
+# wasmcloud-test-util = "0.4.1"
+wasmcloud-test-util = { git = "https://github.com/wasmcloud/wasmcloud-test", branch = "fix/async-nats-bug" }
 
 [dev-dependencies]
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls"]}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,10 +7,10 @@ use crate::{
     util::{CommandOutput, OutputKind, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT},
 };
 use anyhow::{bail, Result};
+use async_nats::Client;
 use clap::{Args, Subcommand};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use wasmbus_rpc::anats::Connection;
 
 mod output;
 
@@ -335,7 +335,7 @@ fn write_model(model: ModelDetails) -> Result<(PathBuf, PathBuf)> {
     Ok((raw_buf, json_buf))
 }
 
-async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Connection, Duration)> {
+async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Client, Duration)> {
     // Attempt to load a context, falling back on the default if not supplied
     let ctx = if let Some(context) = opts.context {
         load_context(&context).ok()
@@ -433,12 +433,17 @@ async fn raw_request(
     let (nc, timeout) = nats_client_from_opts(opts.clone()).await?;
     let topic = generate_topic(opts.lattice_prefix, elements);
 
-    let res = nc.request_timeout(&topic, req, timeout).await?;
-    let env: WadmEnvelope = serde_json::from_slice(&res.data)?;
-    if env.result == "success" {
-        Ok(env.data)
-    } else {
-        bail!("{}", env.message.unwrap_or_else(|| "".to_string()))
+    match tokio::time::timeout(timeout, nc.request(topic, req.to_vec().into())).await {
+        Ok(Ok(res)) => {
+            let env: WadmEnvelope = serde_json::from_slice(&res.payload)?;
+            if env.result == "success" {
+                Ok(env.data)
+            } else {
+                bail!("{}", env.message.unwrap_or_else(|| "".to_string()))
+            }
+        }
+        Ok(Err(e)) => bail!("Error making message request: {}", e),
+        Err(e) => bail!("Request timed out:  {}", e),
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -381,7 +381,7 @@ async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Client, Duration
         crate::util::nats_client_from_opts(&ctl_host, &ctl_port, ctl_jwt, ctl_seed, ctl_credsfile)
             .await?;
 
-    let timeout = Duration::from_millis(opts.ack_timeout_ms);
+    let timeout = Duration::from_millis(opts.timeout_ms);
 
     Ok((nc, timeout))
 }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -400,10 +400,6 @@ pub(crate) struct StopActorCommand {
     /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the actor to stp[].
     #[clap(long = "skip-wait")]
     skip_wait: bool,
-
-    /// Timeout to await the actor stop, defaults to 3000 milliseconds.
-    #[clap(long = "timeout-ms", default_value_t = 3000)]
-    timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -431,10 +427,6 @@ pub(crate) struct StopProviderCommand {
     /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the provider to stop.
     #[clap(long = "skip-wait")]
     skip_wait: bool,
-
-    /// Timeout to await the provider stop, defaults to 3000 milliseconds.
-    #[clap(long = "timeout-ms", default_value_t = 3000)]
-    timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -1262,7 +1254,6 @@ mod test {
                 actor_id,
                 count,
                 skip_wait,
-                timeout_ms,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
@@ -1272,7 +1263,6 @@ mod test {
                 assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(count, 2);
                 assert!(!skip_wait);
-                assert_eq!(timeout_ms, 3000);
             }
             cmd => panic!("ctl stop actor constructed incorrect command {:?}", cmd),
         }
@@ -1301,7 +1291,6 @@ mod test {
                 link_name,
                 contract_id,
                 skip_wait,
-                timeout_ms,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
@@ -1312,7 +1301,6 @@ mod test {
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
                 assert!(!skip_wait);
-                assert_eq!(timeout_ms, 3000);
             }
             cmd => panic!("ctl stop actor constructed incorrect command {:?}", cmd),
         }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     util::{
         convert_error, default_timeout_ms, labels_vec_to_hashmap, validate_contract_id,
         CommandOutput, OutputKind, DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT,
-        DEFAULT_NATS_TIMEOUT_MS, DEFAULT_START_PROVIDER_TIMEOUT_MS,
+        DEFAULT_NATS_TIMEOUT_MS, DEFAULT_START_ACTOR_TIMEOUT_MS, DEFAULT_START_PROVIDER_TIMEOUT_MS,
     },
 };
 use anyhow::{bail, Result};
@@ -36,7 +36,6 @@ mod wait;
 const ONE_ACTOR: u16 = 1;
 
 #[derive(Args, Debug, Clone)]
-//#[clap(PARENT_APP_ATTRIBUTE)]
 pub(crate) struct ConnectionOpts {
     /// CTL Host for connection, defaults to 127.0.0.1 for local nats
     #[clap(short = 'r', long = "ctl-host", env = "WASMCLOUD_CTL_HOST")]
@@ -66,11 +65,11 @@ pub(crate) struct ConnectionOpts {
     /// Timeout length to await a control interface response, defaults to 2000 milliseconds
     #[clap(
         short = 't',
-        long = "ack-timeout-ms",
+        long = "timeout-ms",
         default_value_t = default_timeout_ms(),
         env = "WASMCLOUD_CTL_TIMEOUT_MS"
     )]
-    pub(crate) ack_timeout_ms: u64,
+    pub(crate) timeout_ms: u64,
 
     /// Path to a context with values to use for CTL connection and authentication
     #[clap(long = "context")]
@@ -86,7 +85,7 @@ impl Default for ConnectionOpts {
             ctl_seed: None,
             ctl_credsfile: None,
             lattice_prefix: Some(DEFAULT_LATTICE_PREFIX.to_string()),
-            ack_timeout_ms: DEFAULT_NATS_TIMEOUT_MS,
+            timeout_ms: DEFAULT_NATS_TIMEOUT_MS,
             context: None,
         }
     }
@@ -339,12 +338,9 @@ pub(crate) struct StartActorCommand {
 
     /// By default, the command will wait until the actor has been started.
     /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the actor to start.
+    /// If this flag is omitted, the timeout will be adjusted to 5 seconds to account for actor download times
     #[clap(long = "skip-wait")]
     skip_wait: bool,
-
-    /// Timeout to await an actor start, defaults to 3000 milliseconds.
-    #[clap(long = "timeout-ms", default_value_t = 3000)]
-    timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -378,12 +374,9 @@ pub(crate) struct StartProviderCommand {
 
     /// By default, the command will wait until the provider has been started.
     /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the provider to start.
+    /// If this flag is omitted, the timeout will be adjusted to 30 seconds to account for provider download times
     #[clap(long = "skip-wait")]
     skip_wait: bool,
-
-    /// Timeout to await the provider start, defaults to 15000 milliseconds.
-    #[clap(long = "timeout-ms", default_value_t = 15000)]
-    timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -661,11 +654,13 @@ pub(crate) async fn link_query(cmd: LinkQueryCommand) -> Result<LinkDefinitionLi
     client.query_links().await.map_err(convert_error)
 }
 
-pub(crate) async fn start_actor(mut cmd: StartActorCommand) -> Result<CommandOutput> {
+pub(crate) async fn start_actor(cmd: StartActorCommand) -> Result<CommandOutput> {
     // If timeout isn't supplied, override with a longer timeout for starting actor
-    if cmd.opts.ack_timeout_ms == DEFAULT_NATS_TIMEOUT_MS {
-        cmd.opts.ack_timeout_ms = DEFAULT_START_PROVIDER_TIMEOUT_MS;
-    }
+    let timeout_ms = if cmd.opts.timeout_ms == DEFAULT_NATS_TIMEOUT_MS {
+        DEFAULT_START_ACTOR_TIMEOUT_MS
+    } else {
+        cmd.opts.timeout_ms
+    };
     let client = ctl_client_from_opts(cmd.opts, Some(cmd.auction_timeout_ms)).await?;
 
     let host = match cmd.host_id {
@@ -709,7 +704,7 @@ pub(crate) async fn start_actor(mut cmd: StartActorCommand) -> Result<CommandOut
 
     let event = wait_for_actor_start_event(
         &mut receiver,
-        Duration::from_millis(cmd.timeout_ms),
+        Duration::from_millis(timeout_ms),
         host.to_string(),
         cmd.actor_ref.clone(),
     )
@@ -724,12 +719,13 @@ pub(crate) async fn start_actor(mut cmd: StartActorCommand) -> Result<CommandOut
     }
 }
 
-pub(crate) async fn start_provider(mut cmd: StartProviderCommand) -> Result<CommandOutput> {
+pub(crate) async fn start_provider(cmd: StartProviderCommand) -> Result<CommandOutput> {
     // If timeout isn't supplied, override with a longer timeout for starting provider
-    if cmd.opts.ack_timeout_ms == DEFAULT_NATS_TIMEOUT_MS {
-        cmd.opts.ack_timeout_ms = DEFAULT_START_PROVIDER_TIMEOUT_MS;
-    }
-    // OCI downloads and response
+    let timeout_ms = if cmd.opts.timeout_ms == DEFAULT_NATS_TIMEOUT_MS {
+        DEFAULT_START_PROVIDER_TIMEOUT_MS
+    } else {
+        cmd.opts.timeout_ms
+    };
     let client = ctl_client_from_opts(cmd.opts, Some(cmd.auction_timeout_ms)).await?;
 
     let host = match cmd.host_id {
@@ -793,7 +789,7 @@ pub(crate) async fn start_provider(mut cmd: StartProviderCommand) -> Result<Comm
 
     let event = wait_for_provider_start_event(
         &mut receiver,
-        Duration::from_millis(cmd.timeout_ms),
+        Duration::from_millis(timeout_ms),
         host.to_string(),
         cmd.provider_ref.clone(),
     )
@@ -841,6 +837,7 @@ pub(crate) async fn scale_actor(cmd: ScaleActorCommand) -> Result<CommandOutput>
 
 pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
     validate_contract_id(&cmd.contract_id)?;
+    let timeout_ms = cmd.opts.timeout_ms;
     let client = ctl_client_from_opts(cmd.opts, None).await?;
 
     let mut receiver = client.events_receiver().await.map_err(convert_error)?;
@@ -868,7 +865,7 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOut
 
     let event = wait_for_provider_stop_event(
         &mut receiver,
-        Duration::from_millis(cmd.timeout_ms),
+        Duration::from_millis(timeout_ms),
         cmd.host_id.to_string(),
         cmd.provider_id.to_string(),
     )
@@ -884,6 +881,7 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOut
 }
 
 pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
+    let timeout_ms = cmd.opts.timeout_ms;
     let client = ctl_client_from_opts(cmd.opts, None).await?;
 
     let mut receiver = client.events_receiver().await.map_err(convert_error)?;
@@ -911,7 +909,7 @@ pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
 
     let event = wait_for_actor_stop_event(
         &mut receiver,
-        Duration::from_millis(cmd.timeout_ms),
+        Duration::from_millis(timeout_ms),
         cmd.host_id.to_string(),
         cmd.actor_id.to_string(),
     )
@@ -1114,7 +1112,7 @@ async fn ctl_client_from_opts(
             .map(|c| c.ctl_credsfile.clone())
             .unwrap_or_default()
     };
-    let auction_timeout_ms = auction_timeout_ms.unwrap_or(DEFAULT_NATS_TIMEOUT_MS);
+    let auction_timeout_ms = auction_timeout_ms.unwrap_or(opts.timeout_ms);
 
     let nc =
         crate::util::nats_client_from_opts(&ctl_host, &ctl_port, ctl_jwt, ctl_seed, ctl_credsfile)
@@ -1122,7 +1120,7 @@ async fn ctl_client_from_opts(
     let ctl_client = CtlClient::new(
         nc,
         Some(lattice_prefix),
-        Duration::from_millis(opts.ack_timeout_ms),
+        Duration::from_millis(opts.timeout_ms),
         Duration::from_millis(auction_timeout_ms),
     );
 
@@ -1180,13 +1178,11 @@ mod test {
                 actor_ref,
                 constraints,
                 auction_timeout_ms,
-                timeout_ms,
                 ..
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(timeout_ms, 2001);
                 assert_eq!(auction_timeout_ms, 2002);
                 assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v1".to_string());
@@ -1204,7 +1200,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             "--auction-timeout-ms",
             "2002",
@@ -1227,12 +1223,11 @@ mod test {
                 auction_timeout_ms,
                 config_json,
                 skip_wait,
-                timeout_ms,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(config_json, None);
                 assert_eq!(auction_timeout_ms, 2002);
                 assert_eq!(link_name, "default".to_string());
@@ -1240,7 +1235,6 @@ mod test {
                 assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
                 assert_eq!(provider_ref, "wasmcloud.azurecr.io/provider:v1".to_string());
                 assert!(skip_wait);
-                assert_eq!(timeout_ms, 15000);
             }
             cmd => panic!("ctl start provider constructed incorrect command {:?}", cmd),
         }
@@ -1254,7 +1248,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             "--count",
             "2",
@@ -1273,7 +1267,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID.parse()?);
                 assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(count, 2);
@@ -1292,7 +1286,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             HOST_ID,
             PROVIDER_ID,
@@ -1312,7 +1306,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID.parse()?);
                 assert_eq!(provider_id, PROVIDER_ID.parse()?);
                 assert_eq!(link_name, "default".to_string());
@@ -1332,7 +1326,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
         ])?;
         match get_hosts_all.command {
@@ -1340,7 +1334,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
             }
             cmd => panic!("ctl get hosts constructed incorrect command {:?}", cmd),
         }
@@ -1354,7 +1348,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             HOST_ID,
         ])?;
@@ -1366,7 +1360,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID.parse()?);
             }
             cmd => panic!("ctl get inventory constructed incorrect command {:?}", cmd),
@@ -1381,7 +1375,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
         ])?;
         match get_claims_all.command {
@@ -1389,7 +1383,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
             }
             cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),
         }
@@ -1403,7 +1397,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             "--link-name",
             "default",
@@ -1424,7 +1418,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(provider_id, PROVIDER_ID.parse()?);
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
@@ -1443,7 +1437,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             HOST_ID,
             ACTOR_ID,
@@ -1459,7 +1453,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID.parse()?);
                 assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(new_actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());
@@ -1477,7 +1471,7 @@ mod test {
             CTL_HOST,
             "--ctl-port",
             CTL_PORT,
-            "--ack-timeout-ms",
+            "--timeout-ms",
             "2001",
             HOST_ID,
             ACTOR_ID,
@@ -1500,7 +1494,7 @@ mod test {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
-                assert_eq!(opts.ack_timeout_ms, 2001);
+                assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID.parse()?);
                 assert_eq!(actor_id, ACTOR_ID.parse()?);
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -686,7 +686,7 @@ pub(crate) async fn start_actor(mut cmd: StartActorCommand) -> Result<CommandOut
         }
     };
 
-    let receiver = client.events_receiver().await.map_err(convert_error)?;
+    let mut receiver = client.events_receiver().await.map_err(convert_error)?;
 
     let ack = client
         .start_actor(&host.to_string(), &cmd.actor_ref, cmd.count, None)
@@ -708,11 +708,12 @@ pub(crate) async fn start_actor(mut cmd: StartActorCommand) -> Result<CommandOut
     }
 
     let event = wait_for_actor_start_event(
-        &receiver,
+        &mut receiver,
         Duration::from_millis(cmd.timeout_ms),
         host.to_string(),
         cmd.actor_ref.clone(),
-    )?;
+    )
+    .await?;
 
     match event {
         FindEventOutcome::Success(_) => Ok(CommandOutput::from_key_and_text(
@@ -766,7 +767,7 @@ pub(crate) async fn start_provider(mut cmd: StartProviderCommand) -> Result<Comm
         None
     };
 
-    let receiver = client.events_receiver().await.map_err(convert_error)?;
+    let mut receiver = client.events_receiver().await.map_err(convert_error)?;
 
     let ack = client
         .start_provider(
@@ -791,11 +792,12 @@ pub(crate) async fn start_provider(mut cmd: StartProviderCommand) -> Result<Comm
     }
 
     let event = wait_for_provider_start_event(
-        &receiver,
+        &mut receiver,
         Duration::from_millis(cmd.timeout_ms),
         host.to_string(),
         cmd.provider_ref.clone(),
-    )?;
+    )
+    .await?;
 
     match event {
         FindEventOutcome::Success(_) => Ok(CommandOutput::from_key_and_text(
@@ -841,7 +843,7 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOut
     validate_contract_id(&cmd.contract_id)?;
     let client = ctl_client_from_opts(cmd.opts, None).await?;
 
-    let receiver = client.events_receiver().await.map_err(convert_error)?;
+    let mut receiver = client.events_receiver().await.map_err(convert_error)?;
 
     let ack = client
         .stop_provider(
@@ -865,11 +867,12 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOut
     }
 
     let event = wait_for_provider_stop_event(
-        &receiver,
+        &mut receiver,
         Duration::from_millis(cmd.timeout_ms),
         cmd.host_id.to_string(),
         cmd.provider_id.to_string(),
-    )?;
+    )
+    .await?;
 
     match event {
         FindEventOutcome::Success(_) => Ok(CommandOutput::from_key_and_text(
@@ -883,7 +886,7 @@ pub(crate) async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOut
 pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
     let client = ctl_client_from_opts(cmd.opts, None).await?;
 
-    let receiver = client.events_receiver().await.map_err(convert_error)?;
+    let mut receiver = client.events_receiver().await.map_err(convert_error)?;
 
     let ack = client
         .stop_actor(
@@ -907,11 +910,12 @@ pub(crate) async fn stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
     }
 
     let event = wait_for_actor_stop_event(
-        &receiver,
+        &mut receiver,
         Duration::from_millis(cmd.timeout_ms),
         cmd.host_id.to_string(),
         cmd.actor_id.to_string(),
-    )?;
+    )
+    .await?;
 
     match event {
         FindEventOutcome::Success(_) => Ok(CommandOutput::from_key_and_text(

--- a/src/ctl/wait.rs
+++ b/src/ctl/wait.rs
@@ -37,16 +37,18 @@ async fn find_event<T>(
                     EventCheckOutcome::NotApplicable => continue,
                 }
             }
-            Ok(None) => {
-                return Ok(FindEventOutcome::Failure(anyhow!(
-                    "Channel dropped before event was received"
-                )))
-            }
             Err(_e) => {
                 return Ok(FindEventOutcome::Failure(anyhow!(
-                    "Timed out waiting for event"
+                    "Timed out waiting for applicable event, operation may have failed"
                 )))
             }
+            // Should only happen due to an internal failure with the events receiver
+            Ok(None) => {
+                return Ok(FindEventOutcome::Failure(anyhow!(
+                    "Channel dropped before event was received, please report this at https://github.com/wasmCloud/wash/issues with details to reproduce"
+                )))
+            }
+
         }
     }
 }

--- a/src/ctl/wait.rs
+++ b/src/ctl/wait.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use cloudevents::{event::Event, AttributesReader};
-use crossbeam_channel::Receiver;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc::Receiver;
 
 /// Uses the NATS reciever to read events being published to the wasmCloud lattice event subject, up until the given timeout duration.
 ///
@@ -13,8 +13,8 @@ use std::time::{Duration, Instant};
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
 ///
 /// You can use the generics in `EventCheckOutcome` and `FindEventOutcome` to return any data from the event out of your `check_function`.
-fn find_event<T>(
-    receiver: &Receiver<Event>,
+async fn find_event<T>(
+    receiver: &mut Receiver<Event>,
     timeout: Duration,
     check_function: impl Fn(Event) -> Result<EventCheckOutcome<T>>,
 ) -> Result<FindEventOutcome<T>> {
@@ -25,16 +25,28 @@ fn find_event<T>(
             bail!("Timeout waiting for event");
         }
 
-        let event = receiver.recv_timeout(timeout - elapsed)?;
+        match tokio::time::timeout(timeout - elapsed, receiver.recv()).await {
+            Ok(Some(event)) => {
+                let outcome = check_function(event)?;
 
-        let outcome = check_function(event)?;
-
-        match outcome {
-            EventCheckOutcome::Success(success_data) => {
-                return Ok(FindEventOutcome::Success(success_data))
+                match outcome {
+                    EventCheckOutcome::Success(success_data) => {
+                        return Ok(FindEventOutcome::Success(success_data))
+                    }
+                    EventCheckOutcome::Failure(e) => return Ok(FindEventOutcome::Failure(e)),
+                    EventCheckOutcome::NotApplicable => continue,
+                }
             }
-            EventCheckOutcome::Failure(e) => return Ok(FindEventOutcome::Failure(e)),
-            EventCheckOutcome::NotApplicable => continue,
+            Ok(None) => {
+                return Ok(FindEventOutcome::Failure(anyhow!(
+                    "Channel dropped before event was received"
+                )))
+            }
+            Err(_e) => {
+                return Ok(FindEventOutcome::Failure(anyhow!(
+                    "Timed out waiting for event"
+                )))
+            }
         }
     }
 }
@@ -61,8 +73,8 @@ enum EventCheckOutcome<T> {
 /// with the `FindEventOutcome` enum containing the success or failure state of the event.
 ///
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
-pub(crate) fn wait_for_actor_start_event(
-    receiver: &Receiver<Event>,
+pub(crate) async fn wait_for_actor_start_event(
+    receiver: &mut Receiver<Event>,
     timeout: Duration,
     host_id: String,
     actor_ref: String,
@@ -105,7 +117,7 @@ pub(crate) fn wait_for_actor_start_event(
         Ok(EventCheckOutcome::NotApplicable)
     };
 
-    let event = find_event(receiver, timeout, check_function)?;
+    let event = find_event(receiver, timeout, check_function).await?;
     Ok(event)
 }
 
@@ -115,8 +127,8 @@ pub(crate) fn wait_for_actor_start_event(
 /// with the `FindEventOutcome` enum containing the success or failure state of the event.
 ///
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
-pub fn wait_for_provider_start_event(
-    receiver: &Receiver<Event>,
+pub async fn wait_for_provider_start_event(
+    receiver: &mut Receiver<Event>,
     timeout: Duration,
     host_id: String,
     provider_ref: String,
@@ -160,7 +172,7 @@ pub fn wait_for_provider_start_event(
         Ok(EventCheckOutcome::NotApplicable)
     };
 
-    let event = find_event(receiver, timeout, check_function)?;
+    let event = find_event(receiver, timeout, check_function).await?;
     Ok(event)
 }
 
@@ -170,8 +182,8 @@ pub fn wait_for_provider_start_event(
 /// with the `FindEventOutcome` enum containing the success or failure state of the event.
 ///
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
-pub fn wait_for_provider_stop_event(
-    receiver: &Receiver<Event>,
+pub async fn wait_for_provider_stop_event(
+    receiver: &mut Receiver<Event>,
     timeout: Duration,
     host_id: String,
     provider_id: String,
@@ -216,7 +228,7 @@ pub fn wait_for_provider_stop_event(
         Ok(EventCheckOutcome::NotApplicable)
     };
 
-    let event = find_event(receiver, timeout, check_function)?;
+    let event = find_event(receiver, timeout, check_function).await?;
     Ok(event)
 }
 
@@ -226,8 +238,8 @@ pub fn wait_for_provider_stop_event(
 /// with the `FindEventOutcome` enum containing the success or failure state of the event.
 ///
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
-pub fn wait_for_actor_stop_event(
-    receiver: &Receiver<Event>,
+pub async fn wait_for_actor_stop_event(
+    receiver: &mut Receiver<Event>,
     timeout: Duration,
     host_id: String,
     actor_id: String,
@@ -270,7 +282,7 @@ pub fn wait_for_actor_stop_event(
         Ok(EventCheckOutcome::NotApplicable)
     };
 
-    let event = find_event(receiver, timeout, check_function)?;
+    let event = find_event(receiver, timeout, check_function).await?;
     Ok(event)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -246,7 +246,8 @@ pub(crate) async fn nats_client_from_opts(
         .connect("localhost")
         .await?
     } else if let Some(credsfile_path) = credsfile {
-        ConnectOptions::with_credentials(&credsfile_path.to_string_lossy())?
+        ConnectOptions::with_credentials_file(credsfile_path)
+            .await?
             .connect(&nats_url)
             .await?
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -244,7 +244,7 @@ pub(crate) async fn nats_client_from_opts(
             let key_pair = kp.clone();
             async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
         })
-        .connect("localhost")
+        .connect(&nats_url)
         .await?
     } else if let Some(credsfile_path) = credsfile {
         ConnectOptions::with_credentials_file(credsfile_path)

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_LATTICE_PREFIX: &str = "default";
 pub const DEFAULT_NATS_TIMEOUT_MS: u64 = 2_000;
+pub const DEFAULT_START_ACTOR_TIMEOUT_MS: u64 = 5_000;
 pub const DEFAULT_START_PROVIDER_TIMEOUT_MS: u64 = 60_000;
 
 /// Used for displaying human-readable output vs JSON format

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,6 @@ use std::{
     str::FromStr,
 };
 use term_table::{Table, TableStyle};
-use wasmbus_rpc::anats;
 
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
@@ -227,35 +226,31 @@ pub(crate) async fn nats_client_from_opts(
     jwt: Option<String>,
     seed: Option<String>,
     credsfile: Option<PathBuf>,
-) -> Result<anats::Connection> {
+) -> Result<async_nats::Client> {
     let nats_url = format!("{}:{}", host, port);
+    use async_nats::ConnectOptions;
 
     let nc = if let Some(jwt_file) = jwt {
         let jwt_contents = extract_arg_value(&jwt_file)?;
-        let kp = if let Some(seed) = seed {
+        let kp = std::sync::Arc::new(if let Some(seed) = seed {
             nkeys::KeyPair::from_seed(&extract_arg_value(&seed)?)?
         } else {
             nkeys::KeyPair::new_user()
-        };
+        });
 
         // You must provide the JWT via a closure
-        anats::Options::with_jwt(
-            move || Ok(jwt_contents.clone()),
-            move |nonce| kp.sign(nonce).unwrap(),
-        )
-        .connect(&nats_url)
+        async_nats::ConnectOptions::with_jwt(jwt_contents, move |nonce| {
+            let key_pair = kp.clone();
+            async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+        })
+        .connect("localhost")
         .await?
-    } else if let Some(seed) = seed {
-        let kp = nkeys::KeyPair::from_seed(&extract_arg_value(&seed)?)?;
-        anats::Options::with_nkey(&kp.public_key(), move |nonce| kp.sign(nonce).unwrap())
-            .connect(&nats_url)
-            .await?
     } else if let Some(credsfile_path) = credsfile {
-        anats::Options::with_credentials(credsfile_path)
+        ConnectOptions::with_credentials(&credsfile_path.to_string_lossy())?
             .connect(&nats_url)
             .await?
     } else {
-        anats::connect(&nats_url).await?
+        async_nats::connect(&nats_url).await?
     };
     Ok(nc)
 }


### PR DESCRIPTION
This PR fixes #283 
I ran a `ctl get hosts` 1000 times and could not reproduce #284, so I'm saying this fixes #284 since I could reproduce it consistently (@connorsmith256 would be curious if you can give this a try too)

This is a breaking change because:
- It removes the ability to authenticate with a NATS server with only an nkey seed
- I removed the `--ack-timeout-ms` flag in favor of a ubiquitous `--timeout-ms` for the control interface.
  - In the case where you don't provide a different timeout for starting actors/providers, I automatically increase the timeout if you don't add `--skip-wait` to avoid automatically "failing" to start a provider if it's your first download
  
This PR also fixes a bug where the default auction timeout was used for `wash ctl get hosts`, ignoring the specified timeout.