### PR TITLE
Feat/wash down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 walkdir = "2.3"
 which = "4.2.2"
-wash-lib = { version = "0.3.1", path = "./crates/wash-lib" }
+wash-lib = { version = "0.4.0-alpha.1", path = "./crates/wash-lib" }
 wascap = "0.8.0"
 weld-codegen = "0.5.0"
 wasmcloud-control-interface = "0.21.0"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -343,7 +343,7 @@ where
             .arg("--pid")
             .arg(parent_path.join(NATS_SERVER_PID))
             .spawn()
-            .map_err(|e| anyhow!(e))
+            .map_err(anyhow::Error::from)
     } else {
         Err(anyhow!(
             "Could not write config to disk, couldn't find download directory"

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -11,11 +11,12 @@ use tokio_stream::StreamExt;
 use tokio_tar::Archive;
 
 const NATS_GITHUB_RELEASE_URL: &str = "https://github.com/nats-io/nats-server/releases/download";
-pub(crate) const NATS_SERVER_CONF: &str = "nats.conf";
+pub const NATS_SERVER_CONF: &str = "nats.conf";
+pub const NATS_SERVER_PID: &str = "nats.pid";
 #[cfg(target_family = "unix")]
-pub(crate) const NATS_SERVER_BINARY: &str = "nats-server";
+pub const NATS_SERVER_BINARY: &str = "nats-server";
 #[cfg(target_family = "windows")]
-pub(crate) const NATS_SERVER_BINARY: &str = "nats-server.exe";
+pub const NATS_SERVER_BINARY: &str = "nats-server.exe";
 
 /// A wrapper around the [ensure_nats_server_for_os_arch_pair] function that uses the
 /// architecture and operating system of the current host machine.
@@ -324,7 +325,8 @@ where
             config.port
         ));
     }
-    if let Some(config_path) = bin_path.as_ref().parent().map(|p| p.join(NATS_SERVER_CONF)) {
+    if let Some(parent_path) = bin_path.as_ref().parent() {
+        let config_path = parent_path.join(NATS_SERVER_CONF);
         let host = config.host.to_owned();
         let port = config.port;
         config.write_to_path(&config_path).await?;
@@ -338,10 +340,14 @@ where
             .arg(host)
             .arg("--port")
             .arg(port.to_string())
+            .arg("--pid")
+            .arg(parent_path.join(NATS_SERVER_PID))
             .spawn()
             .map_err(|e| anyhow!(e))
     } else {
-        Err(anyhow!("Could not write config to disk"))
+        Err(anyhow!(
+            "Could not write config to disk, couldn't find download directory"
+        ))
     }
 }
 

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -17,9 +17,9 @@ use tokio_tar::Archive;
 const WASMCLOUD_GITHUB_RELEASE_URL: &str =
     "https://github.com/wasmCloud/wasmcloud-otp/releases/download";
 #[cfg(target_family = "unix")]
-pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin/wasmcloud_host";
+pub const WASMCLOUD_HOST_BIN: &str = "bin/wasmcloud_host";
 #[cfg(target_family = "windows")]
-pub(crate) const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
+pub const WASMCLOUD_HOST_BIN: &str = "bin\\wasmcloud_host.bat";
 
 // Any version of wasmCloud under 0.57.0 uses distillery releases and is incompatible
 const MINIMUM_WASMCLOUD_VERSION: &str = "0.57.0";

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -1,10 +1,11 @@
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use serde_json::json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
 use tokio::process::Command;
 
 use crate::appearance::spinner::Spinner;
@@ -83,7 +84,7 @@ where
         .arg("stop")
         .output()
         .await
-        .map_err(|e| anyhow!(e))
+        .map_err(anyhow::Error::from)
 }
 
 /// Helper function to send the nats-server the stop command
@@ -104,7 +105,7 @@ where
         .stdin(Stdio::null())
         .output()
         .await
