### PR TITLE
Update wash-lib with minimum version requirement and mix releases

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -20,11 +20,16 @@ jobs:
   unit_tests:
     name: Unit Tests
     strategy:
+      fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      # Ensure the host can find the C++ toolchain when running on Windows
+      - name: Set up Visual Studio C++ toolchain for Windows
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startswith(matrix.os, 'windows') }}
       - name: Run unit tests
         run: make test
   integration_tests:

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -26,10 +26,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      # Ensure the host can find the C++ toolchain when running on Windows
-      - name: Set up Visual Studio C++ toolchain for Windows
-        uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ startswith(matrix.os, 'windows') }}
       - name: Run unit tests
         run: make test
   integration_tests:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ docker-compose.yml
 *.gz
 flake.lock
 .vscode
+
+# Host config files
+host_config.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,7 @@ dependencies = [
  "futures 0.3.23",
  "log",
  "reqwest",
+ "semver",
  "tokio",
  "tokio-stream",
  "tokio-tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.12.0-alpha.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.12.0-alpha.2"
+version = "0.12.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -58,7 +58,7 @@ toml = "0.5"
 walkdir = "2.3"
 which = "4.2.2"
 
-wash-lib = { version = "0.1.0", path = "./crates/wash-lib" }
+wash-lib = { version = "0.2.0", path = "./crates/wash-lib" }
 wascap = "0.8.0"
 weld-codegen = "0.4.6"
 wasmcloud-control-interface = "0.17.0"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3"
 tokio = {version = "1", default-features = false, features = ["process"]}
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"]}
 async-compression = { version = "0.3", default-features = false, features = ["tokio", "gzip"] }
+semver = "1.0.13"
 tokio-tar = "0.3"
 tokio-stream = "0.1"
 log = "0.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -31,7 +31,7 @@
 //!     ).await?;
 //!     
 //!     // Download wasmCloud if not already installed
-//!     let wasmcloud_executable = ensure_wasmcloud("v0.55.1", &install_dir).await?;
+//!     let wasmcloud_executable = ensure_wasmcloud("v0.57.0", &install_dir).await?;
 //!     
 //!     // Redirect output (which is on stderr) to a log file
 //!     let log_path = install_dir.join("wasmcloud_stderr.log");

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -31,7 +31,7 @@
 //!     ).await?;
 //!     
 //!     // Download wasmCloud if not already installed
-//!     let wasmcloud_executable = ensure_wasmcloud("v0.57.0", &install_dir).await?;
+//!     let wasmcloud_executable = ensure_wasmcloud("v0.57.1", &install_dir).await?;
 //!     
 //!     // Redirect output (which is on stderr) to a log file
 //!     let log_path = install_dir.join("wasmcloud_stderr.log");

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -21,7 +21,7 @@ pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin/wasmcloud_host";
 #[cfg(target_family = "windows")]
 pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
 
-// Any version of wasmCloud under 0.57.0 uses distillery releases and are incompatible
+// Any version of wasmCloud under 0.57.0 uses distillery releases and is incompatible
 const MINIMUM_WASMCLOUD_VERSION: &str = "v0.57.0";
 
 /// A wrapper around the [ensure_wasmcloud_for_os_arch_pair] function that uses the
@@ -243,38 +243,17 @@ where
         ));
     }
 
