### PR TITLE
Set stdin to null when starting a wasmcloud host with wash-lib

### DIFF
--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -275,8 +275,8 @@ impl NatsConfig {
             (Some(url), Some(creds)) => format!(
                 r#"
 leafnodes {{
-    remotes = [ 
-        {{ 
+    remotes = [
+        {{
             url: "{}"
             credentials: "{}"
         }}
@@ -330,6 +330,7 @@ where
         config.write_to_path(&config_path).await?;
         Command::new(bin_path.as_ref())
             .stderr(stderr)
+            .stdin(Stdio::null())
             .arg("-js")
             .arg("--config")
             .arg(config_path)

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -261,6 +261,7 @@ where
         // wasmCloud host logs are sent to stderr as of https://github.com/wasmCloud/wasmcloud-otp/pull/418
         .stderr(stderr)
         .stdout(stdout)
+        .stdin(Stdio::null())
         .envs(&env_vars)
         .arg("start");
 


### PR DESCRIPTION
By default `tokio::process::Command` inherits stdin from the running process, which means that if you're trying to start a wasmcloud host with wash-lib it will capture stdin and make that particular terminal unusable until you kill the wasmcloud process.

This fixes the issue by setting stdin to null when starting the process.