### PR TITLE
Fix credentials path format for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,6 +4020,7 @@ dependencies = [
  "claims",
  "command-group",
  "config",
+ "dirs",
  "futures 0.3.25",
  "log",
  "reqwest",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -34,5 +34,6 @@ serde = { version = "1", features = ["derive"], optional = true}
 serde_json = {version = "1.0.82", optional = true}
 
 [dev-dependencies]
+dirs = "4.0"
 tokio = {version = "1", features = ["full"]}
 claims = "0.7.1"

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -498,9 +498,9 @@ mod test {
         credsfile.read_to_string(&mut contents).await?;
 
         assert_eq!(contents, format!("\njetstream {{\n    domain={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", "connect.ngs.global", creds.to_string_lossy()));
-        // A simple check to ensure we are properly escaping quotes, remember \\\\ == \\ after escape
+        // A simple check to ensure we are properly escaping quotes, this is unescaped and checks for "\\"
         #[cfg(target_family = "windows")]
-        assert!(creds.to_string_lossy().contains("\\\\"));
+        assert!(creds.to_string_lossy().contains("\\"));
 
         let _ = remove_dir_all(install_dir).await;
         Ok(())

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -278,13 +278,13 @@ leafnodes {{
     remotes = [
         {{
             url: "{}"
-            credentials: "{}"
+            credentials: {:?}
         }}
     ]
 }}
                 "#,
                 url,
-                creds.display()
+                creds.to_string_lossy()
             ),
             _ => "".to_owned(),
         };
