### PR TITLE
clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 dependencies = [
  "backtrace",
 ]
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -535,7 +535,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -632,13 +632,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -691,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
 ]
 
 [[package]]
@@ -702,20 +702,19 @@ checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
@@ -732,12 +731,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -906,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1031,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -1324,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360d9740069b2f6cbb63ce2dbaa71a20d3185350cbb990d7bebeb9318415eb17"
+checksum = "56b224eaa4987c03c30b251de7ef0c15a6a59f34222905850dbc3026dfb24d5f"
 dependencies = [
  "log",
  "pest",
@@ -1503,14 +1501,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1549,7 +1546,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
  "globset",
  "lazy_static",
  "log",
@@ -1574,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
 dependencies = [
  "console",
  "number_prefix",
@@ -1600,9 +1597,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1615,18 +1612,18 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1686,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libgit2-sys"
@@ -1738,9 +1735,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2037,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "opaque-debug"
@@ -2055,9 +2052,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -2234,9 +2231,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2256,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2266,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2279,13 +2276,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -2392,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2484,7 +2481,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2494,7 +2491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2505,9 +2502,9 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -2532,7 +2529,7 @@ checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
  "num_cpus",
 ]
 
@@ -2606,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -2622,9 +2619,9 @@ dependencies = [
  "hyper-rustls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
+ "once_cell",
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls 0.20.6",
@@ -2672,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
 dependencies = [
  "byteorder",
  "rmp",
@@ -2886,18 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -2913,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2995,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3033,14 +3030,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3058,13 +3055,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3092,16 +3089,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfecc059e81632eef1dd9b79e22fc28b8fe69b30d3357512a77a0ad8ee3c782"
 dependencies = [
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "signature",
  "zeroize",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
 
 [[package]]
 name = "slab"
@@ -3231,9 +3228,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3335,24 +3332,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3408,9 +3405,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3418,7 +3415,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3471,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3763,42 +3759,42 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "untrusted"
@@ -3936,14 +3932,14 @@ dependencies = [
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
- "clap 3.2.20",
+ "clap 3.2.22",
  "cloudevents-sdk",
  "console",
  "ctrlc",
  "derive_more",
  "dialoguer",
  "dirs",
- "env_logger 0.9.0",
+ "env_logger 0.9.1",
  "envmnt",
  "git2",
  "heck 0.4.0",
@@ -3968,7 +3964,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "serial_test",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "tempfile",
  "term-table",
  "test-case",
@@ -4020,9 +4016,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4030,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -4045,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4057,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4067,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4080,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmbus-macros"
@@ -4098,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e3ab2907e44494c1fdcabad972afec0ffcdb9becc13229252cfad8f503941a"
+checksum = "84264f6ad19b3ed5802bbd4abfda11736a3b575d2a12f66d707fecec88c2efaf"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4123,7 +4119,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "thiserror",
  "time 0.3.14",
  "tokio",
@@ -4197,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4227,9 +4223,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki 0.22.0",
 ]
@@ -4248,7 +4244,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if 1.0.0",
- "clap 3.2.20",
+ "clap 3.2.22",
  "directories",
  "downloader",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,13 +529,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.1",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
 ]
 
 [[package]]
@@ -552,10 +567,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -3932,7 +3969,7 @@ dependencies = [
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
- "clap 3.2.22",
+ "clap 4.0.4",
  "cloudevents-sdk",
  "console",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-nats = "0.18.0"
 atelier_core = "0.2"
 bytes = "1.0"
 cargo_atelier = "0.2"
-clap = { version="3", features=["derive", "env"] }
+clap = { version="4", features=["derive", "env"] }
 cloudevents-sdk = "0.5.0"
 console = "0.15"
 ctrlc = "3.2.2"

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -3,14 +3,14 @@ use config::Config;
 use semver::Version;
 use std::{fs, path::PathBuf};
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LanguageConfig {
     Rust(RustConfig),
     TinyGo(TinyGoConfig),
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TypeConfig {
     Actor(ActorConfig),
@@ -30,7 +30,7 @@ pub struct ProjectConfig {
     pub common: CommonConfig,
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct ActorConfig {
     /// The list of provider claims that this actor requires. eg. ["wasmcloud:httpserver", "wasmcloud:blobstore"]
     pub claims: Vec<String>,
@@ -84,7 +84,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
         })
     }
 }
-#[derive(serde::Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct ProviderConfig {
     /// The capability ID of the provider.
     pub capability_id: String,
@@ -110,7 +110,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
     }
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct InterfaceConfig {
     /// Directory to output HTML.
     pub html_target: PathBuf,
@@ -141,7 +141,7 @@ impl TryFrom<RawInterfaceConfig> for InterfaceConfig {
     }
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct RustConfig {
     /// The path to the cargo binary. Optional, will default to search the user's `PATH` for `cargo` if not specified.
     pub cargo_path: Option<PathBuf>,
@@ -169,7 +169,7 @@ impl TryFrom<RawRustConfig> for RustConfig {
 }
 
 /// Configuration common amoung all project types & languages.
-#[derive(serde::Deserialize, Debug, PartialEq, Clone)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CommonConfig {
     /// Name of the project.
     pub name: String,
@@ -196,7 +196,7 @@ struct RawProjectConfig {
     pub tinygo: Option<RawTinyGoConfig>,
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct TinyGoConfig {
     /// The path to the tinygo binary. Optional, will default to `tinygo` if not specified.
     pub tinygo_path: Option<PathBuf>,

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -244,18 +244,15 @@ where
     }
 
     #[cfg(target_family = "unix")]
-    match Command::new(bin_path.as_ref()).arg("pid").output().await {
-        Ok(output) => {
-            // Stderr will include :nodedown if no other host is running, otherwise
-            // stdout will contain the PID
-            if !String::from_utf8_lossy(&output.stderr).contains(":nodedown") {
-                return Err(anyhow!(
-                    "Another wasmCloud host is already running on this machine with PID {}",
-                    String::from_utf8_lossy(&output.stdout)
-                ));
-            }
+    if let Ok(output) = Command::new(bin_path.as_ref()).arg("pid").output().await {
+        // Stderr will include :nodedown if no other host is running, otherwise
+        // stdout will contain the PID
+        if !String::from_utf8_lossy(&output.stderr).contains(":nodedown") {
+            return Err(anyhow!(
+                "Another wasmCloud host is already running on this machine with PID {}",
+                String::from_utf8_lossy(&output.stdout)
+            ));
         }
-        _ => (),
     }
 
     // Constructing this object in one step results in a temporary value that's dropped
@@ -333,7 +330,7 @@ mod test {
         NATS_SERVER_BINARY,
     };
     use reqwest::StatusCode;
-    use std::{collections::HashMap, env::temp_dir, process::Stdio};
+    use std::{collections::HashMap, env::temp_dir};
     use tokio::fs::{create_dir_all, remove_dir_all};
     const WASMCLOUD_VERSION: &str = "v0.57.1";
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -110,7 +110,7 @@ pub(crate) struct CallCommand {
         short = 'c',
         long = "cluster-seed",
         env = "WASMCLOUD_CLUSTER_SEED",
-        parse(try_from_str)
+        value_parser
     )]
     pub(crate) cluster_seed: Option<ClusterSeed>,
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -124,7 +124,7 @@ pub(crate) enum CtlCliCommand {
 #[derive(Args, Debug, Clone)]
 pub(crate) struct ApplyCommand {
     /// Public key of the target host for the manifest application
-    #[clap(name = "host-key", parse(try_from_str))]
+    #[clap(name = "host-key", value_parser)]
     pub(crate) host_key: ServerId,
 
     /// Path to the manifest file. Note that all the entries in this file are imperative instructions, and all actor and provider references MUST be valid OCI references.
@@ -181,7 +181,7 @@ pub(crate) struct LinkDelCommand {
     opts: ConnectionOpts,
 
     /// Public key ID of actor
-    #[clap(name = "actor-id", parse(try_from_str))]
+    #[clap(name = "actor-id", value_parser)]
     pub(crate) actor_id: ModuleId,
 
     /// Capability contract ID between actor and provider
@@ -202,11 +202,11 @@ pub(crate) struct LinkPutCommand {
     opts: ConnectionOpts,
 
     /// Public key ID of actor
-    #[clap(name = "actor-id", parse(try_from_str))]
+    #[clap(name = "actor-id", value_parser)]
     pub(crate) actor_id: ModuleId,
 
     /// Public key ID of provider
-    #[clap(name = "provider-id", parse(try_from_str))]
+    #[clap(name = "provider-id", value_parser)]
     pub(crate) provider_id: ServiceId,
 
     /// Capability contract ID between actor and provider
@@ -268,11 +268,11 @@ pub struct ScaleActorCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     host_id: ServerId,
 
     /// Actor Id, e.g. the public key for the actor
-    #[clap(name = "actor-id", parse(try_from_str))]
+    #[clap(name = "actor-id", value_parser)]
     pub(crate) actor_id: ModuleId,
 
     /// Actor reference, e.g. the OCI URL for the actor.
@@ -301,7 +301,7 @@ pub(crate) struct GetHostInventoryCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     pub(crate) host_id: ServerId,
 }
 
@@ -317,7 +317,7 @@ pub(crate) struct StartActorCommand {
     opts: ConnectionOpts,
 
     /// Id of host, if omitted the actor will be auctioned in the lattice to find a suitable host
-    #[clap(long = "host-id", name = "host-id", parse(try_from_str))]
+    #[clap(long = "host-id", name = "host-id", value_parser)]
     pub(crate) host_id: Option<ServerId>,
 
     /// Actor reference, e.g. the OCI URL for the actor.
@@ -349,7 +349,7 @@ pub(crate) struct StartProviderCommand {
     opts: ConnectionOpts,
 
     /// Id of host, if omitted the provider will be auctioned in the lattice to find a suitable host
-    #[clap(long = "host-id", name = "host-id", parse(try_from_str))]
+    #[clap(long = "host-id", name = "host-id", value_parser)]
     host_id: Option<ServerId>,
 
     /// Provider reference, e.g. the OCI URL for the provider
@@ -385,11 +385,11 @@ pub(crate) struct StopActorCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     pub(crate) host_id: ServerId,
 
     /// Actor Id, e.g. the public key for the actor
-    #[clap(name = "actor-id", parse(try_from_str))]
+    #[clap(name = "actor-id", value_parser)]
     pub(crate) actor_id: ModuleId,
 
     /// Number of actors to stop
@@ -408,11 +408,11 @@ pub(crate) struct StopProviderCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     host_id: ServerId,
 
     /// Provider Id, e.g. the public key for the provider
-    #[clap(name = "provider-id", parse(try_from_str))]
+    #[clap(name = "provider-id", value_parser)]
     pub(crate) provider_id: ServiceId,
 
     /// Link name of provider
@@ -435,7 +435,7 @@ pub(crate) struct StopHostCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     host_id: ServerId,
 
     /// The timeout in ms for how much time to give the host for graceful shutdown
@@ -452,11 +452,11 @@ pub(crate) struct UpdateActorCommand {
     opts: ConnectionOpts,
 
     /// Id of host
-    #[clap(name = "host-id", parse(try_from_str))]
+    #[clap(name = "host-id", value_parser)]
     pub(crate) host_id: ServerId,
 
     /// Actor Id, e.g. the public key for the actor
-    #[clap(name = "actor-id", parse(try_from_str))]
+    #[clap(name = "actor-id", value_parser)]
     pub(crate) actor_id: ModuleId,
 
     /// Actor reference, e.g. the OCI URL for the actor.

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -36,7 +36,7 @@
 //   license: MIT/Apache-2.0
 //
 use anyhow::{anyhow, Context, Result};
-use clap::{ArgEnum, Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use config::{Config, CONFIG_FILE_NAME};
 use console::style;
 use git::GitConfig;
@@ -83,7 +83,7 @@ pub(crate) enum NewCliCommand {
 }
 
 /// Type of project to be generated
-#[derive(Debug, Clone, ArgEnum)]
+#[derive(Debug, Clone, ValueEnum)]
 pub(crate) enum ProjectKind {
     Actor,
     Interface,

--- a/src/smithy.rs
+++ b/src/smithy.rs
@@ -95,7 +95,7 @@ pub(crate) struct GenerateOptions {
 
     /// Additional defines in the form of key=value to be passed to renderer
     /// Use `-D key=value` for each term to be added.
-    #[clap(short = 'D', parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[clap(short = 'D', value_parser = parse_key_val, number_of_values = 1)]
     defines: Vec<(String, TomlValue)>,
 
     /// Enable verbose logging

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -40,11 +40,27 @@ pub(crate) struct UpCommand {
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct NatsOpts {
+    /// Optional path to a NATS credentials file to authenticate and extend existing NATS infrastructure.
+    #[clap(
+        long = "nats-credsfile",
+        env = "NATS_CREDSFILE",
+        requires = "nats_remote_url"
+    )]
+    pub(crate) nats_credsfile: Option<PathBuf>,
+
+    /// Optional remote URL of existing NATS infrastructure to extend.
+    #[clap(
+        long = "nats-remote-url",
+        env = "NATS_REMOTE_URL",
+        requires = "nats_credsfile"
+    )]
+    pub(crate) nats_remote_url: Option<String>,
+
     /// If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
     #[clap(
         long = "nats-connect-only",
         env = "NATS_CONNECT_ONLY",
-        conflicts_with = "nats-remote-url"
+        conflicts_with = "nats_remote_url"
     )]
     pub(crate) connect_only: bool,
 
@@ -63,22 +79,6 @@ pub(crate) struct NatsOpts {
     /// NATS Server Jetstream domain, defaults to `core`
     #[clap(long = "nats-js-domain", env = "NATS_JS_DOMAIN")]
     pub(crate) nats_js_domain: Option<String>,
-
-    /// Optional remote URL of existing NATS infrastructure to extend.
-    #[clap(
-        long = "nats-remote-url",
-        env = "NATS_REMOTE_URL",
-        requires = "nats-credsfile"
-    )]
-    pub(crate) nats_remote_url: Option<String>,
-
-    /// Optional path to a NATS credentials file to authenticate and extend existing NATS infrastructure.
-    #[clap(
-        long = "nats-credsfile",
-        env = "NATS_CREDSFILE",
-        requires = "nats-remote-url"
-    )]
-    pub(crate) nats_credsfile: Option<PathBuf>,
 }
 
 impl From<NatsOpts> for NatsConfig {
@@ -121,7 +121,7 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) rpc_port: Option<u16>,
 
     /// A seed nkey to use to authenticate to NATS for RPC messages
-    #[clap(long = "rpc-seed", env = WASMCLOUD_RPC_SEED, requires = "rpc-jwt")]
+    #[clap(long = "rpc-seed", env = WASMCLOUD_RPC_SEED, requires = "rpc_jwt")]
     pub(crate) rpc_seed: Option<String>,
 
     /// Timeout in milliseconds for all RPC calls
@@ -129,7 +129,7 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) rpc_timeout_ms: u32,
 
     /// A user JWT to use to authenticate to NATS for RPC messages
-    #[clap(long = "rpc-jwt", env = WASMCLOUD_RPC_JWT, requires = "rpc-seed")]
+    #[clap(long = "rpc-jwt", env = WASMCLOUD_RPC_JWT, requires = "rpc_seed")]
     pub(crate) rpc_jwt: Option<String>,
 
     /// Optional flag to enable host communication with a NATS server over TLS for RPC messages
@@ -149,7 +149,7 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) prov_rpc_port: Option<u16>,
 
     /// A seed nkey to use to authenticate to NATS for Provider RPC messages
-    #[clap(long = "prov-rpc-seed", env = WASMCLOUD_PROV_RPC_SEED, requires = "prov-rpc-jwt")]
+    #[clap(long = "prov-rpc-seed", env = WASMCLOUD_PROV_RPC_SEED, requires = "prov_rpc_jwt")]
     pub(crate) prov_rpc_seed: Option<String>,
 
     /// Optional flag to enable host communication with a NATS server over TLS for Provider RPC messages
@@ -157,7 +157,7 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) prov_rpc_tls: bool,
 
     /// A user JWT to use to authenticate to NATS for Provider RPC messages
-    #[clap(long = "prov-rpc-jwt", env = WASMCLOUD_PROV_RPC_JWT, requires = "prov-rpc-seed")]
+    #[clap(long = "prov-rpc-jwt", env = WASMCLOUD_PROV_RPC_JWT, requires = "prov_rpc_seed")]
     pub(crate) prov_rpc_jwt: Option<String>,
 
     /// Convenience flag for Provider RPC authentication, internally this parses the JWT and seed from the credsfile
@@ -173,11 +173,11 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) ctl_port: Option<u16>,
 
     /// A seed nkey to use to authenticate to NATS for CTL messages
-    #[clap(long = "ctl-seed", env = WASMCLOUD_CTL_SEED, requires = "ctl-jwt")]
+    #[clap(long = "ctl-seed", env = WASMCLOUD_CTL_SEED, requires = "ctl_jwt")]
     pub(crate) ctl_seed: Option<String>,
 
     /// A user JWT to use to authenticate to NATS for CTL messages
-    #[clap(long = "ctl-jwt", env = WASMCLOUD_CTL_JWT, requires = "ctl-seed")]
+    #[clap(long = "ctl-jwt", env = WASMCLOUD_CTL_JWT, requires = "ctl_seed")]
     pub(crate) ctl_jwt: Option<String>,
 
     /// Convenience flag for CTL authentication, internally this parses the JWT and seed from the credsfile

--- a/tests/integration_claims.rs
+++ b/tests/integration_claims.rs
@@ -123,7 +123,7 @@ fn integration_claims_inspect() {
 
     assert_json_include!(
         actual: local_inspect_output,
-        expected: expected_inspect_output.clone()
+        expected: expected_inspect_output
     );
 
     let local_reg_inspect = wash()
@@ -142,7 +142,7 @@ fn integration_claims_inspect() {
 
     assert_json_include!(
         actual: local_reg_inspect_output,
-        expected: expected_inspect_output.clone()
+        expected: expected_inspect_output
     );
 
     let remote_inspect = wash()

--- a/tests/integration_par.rs
+++ b/tests/integration_par.rs
@@ -146,7 +146,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
         "vendor": "TestRunner",
         "version": "3.2.1"
     });
-    assert_json_include!(actual: output.clone(), expected: expected);
+    assert_json_include!(actual: output, expected: expected);
     let targets: Vec<String> = output
         .get("targets")
         .unwrap()
@@ -200,7 +200,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
         "vendor": "TestRunner",
         "version": "3.2.1"
     });
-    assert_json_include!(actual: output.clone(), expected: expected);
+    assert_json_include!(actual: output, expected: expected);
     let targets: Vec<String> = output
         .get("targets")
         .unwrap()
@@ -270,7 +270,7 @@ fn integration_par_inspect() {
         "service": HTTP_SERVICE,
         "capability_contract_id": "wasmcloud:httpclient",
     });
-    assert_json_include!(actual: local_inspect_output, expected: inspect_expected.clone());
+    assert_json_include!(actual: local_inspect_output, expected: inspect_expected);
 
     let local_reg_inspect = wash()
         .args(&[
@@ -285,7 +285,7 @@ fn integration_par_inspect() {
         .expect("failed to inspect local registry wasm");
     assert!(local_reg_inspect.status.success());
     let local_reg_inspect_output = get_json_output(local_reg_inspect).unwrap();
-    assert_json_include!(actual: local_reg_inspect_output, expected: inspect_expected.clone());
+    assert_json_include!(actual: local_reg_inspect_output, expected: inspect_expected);
 
     let remote_inspect = wash()
         .args(&["par", "inspect", HTTP_OCI, "-o", "json"])


### PR DESCRIPTION
A series of chores with the end goal of updating to clap v4. The following was done in stages and is self-contained by commit:

- Fixed clippy warnings
- Bumped dependencies
- Then updated clap to v4