-    // Windows powershell will ping forever if it's the first command,
-    // this is essentially an initialization
-    //TODO: Mix release version of this
-    // #[cfg(target_family = "windows")]
-    // {
-    //     let tmp_log = std::env::temp_dir().join("init.log");
-    //     let init_run = tokio::fs::File::create(&tmp_log).await?.into_std().await;
-    //     let mut child = tokio::process::Command::new(bin_path.as_ref())
-    //         .stdout(init_run)
-    //         .arg("ping")
-    //         .spawn()?;
-    //     // Give the wasmcloud initialization a few seconds to unpack
-    //     for _ in 0..5 {
-    //         let log_contents = tokio::fs::read_to_string(&tmp_log).await?;
-    //         if log_contents.is_empty() {
-    //             // Give just a little bit of time for the startup logs to flow in
-    //             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    //         } else {
-    //             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    //             break;
-    //         }
-    //     }
-    //     let _ = child.kill();
-    // }
-
     match Command::new(bin_path.as_ref()).arg("pid").output().await {
         // If ping was successful, returning "pong", another host is already running
-        Ok(output) if output.status.success() => {
-            return Err(anyhow!(
-                "Another wasmCloud host is already running on this machine with PID {}",
-                String::from_utf8_lossy(&output.stdout)
-            ));
+        Ok(output) => {
+            // Stderr will include :nodedown if no other host is running, otherwise
+            // stdout will contain the PID
+            if !String::from_utf8_lossy(&output.stderr).contains(":nodedown") {
+                return Err(anyhow!(
+                    "Another wasmCloud host is already running on this machine with PID {}",
+                    String::from_utf8_lossy(&output.stdout)
+                ));
+            }
         }
         _ => (),
     }

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -472,19 +472,23 @@ mod test {
         assert!(child_res.is_err());
 
         // Should fail because another erlang wasmcloud_host node is running
-        let mut host_env = HashMap::new();
-        host_env.insert("PORT".to_string(), "4002".to_string());
-        host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
-        let child_res = start_wasmcloud_host(
-            &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
-            std::process::Stdio::null(),
-            std::process::Stdio::null(),
-            host_env,
-        )
-        .await;
-        assert!(child_res.is_err());
+        #[cfg(target_family = "unix")]
+        // Windows is unable to properly check running erlang nodes with `pid`
+        {
+            let mut host_env = HashMap::new();
+            host_env.insert("PORT".to_string(), "4002".to_string());
+            host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
+            host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
+            host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
+            let child_res = start_wasmcloud_host(
+                &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
+                std::process::Stdio::null(),
+                std::process::Stdio::null(),
+                host_env,
+            )
+            .await;
+            assert!(child_res.is_err());
+        }
 
         host_child.unwrap().kill().await?;
         nats_child.unwrap().kill().await?;

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -233,18 +233,18 @@ where
         .get("PORT")
         .cloned()
         .unwrap_or_else(|| "4000".to_string());
-    if tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+    if tokio::net::TcpStream::connect(format!("localhost:{}", port))
         .await
         .is_ok()
     {
         return Err(anyhow!(
-            "Could not start wasmCloud, a process is already listening on 127.0.0.1:{}",
+            "Could not start wasmCloud, a process is already listening on localhost:{}",
             port
         ));
     }
 
+    #[cfg(target_family = "unix")]
     match Command::new(bin_path.as_ref()).arg("pid").output().await {
-        // If ping was successful, returning "pong", another host is already running
         Ok(output) => {
             // Stderr will include :nodedown if no other host is running, otherwise
             // stdout will contain the PID
@@ -418,6 +418,7 @@ mod test {
             host_env,
         )
         .await;
+        println!("child: {:?}", host_child);
         assert!(host_child.is_ok());
 
         // Give wasmCloud max 15 seconds to start up

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -22,7 +22,7 @@ pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin/wasmcloud_host";
 pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
 
 // Any version of wasmCloud under 0.57.0 uses distillery releases and is incompatible
-const MINIMUM_WASMCLOUD_VERSION: &str = "v0.57.0";
+const MINIMUM_WASMCLOUD_VERSION: &str = "0.57.0";
 
 /// A wrapper around the [ensure_wasmcloud_for_os_arch_pair] function that uses the
 /// architecture and operating system of the current host machine.
@@ -308,14 +308,20 @@ fn wasmcloud_url(os: &str, arch: &str, version: &str) -> String {
 /// Helper function to ensure the version of wasmCloud is above the minimum
 /// supported version (v0.57.0) that runs mix releases
 fn check_version(version: &str) -> Result<()> {
-    if version < MINIMUM_WASMCLOUD_VERSION {
-        Err(anyhow!(
-            "wasmCloud version {} is earlier than the minimum supported version of {}",
+    let version_req = semver::VersionReq::parse(&format!(">={}", MINIMUM_WASMCLOUD_VERSION))?;
+    match semver::Version::parse(version.trim_start_matches('v')) {
+        Ok(parsed_version) if !version_req.matches(&parsed_version) => Err(anyhow!(
+            "wasmCloud version {} is earlier than the minimum supported version of v{}",
             version,
             MINIMUM_WASMCLOUD_VERSION
-        ))
-    } else {
-        Ok(())
+        )),
+        Ok(_ver) => Ok(()),
+        Err(_parse_err) => {
+            log::warn!(
+                "Failed to parse wasmCloud version as a semantic version, download may fail"
+            );
+            Ok(())
+        }
     }
 }
 #[cfg(test)]
@@ -431,6 +437,7 @@ mod test {
                 // Give just a little bit of time for the startup logs to flow in, re-read logs
                 tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
                 let log_contents = tokio::fs::read_to_string(&stderr_log_path).await?;
+                println!("log contents: {:?}", log_contents);
                 assert!(log_contents
                     .contains("Connecting to control interface NATS without authentication"));
                 assert!(
@@ -484,6 +491,8 @@ mod test {
         assert!(check_version("v0.57.1").is_ok());
         assert!(check_version("v0.57.2").is_ok());
         assert!(check_version("v0.58.0").is_ok());
+        assert!(check_version("v0.100.0").is_ok());
+        assert!(check_version("v0.203.0").is_ok());
 
         // Ensure we deny versions < 0.57.0
         assert!(check_version("v0.48.0").is_err());
@@ -495,6 +504,10 @@ mod test {
         } else {
             panic!("v0.56.0 should be before the minimum version")
         }
+
+        // The check_version will allow bad semantic versions, rather than failing immediately
+        assert!(check_version("ungabunga").is_ok());
+        assert!(check_version("v11.1").is_ok());
 
         Ok(())
     }

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -391,8 +391,6 @@ mod test {
         create_dir_all(&install_dir).await?;
         assert!(!is_wasmcloud_installed(&install_dir).await);
 
-        println!("Install dir: {:?}", install_dir);
-
         // Install and start NATS server for this test
         let nats_port = 10004;
         assert!(ensure_nats_server(NATS_SERVER_VERSION, &install_dir)
@@ -433,7 +431,6 @@ mod test {
             host_env,
         )
         .await;
-        println!("child: {:?}", host_child);
         assert!(host_child.is_ok());
 
         // Give wasmCloud max 15 seconds to start up
@@ -446,7 +443,6 @@ mod test {
                 // Give just a little bit of time for the startup logs to flow in, re-read logs
                 tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
                 let log_contents = tokio::fs::read_to_string(&stderr_log_path).await?;
-                println!("log contents: {:?}", log_contents);
                 assert!(log_contents
                     .contains("Connecting to control interface NATS without authentication"));
                 assert!(

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -21,12 +21,15 @@ pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin/wasmcloud_host";
 #[cfg(target_family = "windows")]
 pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
 
+// Any version of wasmCloud under 0.57.0 uses distillery releases and are incompatible
+const MINIMUM_WASMCLOUD_VERSION: &str = "v0.57.0";
+
 /// A wrapper around the [ensure_wasmcloud_for_os_arch_pair] function that uses the
 /// architecture and operating system of the current host machine.
 ///
 /// # Arguments
 ///
-/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`. Must be at least v0.57.0.
 /// * `dir` - Where to unpack the wasmCloud host contents into
 /// # Examples
 ///
@@ -34,7 +37,7 @@ pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::ensure_wasmcloud;
-/// let res = ensure_wasmcloud("v0.55.1", "/tmp/wasmcloud/").await;
+/// let res = ensure_wasmcloud("v0.57.0", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -55,7 +58,7 @@ where
 ///
 /// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
 /// * `arch` - Specifies the architecture of the binary to download, e.g. `amd64`
-/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`. Must be at least v0.57.0.
 /// * `dir` - Where to unpack the wasmCloud host contents into
 /// # Examples
 ///
@@ -65,7 +68,7 @@ where
 /// use wash_lib::start::ensure_wasmcloud_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = ensure_wasmcloud_for_os_arch_pair(os, arch, "v0.55.1", "/tmp/wasmcloud/").await;
+/// let res = ensure_wasmcloud_for_os_arch_pair(os, arch, "v0.57.0", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -79,6 +82,7 @@ pub async fn ensure_wasmcloud_for_os_arch_pair<P>(
 where
     P: AsRef<Path>,
 {
+    check_version(version)?;
     if is_wasmcloud_installed(&dir).await {
         // wasmCloud already exists, return early
         return Ok(dir.as_ref().join(WASMCLOUD_HOST_BIN));
@@ -100,7 +104,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::download_wasmcloud;
-/// let res = download_wasmcloud("v0.55.1", "/tmp/wasmcloud/").await;
+/// let res = download_wasmcloud("v0.57.0", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -130,7 +134,7 @@ where
 /// use wash_lib::start::download_wasmcloud_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = download_wasmcloud_for_os_arch_pair(os, arch, "v0.55.1", "/tmp/wasmcloud/").await;
+/// let res = download_wasmcloud_for_os_arch_pair(os, arch, "v0.57.0", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -175,6 +179,8 @@ where
                         if file_path.to_string_lossy().contains("bin")
                             || file_name.contains(".sh")
                             || file_name.contains(".bat")
+                            || file_name.eq("iex")
+                            || file_name.eq("elixir")
                             || file_name.eq("wasmcloud_host")
                         {
                             let mut perms = wasmcloud_file.metadata().await?.permissions();
@@ -239,36 +245,36 @@ where
 
     // Windows powershell will ping forever if it's the first command,
     // this is essentially an initialization
-    #[cfg(target_family = "windows")]
-    {
-        let tmp_log = std::env::temp_dir().join("init.log");
-        let init_run = tokio::fs::File::create(&tmp_log).await?.into_std().await;
-        let mut child = tokio::process::Command::new(bin_path.as_ref())
-            .stdout(init_run)
-            .arg("ping")
-            .spawn()?;
-        // Give the wasmcloud initialization a few seconds to unpack
-        for _ in 0..5 {
-            let log_contents = tokio::fs::read_to_string(&tmp_log).await?;
-            if log_contents.is_empty() {
-                // Give just a little bit of time for the startup logs to flow in
-                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-            } else {
-                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-                break;
-            }
-        }
-        let _ = child.kill();
-    }
+    //TODO: Mix release version of this
+    // #[cfg(target_family = "windows")]
+    // {
+    //     let tmp_log = std::env::temp_dir().join("init.log");
+    //     let init_run = tokio::fs::File::create(&tmp_log).await?.into_std().await;
+    //     let mut child = tokio::process::Command::new(bin_path.as_ref())
+    //         .stdout(init_run)
+    //         .arg("ping")
+    //         .spawn()?;
+    //     // Give the wasmcloud initialization a few seconds to unpack
+    //     for _ in 0..5 {
+    //         let log_contents = tokio::fs::read_to_string(&tmp_log).await?;
+    //         if log_contents.is_empty() {
+    //             // Give just a little bit of time for the startup logs to flow in
+    //             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    //         } else {
+    //             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    //             break;
+    //         }
+    //     }
+    //     let _ = child.kill();
+    // }
 
-    match Command::new(bin_path.as_ref()).arg("ping").output().await {
+    match Command::new(bin_path.as_ref()).arg("pid").output().await {
         // If ping was successful, returning "pong", another host is already running
         Ok(output) if output.status.success() => {
-            if String::from_utf8_lossy(&output.stdout).contains("pong") {
-                return Err(anyhow!(
-                    "Another wasmCloud host is already running on this machine"
-                ));
-            }
+            return Err(anyhow!(
+                "Another wasmCloud host is already running on this machine with PID {}",
+                String::from_utf8_lossy(&output.stdout)
+            ));
         }
         _ => (),
     }
@@ -280,7 +286,7 @@ where
         .stderr(stderr)
         .stdout(stdout)
         .envs(&env_vars)
-        .arg("foreground");
+        .arg("start");
 
     #[cfg(target_family = "unix")]
     {
@@ -319,9 +325,23 @@ fn wasmcloud_url(os: &str, arch: &str, version: &str) -> String {
         WASMCLOUD_GITHUB_RELEASE_URL, version, arch, os
     )
 }
+
+/// Helper function to ensure the version of wasmCloud is above the minimum
+/// supported version (v0.57.0) that runs mix releases
+fn check_version(version: &str) -> Result<()> {
+    if version < MINIMUM_WASMCLOUD_VERSION {
+        Err(anyhow!(
+            "wasmCloud version {} is earlier than the minimum supported version of {}",
+            version,
+            MINIMUM_WASMCLOUD_VERSION
+        ))
+    } else {
+        Ok(())
+    }
+}
 #[cfg(test)]
 mod test {
-    use super::{ensure_wasmcloud, wasmcloud_url};
+    use super::{check_version, ensure_wasmcloud, wasmcloud_url};
     use crate::start::{
         ensure_nats_server, ensure_wasmcloud_for_os_arch_pair, is_nats_installed,
         is_wasmcloud_installed, start_nats_server, start_wasmcloud_host, NatsConfig,
@@ -330,7 +350,7 @@ mod test {
     use reqwest::StatusCode;
     use std::{collections::HashMap, env::temp_dir};
     use tokio::fs::{create_dir_all, remove_dir_all};
-    const WASMCLOUD_VERSION: &str = "v0.55.1";
+    const WASMCLOUD_VERSION: &str = "v0.57.0";
 
     #[tokio::test]
     async fn can_request_supported_wasmcloud_urls() {
@@ -370,7 +390,7 @@ mod test {
     }
 
     const NATS_SERVER_VERSION: &str = "v2.8.4";
-    const WASMCLOUD_HOST_VERSION: &str = "v0.55.1";
+    const WASMCLOUD_HOST_VERSION: &str = "v0.57.0";
 
     #[tokio::test]
     async fn can_download_and_start_wasmcloud() -> anyhow::Result<()> {
@@ -473,6 +493,29 @@ mod test {
         host_child.unwrap().kill().await?;
         nats_child.unwrap().kill().await?;
         let _ = remove_dir_all(install_dir).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_properly_deny_distillery_release_hosts() -> anyhow::Result<()> {
+        // Ensure we allow versions >= 0.57.0
+        assert!(check_version("v1.56.0").is_ok());
+        assert!(check_version("v0.57.0").is_ok());
+        assert!(check_version("v0.57.1").is_ok());
+        assert!(check_version("v0.57.2").is_ok());
+        assert!(check_version("v0.58.0").is_ok());
+
+        // Ensure we deny versions < 0.57.0
+        assert!(check_version("v0.48.0").is_err());
+        assert!(check_version("v0.56.0").is_err());
+        assert!(check_version("v0.12.0").is_err());
+        assert!(check_version("v0.56.999").is_err());
+        if let Err(e) = check_version("v0.56.0") {
+            assert_eq!(e.to_string(), "wasmCloud version v0.56.0 is earlier than the minimum supported version of v0.57.0");
+        } else {
+            panic!("v0.56.0 should be before the minimum version")
+        }
+
         Ok(())
     }
 }

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -379,12 +379,18 @@ mod test {
 
     #[tokio::test]
     async fn can_download_and_start_wasmcloud() -> anyhow::Result<()> {
+        #[cfg(target_family = "unix")]
         let install_dir = temp_dir().join("can_download_and_start_wasmcloud");
+        // This is a very specific hack to download wasmCloud to the same _drive_ on Windows
+        // Turns out the mix release .bat file can't support executing an application that's installed
+        // on a different drive (e.g. running wasmCloud on the D: drive from the C: drive), which is what
+        // GitHub Actions does by default (runs in the D: drive, creates temp dir in the C: drive)
+        #[cfg(target_family = "windows")]
+        let install_dir = std::env::current_dir()?.join("can_download_and_start_wasmcloud");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
         assert!(!is_wasmcloud_installed(&install_dir).await);
 
-        println!("Current directory: {:?}", std::env::current_dir());
         println!("Install dir: {:?}", install_dir);
 
         // Install and start NATS server for this test
@@ -420,19 +426,6 @@ mod test {
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
-        #[cfg(target_family = "windows")]
-        let host_child = start_wasmcloud_host(
-            &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
-            Stdio::null(),
-            Stdio::null(),
-            host_env.clone(),
-        )
-        .await;
-        #[cfg(target_family = "windows")]
-        println!("child: {:?}", host_child);
-        println!("trying the first");
-        tokio::time::sleep(std::time::Duration::from_millis(10000)).await;
-        println!("trying the second");
         let host_child = start_wasmcloud_host(
             &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
             stdout_log_file,
@@ -440,7 +433,7 @@ mod test {
             host_env,
         )
         .await;
-        println!("child2: {:?}", host_child);
+        println!("child: {:?}", host_child);
         assert!(host_child.is_ok());
 
         // Give wasmCloud max 15 seconds to start up

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -37,7 +37,7 @@ const MINIMUM_WASMCLOUD_VERSION: &str = "0.57.0";
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::ensure_wasmcloud;
-/// let res = ensure_wasmcloud("v0.57.0", "/tmp/wasmcloud/").await;
+/// let res = ensure_wasmcloud("v0.57.1", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -68,7 +68,7 @@ where
 /// use wash_lib::start::ensure_wasmcloud_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = ensure_wasmcloud_for_os_arch_pair(os, arch, "v0.57.0", "/tmp/wasmcloud/").await;
+/// let res = ensure_wasmcloud_for_os_arch_pair(os, arch, "v0.57.1", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -104,7 +104,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::download_wasmcloud;
-/// let res = download_wasmcloud("v0.57.0", "/tmp/wasmcloud/").await;
+/// let res = download_wasmcloud("v0.57.1", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -134,7 +134,7 @@ where
 /// use wash_lib::start::download_wasmcloud_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = download_wasmcloud_for_os_arch_pair(os, arch, "v0.57.0", "/tmp/wasmcloud/").await;
+/// let res = download_wasmcloud_for_os_arch_pair(os, arch, "v0.57.1", "/tmp/wasmcloud/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wasmcloud/bin/wasmcloud_host".to_string());
 /// # }
@@ -333,9 +333,9 @@ mod test {
         NATS_SERVER_BINARY,
     };
     use reqwest::StatusCode;
-    use std::{collections::HashMap, env::temp_dir};
+    use std::{collections::HashMap, env::temp_dir, process::Stdio};
     use tokio::fs::{create_dir_all, remove_dir_all};
-    const WASMCLOUD_VERSION: &str = "v0.57.0";
+    const WASMCLOUD_VERSION: &str = "v0.57.1";
 
     #[tokio::test]
     async fn can_request_supported_wasmcloud_urls() {
@@ -375,7 +375,7 @@ mod test {
     }
 
     const NATS_SERVER_VERSION: &str = "v2.8.4";
-    const WASMCLOUD_HOST_VERSION: &str = "v0.57.0";
+    const WASMCLOUD_HOST_VERSION: &str = "v0.57.1";
 
     #[tokio::test]
     async fn can_download_and_start_wasmcloud() -> anyhow::Result<()> {
@@ -383,6 +383,9 @@ mod test {
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
         assert!(!is_wasmcloud_installed(&install_dir).await);
+
+        println!("Current directory: {:?}", std::env::current_dir());
+        println!("Install dir: {:?}", install_dir);
 
         // Install and start NATS server for this test
         let nats_port = 10004;
@@ -417,6 +420,19 @@ mod test {
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
+        #[cfg(target_family = "windows")]
+        let host_child = start_wasmcloud_host(
+            &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
+            Stdio::null(),
+            Stdio::null(),
+            host_env.clone(),
+        )
+        .await;
+        #[cfg(target_family = "windows")]
+        println!("child: {:?}", host_child);
+        println!("trying the first");
+        tokio::time::sleep(std::time::Duration::from_millis(10000)).await;
+        println!("trying the second");
         let host_child = start_wasmcloud_host(
             &install_dir.join(crate::start::wasmcloud::WASMCLOUD_HOST_BIN),
             stdout_log_file,
@@ -424,7 +440,7 @@ mod test {
             host_env,
         )
         .await;
-        println!("child: {:?}", host_child);
+        println!("child2: {:?}", host_child);
         assert!(host_child.is_ok());
 
         // Give wasmCloud max 15 seconds to start up

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -8,7 +8,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.8.4";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.55.1";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.57.0";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -8,7 +8,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.8.4";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.57.0";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.57.1";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -477,11 +477,16 @@ async fn stop_wasmcloud<P>(bin_path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
-    Command::new(bin_path.as_ref())
+    if !Command::new(bin_path.as_ref())
         .stdout(Stdio::piped())
         .arg("stop")
         .output()
-        .await?;
+        .await?
+        .status
+        .success()
+    {
+        log::warn!("wasmCloud exited with a non-zero exit status, processes may need to be cleaned up manually")
+    }
 
     Ok(())
 }

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -477,24 +477,21 @@ async fn stop_wasmcloud<P>(bin_path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
-    let child = Command::new(bin_path.as_ref())
+    Command::new(bin_path.as_ref())
         .stdout(Stdio::piped())
         .arg("stop")
-        .spawn()?;
+        .output()
+        .await?;
 
-    // Wait for the stop command to return "ok", then exit
-    tokio::spawn(async {
-        if let Some(stdout) = child.stdout {
-            let mut lines = BufReader::new(stdout).lines();
-
-            while let Ok(Some(line)) = lines.next_line().await {
-                if line == "ok" {
-                    return;
-                }
-            }
-        }
-    })
-    .await?;
+    //TODO: evaluate necessity
+    // Wait for the stop command return "ok", then exit
+    // tokio::spawn(async {
+    //     if let Some(stdout) = child.stdout {
+    //         let mut lines = BufReader::new(stdout).lines();
+    //         while let Ok(Some(_line)) = lines.next_line().await {}
+    //     }
+    // })
+    // .await?;
 
     Ok(())
 }
@@ -580,7 +577,7 @@ mod tests {
             "--wasmcloud-js-domain",
             "domain",
             "--wasmcloud-version",
-            "v0.55.1",
+            "v0.57.0",
             "--lattice-prefix",
             "anotherprefix",
         ])?;
@@ -658,7 +655,7 @@ mod tests {
         );
         assert_eq!(
             up_all_flags.wasmcloud_opts.wasmcloud_version,
-            "v0.55.1".to_string()
+            "v0.57.0".to_string()
         );
         assert_eq!(
             up_all_flags.wasmcloud_opts.lattice_prefix,

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -567,7 +567,7 @@ mod tests {
             "--wasmcloud-js-domain",
             "domain",
             "--wasmcloud-version",
-            "v0.57.0",
+            "v0.57.1",
             "--lattice-prefix",
             "anotherprefix",
         ])?;
@@ -645,7 +645,7 @@ mod tests {
         );
         assert_eq!(
             up_all_flags.wasmcloud_opts.wasmcloud_version,
-            "v0.57.0".to_string()
+            "v0.57.1".to_string()
         );
         assert_eq!(
             up_all_flags.wasmcloud_opts.lattice_prefix,

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -457,7 +457,7 @@ async fn run_wasmcloud_interactive(
         tokio::spawn(async {
             let mut lines = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                //TODO(brooksmtownsend): in the future, would be great print these in a prettier format
+                //TODO(brooksmtownsend): in the future, would be great to print these in a prettier format
                 println!("{}", line)
             }
         })
@@ -482,16 +482,6 @@ where
         .arg("stop")
         .output()
         .await?;
-
-    //TODO: evaluate necessity
-    // Wait for the stop command return "ok", then exit
-    // tokio::spawn(async {
-    //     if let Some(stdout) = child.stdout {
-    //         let mut lines = BufReader::new(stdout).lines();
-    //         while let Ok(Some(_line)) = lines.next_line().await {}
-    //     }
-    // })
-    // .await?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR updates the `wash-lib` crate to use the wasmCloud host version 0.57.0, which is using mix releases instead of distillery releases. As a part of this the commands changed to run and evaluate wasmCloud hosts, so the wash-lib needed an upgrade. After some consensus, we've decided to restrict the minimum version to 0.57 and drop support for distillery releases with wash-lib going forward as this will bring an unnecessary maintenance burden for a small use case (manually specifying old versions of the host)