@@ -381,7 +381,7 @@ mod test {
     use std::{env::temp_dir, path::PathBuf};
     use tokio::{
         fs::{create_dir_all, remove_dir_all},
-        time::sleep,
+        io::AsyncReadExt,
     };
 
     const NATS_SERVER_VERSION: &str = "v2.8.4";
@@ -473,8 +473,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn can_start_nats_with_credentials() -> Result<()> {
-        let install_dir = temp_dir().join("can_start_nats_with_credentials");
+    async fn can_write_properly_formed_credsfile() -> Result<()> {
+        let install_dir = temp_dir().join("can_write_properly_formed_credsfile");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
         assert!(!is_nats_installed(&install_dir).await);
@@ -482,7 +482,7 @@ mod test {
         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
         assert!(res.is_ok());
 
-        let creds = PathBuf::from("./nats-creds.creds");
+        let creds = PathBuf::from(dirs::home_dir().unwrap().join("nats.creds"));
         let config: NatsConfig = NatsConfig::new_leaf(
             "127.0.0.1",
             4243,
@@ -491,22 +491,17 @@ mod test {
             creds.clone(),
         );
 
-        println!("creds: {:?}", creds);
-        println!("creds: {}", creds.display());
-        println!("creds: {:?}", creds.canonicalize());
+        config.write_to_path(creds.clone()).await?;
 
-        let nats_server = start_nats_server(
-            &install_dir.join(NATS_SERVER_BINARY),
-            std::process::Stdio::piped(),
-            config.clone(),
-        )
-        .await;
-        assert!(nats_server.is_ok());
-        let mut server_process = nats_server.unwrap();
-        sleep(std::time::Duration::from_secs(2)).await;
-        println!("output: {:?}", server_process.stdout);
+        let mut credsfile = tokio::fs::File::open(creds).await?;
+        let mut contents = String::new();
+        credsfile.read_to_string(&mut contents).await?;
 
-        server_process.kill().await?;
+        #[cfg(target_family = "unix")]
+        assert_eq!(contents, "\njetstream {\n    domain=core\n}\n\nleafnodes {\n    remotes = [\n        {\n            url: \"connect.ngs.global\"\n            credentials: \"/Users/brooks/nats.creds\"\n        }\n    ]\n}\n                \n");
+        #[cfg(target_family = "windows")]
+        assert_eq!(contents, "\njetstream {\n    domain=core\n}\n\nleafnodes {\n    remotes = [\n        {\n            url: \"connect.ngs.global\"\n            credentials: \"C:\\\\Users\\\\brooks\\\\nats.creds\"\n        }\n    ]\n}\n                \n");
+
         let _ = remove_dir_all(install_dir).await;
         Ok(())
     }

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -493,14 +493,14 @@ mod test {
 
         config.write_to_path(creds.clone()).await?;
 
-        let mut credsfile = tokio::fs::File::open(creds).await?;
+        let mut credsfile = tokio::fs::File::open(creds.clone()).await?;
         let mut contents = String::new();
         credsfile.read_to_string(&mut contents).await?;
 
-        #[cfg(target_family = "unix")]
-        assert_eq!(contents, "\njetstream {\n    domain=core\n}\n\nleafnodes {\n    remotes = [\n        {\n            url: \"connect.ngs.global\"\n            credentials: \"/Users/brooks/nats.creds\"\n        }\n    ]\n}\n                \n");
+        assert_eq!(contents, format!("\njetstream {{\n    domain={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", "connect.ngs.global", creds.to_string_lossy()));
+        // A simple check to ensure we are properly escaping quotes, remember \\\\ == \\ after escape
         #[cfg(target_family = "windows")]
-        assert_eq!(contents, "\njetstream {\n    domain=core\n}\n\nleafnodes {\n    remotes = [\n        {\n            url: \"connect.ngs.global\"\n            credentials: \"C:\\\\Users\\\\brooks\\\\nats.creds\"\n        }\n    ]\n}\n                \n");
+        assert!(creds.to_string_lossy().contains("\\\\"));
 
         let _ = remove_dir_all(install_dir).await;
         Ok(())

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -284,7 +284,7 @@ leafnodes {{
 }}
                 "#,
                 url,
-                creds.to_string_lossy()
+                creds.display()
             ),
             _ => "".to_owned(),
         };
@@ -378,8 +378,11 @@ mod test {
         ensure_nats_server, is_nats_installed, start_nats_server, NatsConfig, NATS_SERVER_BINARY,
     };
     use anyhow::Result;
-    use std::env::temp_dir;
-    use tokio::fs::{create_dir_all, remove_dir_all};
+    use std::{env::temp_dir, path::PathBuf};
+    use tokio::{
+        fs::{create_dir_all, remove_dir_all},
+        time::sleep,
+    };
 
     const NATS_SERVER_VERSION: &str = "v2.8.4";
 
@@ -466,6 +469,45 @@ mod test {
         nats_one.unwrap().kill().await?;
         let _ = remove_dir_all(install_dir).await;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_start_nats_with_credentials() -> Result<()> {
+        let install_dir = temp_dir().join("can_start_nats_with_credentials");
+        let _ = remove_dir_all(&install_dir).await;
+        create_dir_all(&install_dir).await?;
+        assert!(!is_nats_installed(&install_dir).await);
+
+        let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
+        assert!(res.is_ok());
+
+        let creds = PathBuf::from("./nats-creds.creds");
+        let config: NatsConfig = NatsConfig::new_leaf(
+            "127.0.0.1",
+            4243,
+            None,
+            "connect.ngs.global".to_string(),
+            creds.clone(),
+        );
+
+        println!("creds: {:?}", creds);
+        println!("creds: {}", creds.display());
+        println!("creds: {:?}", creds.canonicalize());
+
+        let nats_server = start_nats_server(
+            &install_dir.join(NATS_SERVER_BINARY),
+            std::process::Stdio::piped(),
+            config.clone(),
+        )
+        .await;
+        assert!(nats_server.is_ok());
+        let mut server_process = nats_server.unwrap();
+        sleep(std::time::Duration::from_secs(2)).await;
+        println!("output: {:?}", server_process.stdout);
+
+        server_process.kill().await?;
+        let _ = remove_dir_all(install_dir).await;
         Ok(())
     }
 }

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,18 +1,27 @@
 mod common;
-use cmd_lib::{run_fun, spawn_with_output};
-use common::test_dir_with_subfolder;
+use common::{output_to_string, test_dir_with_subfolder, wash};
 use std::{
     fs::{read_to_string, remove_dir_all},
     process::Command,
 };
 
 #[test]
-fn integration_up_can_start_wasmcloud_and_actor() -> Result<(), anyhow::Error> {
+fn integration_up_can_start_wasmcloud_and_actor() {
     let dir = test_dir_with_subfolder("can_start_wasmcloud");
-    let wash = env!("CARGO_BIN_EXE_wash");
+    let path = dir.join("washup.log");
+    let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
-    let mut proc = spawn_with_output!( $wash up --nats-port 5893 -o json --detached )?;
-    let out = proc.wait_with_output()?;
+    let mut up_cmd = wash()
+        .args(&["up", "--nats-port", "5893", "-o", "json", "--detached"])
+        .stdout(stdout)
+        .spawn()
+        .expect("Could not spawn wash up process");
+
+    let status = up_cmd.wait().expect("up command failed to complete");
+
+    assert!(status.success());
+    let out = read_to_string(&path).expect("could not read output of wash up");
+
     let (kill_cmd, wasmcloud_log) = match serde_json::from_str::<serde_json::Value>(&out) {
         Ok(v) => (v["kill_cmd"].to_owned(), v["wasmcloud_log"].to_owned()),
         Err(_e) => panic!("Unable to parse kill cmd from wash up output"),
@@ -29,19 +38,28 @@ fn integration_up_can_start_wasmcloud_and_actor() -> Result<(), anyhow::Error> {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
-    let out = run_fun!( $wash ctl start actor wasmcloud.azurecr.io/echo:0.3.4 --ctl-port 5893 )
-        .expect("start echo failed");
-    assert!(out.contains("Actor wasmcloud.azurecr.io/echo:0.3.4 started on host N"));
+    let start_echo = wash()
+        .args(&[
+            "ctl",
+            "start",
+            "actor",
+            "wasmcloud.azurecr.io/echo:0.3.4",
+            "--ctl-port",
+            "5893",
+        ])
+        .output()
+        .expect("could not start echo actor on new host");
+
+    assert!(output_to_string(start_echo)
+        .expect("could not retrieve output from echo start")
+        .contains("Actor wasmcloud.azurecr.io/echo:0.3.4 started on host N"));
 
     let kill_cmd = kill_cmd.to_string();
     let (wasmcloud_stop, nats_kill) = kill_cmd.trim_matches('"').split_once(';').unwrap();
-
-    // run_cmd doesn't work as well for commands as strings, so leave these as process::command for now
     let (cmd, arg) = wasmcloud_stop.trim().split_once(' ').unwrap();
     Command::new(cmd).arg(arg).output().unwrap();
     let (cmd, arg) = nats_kill.trim().split_once(' ').unwrap();
     Command::new(cmd).arg(arg).output().unwrap();
 
     remove_dir_all(dir).unwrap();
-    Ok(())
 }


### PR DESCRIPTION
This PR fixes a small issue with NATS configs that require backslashes in Windows paths to be properly escaped with a backslash. 

For example, `C:\Users\tmp\nats.creds` is invalid, NATS is expecting `C:\\Users\\tmp\\nats.creds`.

So you may be wondering, how does this PR fix the issue?
```
-            credentials: "{}"
+           credentials: {:?}
```

Essentially here, instead of quoting the string path that comes out of `path.to_string_lossy()`, we instead use the debug output. This, on unix systems, doesn't change anything other than adding quotes around the edges (hence removing the quotes) and on Windows this escapes the backslashes. I wrote a test to verify this functionality and to ensure we're writing out credsfiles in the proper format. I don't love that it contains newlines and very specific space counts, and would be happy to consider an alternative if desired.