-        .map_err(|e| anyhow!(e));
+        .map_err(anyhow::Error::from);
 
     // remove PID file
     if pid_file.is_file() {

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+use crate::appearance::spinner::Spinner;
+use crate::cfg::cfg_dir;
+use crate::up::DOWNLOADS_DIR;
+use crate::util::{CommandOutput, OutputKind};
+use wash_lib::start::*;
+
+#[derive(Parser, Debug, Clone)]
+pub(crate) struct DownCommand {}
+
+pub(crate) async fn handle_command(
+    command: DownCommand,
+    output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    handle_down(command, output_kind).await
+}
+
+pub(crate) async fn handle_down(
+    _cmd: DownCommand,
+    output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    let install_dir = cfg_dir()?.join(DOWNLOADS_DIR);
+    let sp = Spinner::new(&output_kind)?;
+
+    let mut out_json = HashMap::new();
+    let mut out_text = String::from("");
+    let host_cmd = install_dir.join(WASMCLOUD_HOST_BIN);
+    if host_cmd.is_file() {
+        sp.update_spinner_message(" Stopping host ...".to_string());
+        let output = Command::new(&host_cmd)
+            .arg("stop")
+            .stdin(Stdio::null())
+            .output()
+            .await;
+        if let Ok(output) = output {
+            if output.stderr.is_empty() && output.stdout.is_empty() {
+                // if there was a host running, 'stop' has no output.
+                // Give it time to stop before stopping nats
+                tokio::time::sleep(Duration::from_secs(6)).await;
+                out_json.insert("host_stopped".to_string(), json!(true));
+                out_text.push_str("✅ wasmCloud host stopped successfully\n");
+            } else {
+                out_json.insert("host_stopped".to_string(), json!(true));
+                out_text.push_str(
+                    "🤔 Host did not appear to be running, assuming it's already stopped\n",
+                );
+            }
+        }
+    }
+
+    let nats_cmd = install_dir.join(NATS_SERVER_BINARY);
+    if nats_cmd.is_file() {
+        let pid_file = install_dir.join(NATS_SERVER_PID);
+        let signal = if pid_file.is_file() {
+            format!("stop={}", &pid_file.display())
+        } else {
+            "stop".into()
+        };
+        sp.update_spinner_message(" Stopping NATS server ...".to_string());
+        if let Err(e) = Command::new(nats_cmd)
+            .arg("--signal")
+            .arg(signal)
+            .stdin(Stdio::null())
+            .output()
+            .await
+        {
+            out_json.insert("nats_stopped".to_string(), json!(false));
+            out_text.push_str(&format!(
+                "❌ NATS server did not stop successfully: {:?}\n",
+                e
+            ));
+        } else {
+            out_json.insert("nats_stopped".to_string(), json!(true));
+            out_text.push_str("✅ NATS server stopped successfully\n");
+        }
+        // remove PID file
+        if pid_file.is_file() {
+            let _ = tokio::fs::remove_file(&pid_file).await;
+        }
+    }
+
+    out_json.insert("success".to_string(), json!(true));
+    out_text.push_str("🛁 wash down completed successfully");
+
+    sp.finish_and_clear();
+    Ok(CommandOutput::new(out_text, out_json))
+}

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use serde_json::json;
 use std::collections::HashMap;
-use std::process::Stdio;
+use std::path::{Path, PathBuf};
+use std::process::{Output, Stdio};
 use std::time::Duration;
 use tokio::process::Command;
 
@@ -31,15 +32,10 @@ pub(crate) async fn handle_down(
 
     let mut out_json = HashMap::new();
     let mut out_text = String::from("");
-    let host_cmd = install_dir.join(WASMCLOUD_HOST_BIN);
-    if host_cmd.is_file() {
+    let host_bin = install_dir.join(WASMCLOUD_HOST_BIN);
+    if host_bin.is_file() {
         sp.update_spinner_message(" Stopping host ...".to_string());
-        let output = Command::new(&host_cmd)
-            .arg("stop")
-            .stdin(Stdio::null())
-            .output()
-            .await;
-        if let Ok(output) = output {
+        if let Ok(output) = stop_wasmcloud(host_bin).await {
             if output.stderr.is_empty() && output.stdout.is_empty() {
                 // if there was a host running, 'stop' has no output.
                 // Give it time to stop before stopping nats
@@ -55,22 +51,10 @@ pub(crate) async fn handle_down(
         }
     }
 
-    let nats_cmd = install_dir.join(NATS_SERVER_BINARY);
-    if nats_cmd.is_file() {
-        let pid_file = install_dir.join(NATS_SERVER_PID);
-        let signal = if pid_file.is_file() {
-            format!("stop={}", &pid_file.display())
-        } else {
-            "stop".into()
-        };
+    let nats_bin = install_dir.join(NATS_SERVER_BINARY);
+    if nats_bin.is_file() {
         sp.update_spinner_message(" Stopping NATS server ...".to_string());
-        if let Err(e) = Command::new(nats_cmd)
-            .arg("--signal")
-            .arg(signal)
-            .stdin(Stdio::null())
-            .output()
-            .await
-        {
+        if let Err(e) = stop_nats(install_dir).await {
             out_json.insert("nats_stopped".to_string(), json!(false));
             out_text.push_str(&format!(
                 "❌ NATS server did not stop successfully: {:?}\n",
@@ -80,10 +64,6 @@ pub(crate) async fn handle_down(
             out_json.insert("nats_stopped".to_string(), json!(true));
             out_text.push_str("✅ NATS server stopped successfully\n");
         }
-        // remove PID file
-        if pid_file.is_file() {
-            let _ = tokio::fs::remove_file(&pid_file).await;
-        }
     }
 
     out_json.insert("success".to_string(), json!(true));
@@ -91,4 +71,52 @@ pub(crate) async fn handle_down(
 
     sp.finish_and_clear();
     Ok(CommandOutput::new(out_text, out_json))
+}
+
+/// Helper function to send wasmCloud the `stop` command and wait for it to clean up
+pub(crate) async fn stop_wasmcloud<P>(bin_path: P) -> Result<Output>
+where
+    P: AsRef<Path>,
+{
+    Command::new(bin_path.as_ref())
+        .stdout(Stdio::piped())
+        .arg("stop")
+        .output()
+        .await
+        .map_err(|e| anyhow!(e))
+}
+
+/// Helper function to send the nats-server the stop command
+pub(crate) async fn stop_nats<P>(install_dir: P) -> Result<Output>
+where
+    P: AsRef<Path>,
+{
+    let bin_path = install_dir.as_ref().join(NATS_SERVER_BINARY);
+    let pid_file = nats_pid(install_dir);
+    let signal = if pid_file.is_file() {
+        format!("stop={}", &pid_file.display())
+    } else {
+        "stop".into()
+    };
+    let output = Command::new(bin_path)
+        .arg("--signal")
+        .arg(signal)
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .map_err(|e| anyhow!(e));
+
+    // remove PID file
+    if pid_file.is_file() {
+        let _ = tokio::fs::remove_file(&pid_file).await;
+    }
+    output
+}
+
+/// Helper function to get the path to the NATS server pid file
+pub(crate) fn nats_pid<P>(install_dir: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    install_dir.as_ref().join(NATS_SERVER_PID)
 }

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -93,7 +93,7 @@ where
     P: AsRef<Path>,
 {
     let bin_path = install_dir.as_ref().join(NATS_SERVER_BINARY);
-    let pid_file = nats_pid(install_dir);
+    let pid_file = nats_pid_path(install_dir);
     let signal = if pid_file.is_file() {
         format!("stop={}", &pid_file.display())
     } else {
@@ -115,7 +115,7 @@ where
 }
 
 /// Helper function to get the path to the NATS server pid file
-pub(crate) fn nats_pid<P>(install_dir: P) -> PathBuf
+pub(crate) fn nats_pid_path<P>(install_dir: P) -> PathBuf
 where
     P: AsRef<Path>,
 {

--- a/src/generate/interactive.rs
+++ b/src/generate/interactive.rs
@@ -9,7 +9,7 @@ use crate::generate::{
     project_variables::{StringEntry, TemplateSlots, VarInfo},
     PROJECT_NAME_REGEX,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Input};
 use serde_json::Value;
@@ -38,7 +38,7 @@ pub(crate) fn user_question(prompt: &str, default: &Option<String>) -> Result<St
     if let Some(s) = default {
         i.default(s.to_owned());
     }
-    i.interact().map_err(|e| anyhow!("{}", e))
+    i.interact().map_err(anyhow::Error::from)
 }
 
 fn extract_default(variable: &VarInfo) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use claims::ClaimsCliCommand;
 use clap::{Parser, Subcommand};
 use ctl::CtlCliCommand;
 use ctx::CtxCommand;
+use down::DownCommand;
 use drain::DrainSelection;
 use generate::NewCliCommand;
 use keys::KeysCliCommand;
@@ -28,6 +29,7 @@ mod cfg;
 mod claims;
 mod ctl;
 mod ctx;
+mod down;
 mod drain;
 mod generate;
 mod id;
@@ -86,6 +88,9 @@ enum CliCommand {
     /// Manage wasmCloud host configuration contexts
     #[clap(name = "ctx", subcommand)]
     Ctx(CtxCommand),
+    /// Tear down a wasmCloud environment launched with wash up
+    #[clap(name = "down")]
+    Down(DownCommand),
     /// Manage contents of local wasmCloud caches
     #[clap(name = "drain", subcommand)]
     Drain(DrainSelection),
@@ -129,6 +134,7 @@ async fn main() {
         CliCommand::Claims(claims_cli) => claims::handle_command(claims_cli, output_kind).await,
         CliCommand::Ctl(ctl_cli) => ctl::handle_command(ctl_cli, output_kind).await,
         CliCommand::Ctx(ctx_cli) => ctx::handle_command(ctx_cli).await,
+        CliCommand::Down(down_cli) => down::handle_command(down_cli, output_kind).await,
         CliCommand::Drain(drain_cli) => drain::handle_command(drain_cli),
         CliCommand::Gen(generate_cli) => smithy::handle_gen_command(generate_cli),
         CliCommand::Keys(keys_cli) => keys::handle_command(keys_cli),

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 
 use crate::up::{credsfile::parse_credsfile, NatsOpts, WasmcloudOpts};
 
-pub(crate) const DOWNLOADS_DIR: &str = "downloads";
+pub const DOWNLOADS_DIR: &str = "downloads";
 // NATS configuration values
 pub(crate) const NATS_SERVER_VERSION: &str = "v2.8.4";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.57.1";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.58.2";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -1,3 +1,6 @@
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::Path;
@@ -7,28 +10,25 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-
-use crate::appearance::spinner::Spinner;
-use crate::cfg::cfg_dir;
-use crate::util::{CommandOutput, OutputKind};
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use serde_json::json;
 use tokio::fs::create_dir_all;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, Command},
 };
 
+use crate::appearance::spinner::Spinner;
+use crate::cfg::cfg_dir;
+use crate::util::{CommandOutput, OutputKind};
 use wash_lib::start::*;
 mod config;
 mod credsfile;
+pub use config::DOWNLOADS_DIR;
 use config::*;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct UpCommand {
     /// Launch NATS and wasmCloud detached from the current terminal as background processes
-    #[clap(short = 'd', long = "detached")]
+    #[clap(short = 'd', long = "detached", alias = "detach")]
     pub(crate) detached: bool,
 
     #[clap(flatten)]
@@ -348,7 +348,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     out_json.insert("success".to_string(), json!(true));
     out_text.push_str("🛁 wash up completed successfully");
 
-    let nats_pid = if let Some(Some(pid)) = nats_process.map(|child| child.id()) {
+    if let Some(Some(pid)) = nats_process.map(|child| child.id()) {
         out_json.insert("nats_pid".to_string(), json!(pid));
         out_json.insert("nats_url".to_string(), json!(nats_listen_address));
         let _ = write!(
@@ -356,42 +356,20 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             "\n🕸  NATS is running in the background at http://{}",
             nats_listen_address
         );
-        Some(pid)
-    } else {
-        None
     };
+
     if cmd.detached {
         let url = "http://localhost:4000";
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
+        out_json.insert("kill_cmd".to_string(), json!("wash down"));
 
         let _ = write!(
             out_text,
             "\n🌐 The wasmCloud dashboard is running at {}\n📜 Logs for the host are being written to {}",
             url, wasmcloud_log_path.to_string_lossy()
         );
-    }
-
-    if let Some(pid) = nats_pid {
-        let kill_cmd = format!(
-            "{} stop; kill {}",
-            wasmcloud_executable.to_string_lossy(),
-            pid,
-        );
-        out_json.insert("kill_cmd".to_string(), json!(kill_cmd));
-        let _ = write!(
-            out_text,
-            "\n\n🛑 To stop the wasmCloud host and the NATS server, run:\n{}",
-            kill_cmd
-        );
-    } else if cmd.detached {
-        let kill_cmd = format!("{} stop", wasmcloud_executable.to_string_lossy());
-        out_json.insert("kill_cmd".to_string(), json!(kill_cmd));
-        let _ = write!(
-            out_text,
-            "\n\n🛑 To stop the wasmCloud host, run:\n{}",
-            kill_cmd
-        );
+        let _ = write!(out_text, "\n\n🛑 To stop wasmCloud, run \"wash down\"");
     }
 
     Ok(CommandOutput::new(out_text, out_json))

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -13,11 +13,13 @@ use std::sync::{
 use tokio::fs::create_dir_all;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
-    process::{Child, Command},
+    process::Child,
 };
 
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
+use crate::down::stop_nats;
+use crate::down::stop_wasmcloud;
 use crate::util::{CommandOutput, OutputKind};
 use wash_lib::start::*;
 mod config;
@@ -253,7 +255,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     // Avoid downloading + starting NATS if the user already runs their own server. Ignore connect_only
     // if this server has a remote and credsfile as we have to start a leafnode in that scenario
     let nats_opts = cmd.nats_opts.clone();
-    let mut nats_process = if !cmd.nats_opts.connect_only
+    let nats_bin = if !cmd.nats_opts.connect_only
         || cmd.nats_opts.nats_remote_url.is_some() && cmd.nats_opts.nats_credsfile.is_some()
     {
         // Download NATS if not already installed
@@ -261,7 +263,8 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         let nats_binary = ensure_nats_server(&cmd.nats_opts.nats_version, &install_dir).await?;
 
         spinner.update_spinner_message(" Starting NATS ...".to_string());
-        Some(start_nats(&install_dir, &nats_binary, cmd.nats_opts.clone()).await?)
+        start_nats(&install_dir, &nats_binary, cmd.nats_opts.clone()).await?;
+        Some(nats_binary)
     } else {
         // If we can connect to NATS, return None as we aren't managing the child process.
         // Otherwise, exit with error since --nats-connect-only was specified
@@ -282,8 +285,8 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         ensure_wasmcloud(&cmd.wasmcloud_opts.wasmcloud_version, &install_dir).await?
     } else {
         // Ensure we clean up the NATS server if we can't start wasmCloud
-        if let Some(mut process) = nats_process {
-            process.kill().await?;
+        if nats_bin.is_some() {
+            stop_nats(install_dir).await?;
         }
         return Err(anyhow!("wasmCloud was not installed, exiting without downloading as --wasmcloud-start-only was set"));
     };
@@ -313,9 +316,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         Ok(child) => child,
         Err(e) => {
             // Ensure we clean up the NATS server if we can't start wasmCloud
-            if let Some(mut process) = nats_process {
-                process.kill().await?;
-            }
+            stop_nats(install_dir).await?;
             return Err(e);
         }
     };
@@ -330,14 +331,12 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         );
 
         // Terminate wasmCloud and NATS processes
-        stop_wasmcloud(wasmcloud_executable.clone()).await?;
-
-        if let Some(process) = nats_process.as_mut() {
-            match process.try_wait() {
-                Ok(Some(_)) => (),
-                _ => process.kill().await?,
-            }
+        let output = stop_wasmcloud(wasmcloud_executable.clone()).await?;
+        if !output.status.success() {
+            log::warn!("wasmCloud exited with a non-zero exit status, processes may need to be cleaned up manually")
         }
+
+        stop_nats(install_dir).await?;
 
         spinner.finish_and_clear();
     }
@@ -348,8 +347,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     out_json.insert("success".to_string(), json!(true));
     out_text.push_str("🛁 wash up completed successfully");
 
-    if let Some(Some(pid)) = nats_process.map(|child| child.id()) {
-        out_json.insert("nats_pid".to_string(), json!(pid));
+    if nats_bin.is_some() {
         out_json.insert("nats_url".to_string(), json!(nats_listen_address));
         let _ = write!(
             out_text,
@@ -450,25 +448,6 @@ async fn run_wasmcloud_interactive(
     if let Some(handle) = handle {
         handle.abort()
     };
-    Ok(())
-}
-
-/// Helper function to send wasmCloud the `stop` command and wait for it to clean up
-async fn stop_wasmcloud<P>(bin_path: P) -> Result<()>
-where
-    P: AsRef<Path>,
-{
-    if !Command::new(bin_path.as_ref())
-        .stdout(Stdio::piped())
-        .arg("stop")
-        .output()
-        .await?
-        .status
-        .success()
-    {
-        log::warn!("wasmCloud exited with a non-zero exit status, processes may need to be cleaned up manually")
-    }
-
     Ok(())
 }
 

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -347,21 +347,18 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     out_json.insert("success".to_string(), json!(true));
     out_text.push_str("🛁 wash up completed successfully");
 
-    if nats_bin.is_some() {
-        out_json.insert("nats_url".to_string(), json!(nats_listen_address));
-        let _ = write!(
-            out_text,
-            "\n🕸  NATS is running in the background at http://{}",
-            nats_listen_address
-        );
-    };
-
     if cmd.detached {
         let url = "http://localhost:4000";
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
         out_json.insert("kill_cmd".to_string(), json!("wash down"));
+        out_json.insert("nats_url".to_string(), json!(nats_listen_address));
 
+        let _ = write!(
+            out_text,
+            "\n🕸  NATS is running in the background at http://{}",
+            nats_listen_address
+        );
         let _ = write!(
             out_text,
             "\n🌐 The wasmCloud dashboard is running at {}\n📜 Logs for the host are being written to {}",

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,9 +1,6 @@
 mod common;
 use common::{output_to_string, test_dir_with_subfolder, wash};
-use std::{
-    fs::{read_to_string, remove_dir_all},
-    process::Command,
-};
+use std::fs::{read_to_string, remove_dir_all};
 
 #[test]
 fn integration_up_can_start_wasmcloud_and_actor() {
@@ -55,11 +52,11 @@ fn integration_up_can_start_wasmcloud_and_actor() {
         .contains("Actor wasmcloud.azurecr.io/echo:0.3.4 started on host N"));
 
     let kill_cmd = kill_cmd.to_string();
-    let (wasmcloud_stop, nats_kill) = kill_cmd.trim_matches('"').split_once(';').unwrap();
-    let (cmd, arg) = wasmcloud_stop.trim().split_once(' ').unwrap();
-    Command::new(cmd).arg(arg).output().unwrap();
-    let (cmd, arg) = nats_kill.trim().split_once(' ').unwrap();
-    Command::new(cmd).arg(arg).output().unwrap();
+    let (_wash, down) = kill_cmd.trim_matches('"').split_once(' ').unwrap();
+    wash()
+        .args(vec![down])
+        .output()
+        .expect("Could not spawn wash down process");
 
     remove_dir_all(dir).unwrap();
 }


### PR DESCRIPTION
Fixes #322 

This PR
1. Adds the command `wash down` which cleans up running wasmCloud hosts and NATS servers launched by `wash up`
2. Adds an additional output file for NATS which includes the PID of the `nats-server` process
3. Adds another option to `wash drain` which lets users easily clean up their wash downloads directory
4. Bumps the host version to `0.58.2`
5. Creates an alias for `detached` called `detach` because I kept typing it wrong and it made me angry
6. Simplifies some of the `up` code now that we don't need to output a complicated stop command

