### PR TITLE
Initial implementation of support for lattice artifacts in wash-lib (no CLI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5788cd6eb396656c504ad4b2b7fd384715a4c188c03490a9d68f75931a1b182"
+dependencies = [
+ "base64 0.13.0",
+ "base64-url",
+ "bytes",
+ "futures 0.3.24",
+ "http",
+ "itertools",
+ "itoa",
+ "lazy_static",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.6.2",
+ "rustls-pemfile 0.3.0",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "subslice",
+ "time 0.3.14",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.4",
+ "tracing",
+ "url 2.3.0",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,7 +3999,7 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
- "async-nats",
+ "async-nats 0.18.0",
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
@@ -4021,15 +4055,17 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-compression",
+ "async-nats 0.21.0",
  "claims",
  "command-group",
  "config",
  "futures 0.3.24",
  "log",
+ "nkeys",
  "reqwest",
  "semver",
  "serde",
@@ -4136,7 +4172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84264f6ad19b3ed5802bbd4abfda11736a3b575d2a12f66d707fecec88c2efaf"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.18.0",
  "async-trait",
  "atty",
  "base64 0.13.0",
@@ -4178,7 +4214,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5cfe6639a35e90871dee70673a11d70726ce2a17eb8114c07962df75f3ace"
 dependencies = [
- "async-nats",
+ "async-nats 0.18.0",
  "cloudevents-sdk",
  "futures 0.3.24",
  "rmp-serde",
@@ -4213,7 +4249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5489a3747d59c4f03f595fad4a10d544d313701a9406aee92c2619dddbfb9a59"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.18.0",
  "async-trait",
  "base64 0.13.0",
  "futures 0.3.24",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"
@@ -19,12 +19,14 @@ start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
 
 [dependencies]
+async-nats = "0.21.0"
 command-group = { version = "1.0.8", features = ["with-tokio"] }
 anyhow = "1.0.58"
 futures = "0.3"
 tokio = {version = "1", default-features = false, features = ["process"]}
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"]}
 async-compression = { version = "0.3", default-features = false, features = ["tokio", "gzip"] }
+nkeys = "0.2.0"
 tokio-tar = "0.3"
 tokio-stream = "0.1"
 log = "0.4"

--- a/crates/wash-lib/src/lattice_artifacts/mod.rs
+++ b/crates/wash-lib/src/lattice_artifacts/mod.rs
@@ -1,0 +1,95 @@
+//! The `lattice_artifacts` module contains functionality relating to reading and writing
+//! actor module bytes to and from a NATS object store corresponding to a lattice.
+//!
+use anyhow::{anyhow, Result};
+use async_nats::jetstream::object_store::{Config, ObjectStore};
+use tokio::io::AsyncReadExt;
+
+fn bucket_name(lattice_id: &str) -> String {
+    format!("ARTIFACT_{}", lattice_id)
+}
+
+/// Creates a new artifact store named ARTIFACT_{lattice_id} using the default
+/// options (file-backed with no limitations) or, if one already exists, returns
+/// a reference to that object store.
+pub async fn create_or_reuse_store(
+    nc: async_nats::Client,
+    lattice_id: &str,
+) -> Result<ObjectStore> {
+    let js = async_nats::jetstream::new(nc);
+    let bucket = bucket_name(lattice_id);
+
+    match js.get_object_store(&bucket).await {
+        Ok(os) => Ok(os),
+        Err(_) => js
+            .create_object_store(Config {
+                bucket,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow!("Failed to create store: {}", e)),
+    }
+}
+
+/// Writes an arbitrary set of bytes (which should correspond to an actor's raw .wasm binary) to the
+/// object store
+pub async fn write_to_store(store: ObjectStore, public_key: &str, bytes: Vec<u8>) -> Result<()> {
+    store
+        .put(public_key, &mut bytes.as_slice())
+        .await
+        .map_err(|e| anyhow!("Failed to write to artifact store: {}", e))
+        .map(|_| ())
+}
+
+/// Removes an item from the artifact store
+pub async fn remove_item_from_store(store: ObjectStore, public_key: &str) -> Result<()> {
+    store
+        .delete(public_key)
+        .await
+        .map_err(|e| anyhow!("Failed to delete item from artifact store: {}", e))
+}
+
+pub async fn get_item_from_store(store: ObjectStore, public_key: &str) -> Result<Vec<u8>> {
+    let mut object = store
+        .get(public_key)
+        .await
+        .map_err(|e| anyhow!("Failed to retrieve item from artifact store: {}", e))?;
+
+    let mut result = Vec::new();
+    object.read_to_end(&mut result).await?;    
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use async_nats::jetstream;
+
+    use super::{
+        create_or_reuse_store, get_item_from_store, remove_item_from_store, write_to_store,
+    };
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_round_trip() {
+        const PK: &str = "Mxxxxx";
+        const LATTICE: &str = "testlattice";
+        const BUCKET: &str = "ARTIFACT_testlattice";
+
+        let nc = async_nats::connect("0.0.0.0:4222").await.unwrap();
+        let _ = create_or_reuse_store(nc.clone(), LATTICE).await.unwrap();
+        let store = create_or_reuse_store(nc.clone(), LATTICE).await.unwrap();
+
+        write_to_store(store.clone(), PK, vec![1, 2, 3, 4, 6])
+            .await
+            .unwrap();
+        let resbytes = get_item_from_store(store.clone(), PK).await.unwrap();
+
+        remove_item_from_store(store.clone(), PK).await.unwrap();
+
+        let js = jetstream::new(nc);
+        js.delete_object_store(BUCKET).await.unwrap();
+
+        assert_eq!(vec![1, 2, 3, 4, 6], resbytes);
+    }
+}

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -8,3 +8,6 @@ pub mod start;
 
 #[cfg(feature = "parser")]
 pub mod parser;
+
+pub mod lattice_artifacts;
+pub mod natsclient;

--- a/crates/wash-lib/src/natsclient/mod.rs
+++ b/crates/wash-lib/src/natsclient/mod.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use std::{fs::File, io::Read, path::PathBuf};
+
+pub async fn nats_client_from_opts(
+    host: &str,
+    port: &str,
+    jwt: Option<String>,
+    seed: Option<String>,
+    credsfile: Option<PathBuf>,
+) -> Result<async_nats::Client> {
+    let nats_url = format!("{}:{}", host, port);
+    use async_nats::ConnectOptions;
+
+    let nc = if let Some(jwt_file) = jwt {
+        let jwt_contents = extract_arg_value(&jwt_file)?;
+        let kp = std::sync::Arc::new(if let Some(seed) = seed {
+            nkeys::KeyPair::from_seed(&extract_arg_value(&seed)?)?
+        } else {
+            nkeys::KeyPair::new_user()
+        });
+
+        // You must provide the JWT via a closure
+        async_nats::ConnectOptions::with_jwt(jwt_contents, move |nonce| {
+            let key_pair = kp.clone();
+            async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+        })
+        .connect(&nats_url)
+        .await?
+    } else if let Some(credsfile_path) = credsfile {
+        ConnectOptions::with_credentials_file(credsfile_path)
+            .await?
+            .connect(&nats_url)
+            .await?
+    } else {
+        async_nats::connect(&nats_url).await?
+    };
+    Ok(nc)
+}
+
+fn extract_arg_value(arg: &str) -> Result<String> {
+    match File::open(arg) {
+        Ok(mut f) => {
+            let mut value = String::new();
+            f.read_to_string(&mut value)?;
+            Ok(value)
+        }
+        Err(_) => Ok(arg.to_string()),
+    }
+}

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1107,7 +1107,7 @@ async fn ctl_client_from_opts(
     let auction_timeout_ms = auction_timeout_ms.unwrap_or(opts.timeout_ms);
 
     let nc =
-        crate::util::nats_client_from_opts(&ctl_host, &ctl_port, ctl_jwt, ctl_seed, ctl_credsfile)
+        wash_lib::natsclient::nats_client_from_opts(&ctl_host, &ctl_port, ctl_jwt, ctl_seed, ctl_credsfile)
             .await?;
 
     let ctl_client = if let Ok(topic_prefix) = std::env::var("WASMCLOUD_CTL_TOPIC_PREFIX") {

--- a/src/util.rs
+++ b/src/util.rs
@@ -228,41 +228,6 @@ fn empty_table_style() -> TableStyle {
     }
 }
 
-pub(crate) async fn nats_client_from_opts(
-    host: &str,
-    port: &str,
-    jwt: Option<String>,
-    seed: Option<String>,
-    credsfile: Option<PathBuf>,
-) -> Result<async_nats::Client> {
-    let nats_url = format!("{}:{}", host, port);
-    use async_nats::ConnectOptions;
-
-    let nc = if let Some(jwt_file) = jwt {
-        let jwt_contents = extract_arg_value(&jwt_file)?;
-        let kp = std::sync::Arc::new(if let Some(seed) = seed {
-            nkeys::KeyPair::from_seed(&extract_arg_value(&seed)?)?
-        } else {
-            nkeys::KeyPair::new_user()
-        });
-
-        // You must provide the JWT via a closure
-        async_nats::ConnectOptions::with_jwt(jwt_contents, move |nonce| {
-            let key_pair = kp.clone();
-            async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
-        })
-        .connect(&nats_url)
-        .await?
-    } else if let Some(credsfile_path) = credsfile {
-        ConnectOptions::with_credentials_file(credsfile_path)
-            .await?
-            .connect(&nats_url)
-            .await?
-    } else {
-        async_nats::connect(&nats_url).await?
-    };
-    Ok(nc)
-}
 
 pub(crate) const OCI_CACHE_DIR: &str = "wasmcloud_ocicache";
 


### PR DESCRIPTION
This adds a `lattice_artifacts` module to wash lib, allowing CLI tools like `wash` to be able to read/write artifacts to the lattice artifact cache. See [this PR](https://github.com/wasmCloud/wasmcloud-otp/pull/495) for the corresponding wasmCloud host implementation.

⚠️ The wash binary will not compile here because wash lib uses a version of async nats that is significantly newer than what wash currently has, so there will be a dependency tree failure during compilation. Leaving this PR as a draft until the wash main binary can be upgraded to use a version of async nats _greater than_ **0.21.0** because we're also awaiting a fix from NATS in the Rust client.

Recap:
* Once fix is available, upgrade wash-lib to newest async nats
* Once fix is available downstream from wasmbus-rpc, upgrade `wash` binary to use that
* Build will compile, can un-draft this PR