### PR TITLE
Converted OCI URLs to lowercase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.14.0-alpha.1"
+version = "0.14.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.14.0-alpha.1"
+version = "0.14.0-alpha.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -138,13 +138,14 @@ pub(crate) async fn handle_pull(
     cmd: PullCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
-    let image: Reference = cmd.url.parse()?;
+    let artifact_url = cmd.url.to_ascii_lowercase();
+    let image: Reference = artifact_url.parse()?;
 
     let spinner = Spinner::new(&output_kind)?;
     spinner.update_spinner_message(format!(" Downloading {} ...", image.whole()));
 
     let artifact = pull_artifact(
-        cmd.url,
+        artifact_url,
         cmd.digest,
         cmd.allow_latest,
         cmd.opts.user,
@@ -333,15 +334,16 @@ pub(crate) async fn handle_push(
     cmd: PushCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
-    if cmd.url.starts_with("localhost:") && !cmd.opts.insecure {
+    let artifact_url = cmd.url.to_ascii_lowercase();
+    if artifact_url.starts_with("localhost:") && !cmd.opts.insecure {
         warn!(" Unless an SSL certificate has been installed, pushing to localhost without the --insecure option will fail")
     }
 
     let spinner = Spinner::new(&output_kind)?;
-    spinner.update_spinner_message(format!(" Pushing {} to {} ...", cmd.artifact, cmd.url));
+    spinner.update_spinner_message(format!(" Pushing {} to {} ...", cmd.artifact, artifact_url));
 
     push_artifact(
-        cmd.url.clone(),
+        artifact_url.clone(),
         cmd.artifact,
         cmd.config,
         cmd.allow_latest,
@@ -359,7 +361,7 @@ pub(crate) async fn handle_push(
     Ok(CommandOutput::new(
         format!(
             "{} Successfully validated and pushed to {}",
-            SHOWER_EMOJI, cmd.url
+            SHOWER_EMOJI, artifact_url
         ),
         map,
     ))


### PR DESCRIPTION
Fixes #323 

This PR, as discussed in the above issue, converts supplied OCI URLs to lowercase before parsing them or attempting to push/pull an artifact to/from them. The OCI spec does not allow for uppercase characters, so this is a simple patch that ensures that URLs that contain capital letters (like GitHub URLs) 