### PR TITLE
Removed prerelease from github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
-          prerelease: true
+          prerelease: false
 
   crates:
     needs: release


### PR DESCRIPTION
Fixes #286 

This just enables our releases to show in the github sidebar