### PR TITLE
pass env vars when checking for running host

### DIFF
--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -244,7 +244,12 @@ where
     }
 
     #[cfg(target_family = "unix")]
-    if let Ok(output) = Command::new(bin_path.as_ref()).arg("pid").output().await {
+    if let Ok(output) = Command::new(bin_path.as_ref())
+        .envs(&env_vars)
+        .arg("pid")
+        .output()
+        .await
+    {
         // Stderr will include :nodedown if no other host is running, otherwise
         // stdout will contain the PID
         if !String::from_utf8_lossy(&output.stderr).contains(":nodedown") {


### PR DESCRIPTION
Before this change, attempting to start a wasmcloud host with wash-lib on a system where one or more wasmcloud hosts are already running would fail. Now wash-lib can be successful, so long as env vars like `WASMCLOUD_DASHBOARD_PORT` and `RELEASE_NODE` are set to unique values

Signed-off-by: Connor Smith <connor@cosmonic.com>