### PR TITLE
chore(*): Update codeowners with the correct users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # wasmcloud team members
-* @autodidaddict @brooksmtownsend @thomastaylor312 @stevelr
+* @autodidaddict @brooksmtownsend @thomastaylor312 @mattwilkinsonn
 
 # wasmcloud devops
-/.github/actions/ @brooksmtownsend
+/.github/actions/ @brooksmtownsend @thomastaylor312


### PR DESCRIPTION
This brings code owners in line with the current maintainer list of @wasmCloud/wash-maintainers 