### PR TITLE
chore(*): Fixes a bunch of clippy lints

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -245,13 +245,13 @@ mod test {
 
     #[test]
     fn test_build_comprehensive() {
-        let cmd: BuildCommand = Parser::try_parse_from(&["build", "--push"]).unwrap();
+        let cmd: BuildCommand = Parser::try_parse_from(["build", "--push"]).unwrap();
         assert!(cmd.push);
 
-        let cmd: BuildCommand = Parser::try_parse_from(&["build", "--no-sign"]).unwrap();
+        let cmd: BuildCommand = Parser::try_parse_from(["build", "--no-sign"]).unwrap();
         assert!(cmd.no_sign);
 
-        let cmd: BuildCommand = Parser::try_parse_from(&["build"]).unwrap();
+        let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
         assert!(!cmd.push);
         assert!(!cmd.no_sign);
     }

--- a/src/call.rs
+++ b/src/call.rs
@@ -333,7 +333,7 @@ mod test {
 
     #[test]
     fn test_rpc_comprehensive() -> Result<()> {
-        let call_all: Cmd = Parser::try_parse_from(&[
+        let call_all: Cmd = Parser::try_parse_from([
             "call",
             "--test",
             "--data",

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -925,7 +925,7 @@ mod test {
     /// Enumerates all options and flags of the `claims inspect` command
     /// to ensure command line arguments do not change between versions
     fn test_claims_inspect_comprehensive() {
-        let cmd: Cmd = Parser::try_parse_from(&[
+        let cmd: Cmd = Parser::try_parse_from([
             "claims",
             "inspect",
             SUBSCRIBER_OCI,
@@ -968,7 +968,7 @@ mod test {
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
 
-        let short_cmd: Cmd = Parser::try_parse_from(&[
+        let short_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "inspect",
             SUBSCRIBER_OCI,
@@ -1019,7 +1019,7 @@ mod test {
         const LOCAL_WASM: &str = "./myactor.wasm";
         const ISSUER_KEY: &str = "SAAOBYD6BLELXSNN4S3TXUM7STGPB3A5HYU3D5T7XA4WHGVQBDBD4LJPOM";
         const SUBJECT_KEY: &str = "SMAMA4ABHIJUYQR54BDFHEMXIIGQATUXK6RYU6XLTFHDNCRVWT4KSDDSVE";
-        let long_cmd: Cmd = Parser::try_parse_from(&[
+        let long_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "sign",
             LOCAL_WASM,
@@ -1089,7 +1089,7 @@ mod test {
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
-        let short_cmd: Cmd = Parser::try_parse_from(&[
+        let short_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "sign",
             LOCAL_WASM,
@@ -1172,7 +1172,7 @@ mod test {
         const ACTOR_KEY: &str = "SMAA2XB7UP7FZLPLO27NJB65PKYISNQAH7PZ6PJUHR6CUARVANXZ4OTZOU";
         const PROVIDER_KEY: &str = "SVAKIVYER6D2LZS7QJFOU7LQYLRAMJ5DZE4B7BJHX6QFJIY24KN43JZGN4";
 
-        let account_cmd: Cmd = Parser::try_parse_from(&[
+        let account_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "token",
             "account",
@@ -1221,7 +1221,7 @@ mod test {
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
-        let actor_cmd: Cmd = Parser::try_parse_from(&[
+        let actor_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "token",
             "actor",
@@ -1306,7 +1306,7 @@ mod test {
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
-        let operator_cmd: Cmd = Parser::try_parse_from(&[
+        let operator_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "token",
             "operator",
@@ -1351,7 +1351,7 @@ mod test {
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
-        let provider_cmd: Cmd = Parser::try_parse_from(&[
+        let provider_cmd: Cmd = Parser::try_parse_from([
             "claims",
             "token",
             "provider",

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1164,7 +1164,7 @@ mod test {
     /// change between versions. This test will fail if any subcommand of `wash ctl`
     /// changes syntax, ordering of required elements, or flags.
     fn test_ctl_comprehensive() -> Result<()> {
-        let start_actor_all: Cmd = Parser::try_parse_from(&[
+        let start_actor_all: Cmd = Parser::try_parse_from([
             "ctl",
             "start",
             "actor",
@@ -1203,7 +1203,7 @@ mod test {
             }
             cmd => panic!("ctl start actor constructed incorrect command {:?}", cmd),
         }
-        let start_provider_all: Cmd = Parser::try_parse_from(&[
+        let start_provider_all: Cmd = Parser::try_parse_from([
             "ctl",
             "start",
             "provider",
@@ -1251,7 +1251,7 @@ mod test {
             }
             cmd => panic!("ctl start provider constructed incorrect command {:?}", cmd),
         }
-        let stop_actor_all: Cmd = Parser::try_parse_from(&[
+        let stop_actor_all: Cmd = Parser::try_parse_from([
             "ctl",
             "stop",
             "actor",
@@ -1287,7 +1287,7 @@ mod test {
             }
             cmd => panic!("ctl stop actor constructed incorrect command {:?}", cmd),
         }
-        let stop_provider_all: Cmd = Parser::try_parse_from(&[
+        let stop_provider_all: Cmd = Parser::try_parse_from([
             "ctl",
             "stop",
             "provider",
@@ -1325,7 +1325,7 @@ mod test {
             }
             cmd => panic!("ctl stop actor constructed incorrect command {:?}", cmd),
         }
-        let get_hosts_all: Cmd = Parser::try_parse_from(&[
+        let get_hosts_all: Cmd = Parser::try_parse_from([
             "ctl",
             "get",
             "hosts",
@@ -1347,7 +1347,7 @@ mod test {
             }
             cmd => panic!("ctl get hosts constructed incorrect command {:?}", cmd),
         }
-        let get_host_inventory_all: Cmd = Parser::try_parse_from(&[
+        let get_host_inventory_all: Cmd = Parser::try_parse_from([
             "ctl",
             "get",
             "inventory",
@@ -1374,7 +1374,7 @@ mod test {
             }
             cmd => panic!("ctl get inventory constructed incorrect command {:?}", cmd),
         }
-        let get_claims_all: Cmd = Parser::try_parse_from(&[
+        let get_claims_all: Cmd = Parser::try_parse_from([
             "ctl",
             "get",
             "claims",
@@ -1396,7 +1396,7 @@ mod test {
             }
             cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),
         }
-        let link_all: Cmd = Parser::try_parse_from(&[
+        let link_all: Cmd = Parser::try_parse_from([
             "ctl",
             "link",
             "put",
@@ -1436,7 +1436,7 @@ mod test {
             }
             cmd => panic!("ctl link put constructed incorrect command {:?}", cmd),
         }
-        let update_all: Cmd = Parser::try_parse_from(&[
+        let update_all: Cmd = Parser::try_parse_from([
             "ctl",
             "update",
             "actor",
@@ -1470,7 +1470,7 @@ mod test {
             cmd => panic!("ctl get claims constructed incorrect command {:?}", cmd),
         }
 
-        let scale_actor_all: Cmd = Parser::try_parse_from(&[
+        let scale_actor_all: Cmd = Parser::try_parse_from([
             "ctl",
             "scale",
             "actor",

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -434,7 +434,7 @@ mod test {
     // Enumerates all options of ctx subcommands to ensure
     // changes are not made to the ctx API
     fn test_ctx_comprehensive() {
-        let cmd: Cmd = Parser::try_parse_from(&[
+        let cmd: Cmd = Parser::try_parse_from([
             "ctx",
             "new",
             "my_name",
@@ -453,7 +453,7 @@ mod test {
             _ => panic!("ctx constructed incorrect command"),
         }
 
-        let cmd: Cmd = Parser::try_parse_from(&[
+        let cmd: Cmd = Parser::try_parse_from([
             "ctx",
             "edit",
             "my_context",
@@ -473,7 +473,7 @@ mod test {
         }
 
         let cmd: Cmd =
-            Parser::try_parse_from(&["ctx", "del", "my_context", "--directory", "./contexts"])
+            Parser::try_parse_from(["ctx", "del", "my_context", "--directory", "./contexts"])
                 .unwrap();
         match cmd.cmd {
             CtxCommand::Del(cmd) => {
@@ -484,7 +484,7 @@ mod test {
         }
 
         let cmd: Cmd =
-            Parser::try_parse_from(&["ctx", "list", "--directory", "./contexts"]).unwrap();
+            Parser::try_parse_from(["ctx", "list", "--directory", "./contexts"]).unwrap();
         match cmd.cmd {
             CtxCommand::List(cmd) => {
                 assert_eq!(cmd.directory.unwrap(), PathBuf::from("./contexts"));
@@ -493,7 +493,7 @@ mod test {
         }
 
         let cmd: Cmd =
-            Parser::try_parse_from(&["ctx", "default", "host_config", "--directory", "./contexts"])
+            Parser::try_parse_from(["ctx", "default", "host_config", "--directory", "./contexts"])
                 .unwrap();
         match cmd.cmd {
             CtxCommand::Default(cmd) => {

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -31,22 +31,22 @@ mod test {
     // Enumerates all options of drain subcommands to ensure
     // changes are not made to the drain API
     fn test_drain_comprehensive() {
-        let all: Cmd = Parser::try_parse_from(&["drain", "all"]).unwrap();
+        let all: Cmd = Parser::try_parse_from(["drain", "all"]).unwrap();
         match all.drain {
             Drain::All => {}
             _ => panic!("drain constructed incorrect command"),
         }
-        let lib: Cmd = Parser::try_parse_from(&["drain", "lib"]).unwrap();
+        let lib: Cmd = Parser::try_parse_from(["drain", "lib"]).unwrap();
         match lib.drain {
             Drain::Lib => {}
             _ => panic!("drain constructed incorrect command"),
         }
-        let oci: Cmd = Parser::try_parse_from(&["drain", "oci"]).unwrap();
+        let oci: Cmd = Parser::try_parse_from(["drain", "oci"]).unwrap();
         match oci.drain {
             Drain::Oci => {}
             _ => panic!("drain constructed incorrect command"),
         }
-        let smithy: Cmd = Parser::try_parse_from(&["drain", "smithy"]).unwrap();
+        let smithy: Cmd = Parser::try_parse_from(["drain", "smithy"]).unwrap();
         match smithy.drain {
             Drain::Smithy => {}
             _ => panic!("drain constructed incorrect command"),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -372,7 +372,7 @@ mod tests {
         ];
 
         key_gen_types.iter().for_each(|cmd| {
-            let gen_cmd: Cmd = clap::Parser::try_parse_from(&["keys", "gen", cmd]).unwrap();
+            let gen_cmd: Cmd = clap::Parser::try_parse_from(["keys", "gen", cmd]).unwrap();
             match gen_cmd.keys {
                 KeysCliCommand::GenCommand { keytype } => {
                     use KeyPairType::*;
@@ -391,7 +391,7 @@ mod tests {
         });
 
         key_gen_types.iter().for_each(|cmd| {
-            let gen_cmd: Cmd = clap::Parser::try_parse_from(&["keys", "gen", cmd]).unwrap();
+            let gen_cmd: Cmd = clap::Parser::try_parse_from(["keys", "gen", cmd]).unwrap();
             match gen_cmd.keys {
                 KeysCliCommand::GenCommand { keytype } => {
                     use KeyPairType::*;
@@ -416,8 +416,7 @@ mod tests {
         const KEYPATH: &str = "./tests/fixtures";
 
         let gen_basic: Cmd =
-            clap::Parser::try_parse_from(&["keys", "get", KEYNAME, "--directory", KEYPATH])
-                .unwrap();
+            clap::Parser::try_parse_from(["keys", "get", KEYNAME, "--directory", KEYPATH]).unwrap();
         match gen_basic.keys {
             KeysCliCommand::GetCommand { keyname, .. } => assert_eq!(keyname, KEYNAME),
             other_cmd => panic!("keys get generated other command {:?}", other_cmd),
@@ -433,7 +432,7 @@ mod tests {
         const KEYNAME: &str = "get_comprehensive_test.nk";
 
         let get_all_flags: Cmd =
-            clap::Parser::try_parse_from(&["keys", "get", KEYNAME, "-d", KEYPATH]).unwrap();
+            clap::Parser::try_parse_from(["keys", "get", KEYNAME, "-d", KEYPATH]).unwrap();
         match get_all_flags.keys {
             KeysCliCommand::GetCommand { keyname, directory } => {
                 assert_eq!(keyname, KEYNAME);
@@ -451,14 +450,14 @@ mod tests {
         const KEYPATH: &str = "./";
 
         let list_basic: Cmd =
-            clap::Parser::try_parse_from(&["keys", "list", "-d", KEYPATH]).unwrap();
+            clap::Parser::try_parse_from(["keys", "list", "-d", KEYPATH]).unwrap();
         match list_basic.keys {
             KeysCliCommand::ListCommand { .. } => (),
             other_cmd => panic!("keys get generated other command {:?}", other_cmd),
         }
 
         let list_all_flags: Cmd =
-            clap::Parser::try_parse_from(&["keys", "list", "-d", KEYPATH]).unwrap();
+            clap::Parser::try_parse_from(["keys", "list", "-d", KEYPATH]).unwrap();
         match list_all_flags.keys {
             KeysCliCommand::ListCommand { directory } => {
                 assert_eq!(directory, Some(PathBuf::from(KEYPATH)));

--- a/src/par.rs
+++ b/src/par.rs
@@ -429,7 +429,7 @@ mod test {
     fn test_par_create_comprehensive() {
         const ISSUER: &str = "SAAJLQZDZO57THPTIIEELEY7FJYOJZQWQD7FF4J67TUYTSCOXTF7R4Y3VY";
         const SUBJECT: &str = "SVAH7IN6QE6XODCGIIWZQDZ5LNSSS4FNEO6SNHZSSASW4BBBKSZ6KWTKWY";
-        let create_long: Cmd = clap::Parser::try_parse_from(&[
+        let create_long: Cmd = clap::Parser::try_parse_from([
             "par",
             "create",
             "--arch",
@@ -490,7 +490,7 @@ mod test {
             }
             cmd => panic!("par insert constructed incorrect command {:?}", cmd),
         }
-        let create_short: Cmd = clap::Parser::try_parse_from(&[
+        let create_short: Cmd = clap::Parser::try_parse_from([
             "par",
             "create",
             "-a",
@@ -557,7 +557,7 @@ mod test {
     fn test_par_insert_comprehensive() {
         const ISSUER: &str = "SAAJLQZDZO57THPTQLEELEY7FJYOJZQWQD7FF4J67TUYTSCOXTF7R4Y3VY";
         const SUBJECT: &str = "SVAH7IN6QE6XODCGQAWZQDZ5LNSSS4FNEO6SNHZSSASW4BBBKSZ6KWTKWY";
-        let insert_short: Cmd = clap::Parser::try_parse_from(&[
+        let insert_short: Cmd = clap::Parser::try_parse_from([
             "par",
             "insert",
             "libtest.par.gz",
@@ -594,7 +594,7 @@ mod test {
             }
             cmd => panic!("par insert constructed incorrect command {:?}", cmd),
         }
-        let insert_long: Cmd = clap::Parser::try_parse_from(&[
+        let insert_long: Cmd = clap::Parser::try_parse_from([
             "par",
             "insert",
             "libtest.par.gz",
@@ -639,7 +639,7 @@ mod test {
         const LOCAL: &str = "./coolthing.par.gz";
         const REMOTE: &str = "wasmcloud.azurecr.io/coolthing.par.gz";
 
-        let inspect_long: Cmd = clap::Parser::try_parse_from(&[
+        let inspect_long: Cmd = clap::Parser::try_parse_from([
             "par",
             "inspect",
             LOCAL,
@@ -672,7 +672,7 @@ mod test {
             }
             cmd => panic!("par inspect constructed incorrect command {:?}", cmd),
         }
-        let inspect_short: Cmd = clap::Parser::try_parse_from(&[
+        let inspect_short: Cmd = clap::Parser::try_parse_from([
             "par",
             "inspect",
             REMOTE,

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -470,11 +470,11 @@ mod tests {
         // Not explicitly used, just a placeholder for a directory
         const TESTDIR: &str = "./tests/fixtures";
 
-        let pull_basic: Cmd = Parser::try_parse_from(&["reg", "pull", ECHO_WASM]).unwrap();
+        let pull_basic: Cmd = Parser::try_parse_from(["reg", "pull", ECHO_WASM]).unwrap();
         let pull_all_flags: Cmd =
-            Parser::try_parse_from(&["reg", "pull", ECHO_WASM, "--allow-latest", "--insecure"])
+            Parser::try_parse_from(["reg", "pull", ECHO_WASM, "--allow-latest", "--insecure"])
                 .unwrap();
-        let pull_all_options: Cmd = Parser::try_parse_from(&[
+        let pull_all_options: Cmd = Parser::try_parse_from([
             "reg",
             "pull",
             ECHO_WASM,
@@ -540,7 +540,7 @@ mod tests {
 
         // Push echo.wasm and pull from local registry
         let echo_push_basic = &format!("{}/echo:pushbasic", LOCAL_REGISTRY);
-        let push_basic: Cmd = Parser::try_parse_from(&[
+        let push_basic: Cmd = Parser::try_parse_from([
             "reg",
             "push",
             echo_push_basic,
@@ -564,7 +564,7 @@ mod tests {
 
         // Push logging.par.gz and pull from local registry
         let logging_push_all_flags = &format!("{}/logging:allflags", LOCAL_REGISTRY);
-        let push_all_flags: Cmd = Parser::try_parse_from(&[
+        let push_all_flags: Cmd = Parser::try_parse_from([
             "reg",
             "push",
             logging_push_all_flags,
@@ -591,7 +591,7 @@ mod tests {
 
         // Push logging.par.gz to different tag and pull to confirm successful push
         let logging_push_all_options = &format!("{}/logging:alloptions", LOCAL_REGISTRY);
-        let push_all_options: Cmd = Parser::try_parse_from(&[
+        let push_all_options: Cmd = Parser::try_parse_from([
             "reg",
             "push",
             logging_push_all_options,

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -460,7 +460,7 @@ mod tests {
         // Not explicitly used, just a placeholder for a directory
         const TESTDIR: &str = "./tests/fixtures";
 
-        let up_all_flags: UpCommand = Parser::try_parse_from(&[
+        let up_all_flags: UpCommand = Parser::try_parse_from([
             "up",
             "--allow-latest",
             "--allowed-insecure",

--- a/tests/integration_claims.rs
+++ b/tests/integration_claims.rs
@@ -20,7 +20,7 @@ fn integration_claims_sign() {
     // as signing an unsigned wasm
     let echo = test_dir_file(SUBFOLDER, "echo.wasm");
     let get_hello_wasm = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             "wasmcloud.azurecr.io/echo:0.2.1",
@@ -33,7 +33,7 @@ fn integration_claims_sign() {
 
     let signed_wasm_path = test_dir_file(SUBFOLDER, "echo_signed.wasm");
     let sign_echo = wash()
-        .args(&[
+        .args([
             "claims",
             "sign",
             echo.to_str().unwrap(),
@@ -73,7 +73,7 @@ fn integration_claims_inspect() {
     // Pull the echo module and push to local registry to test local inspect
     let echo = test_dir_file(SUBFOLDER, "echo.wasm");
     let get_hello_wasm = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_OCI,
@@ -84,7 +84,7 @@ fn integration_claims_inspect() {
         .expect("failed to pull echo for claims sign test");
     assert!(get_hello_wasm.status.success());
     let push_echo = wash()
-        .args(&[
+        .args([
             "reg",
             "push",
             "localhost:5000/echo:claimsinspect",
@@ -97,7 +97,7 @@ fn integration_claims_inspect() {
 
     // Inspect local, local registry, and remote registry actor wasm
     let local_inspect = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             echo.to_str().unwrap(),
@@ -127,7 +127,7 @@ fn integration_claims_inspect() {
     );
 
     let local_reg_inspect = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             "localhost:5000/echo:claimsinspect",
@@ -146,7 +146,7 @@ fn integration_claims_inspect() {
     );
 
     let remote_inspect = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             ECHO_OCI,
@@ -181,7 +181,7 @@ fn integration_claims_inspect_cached() {
     echo_cache_path.set_extension("bin");
 
     let get_hello_wasm = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_OCI,
@@ -193,7 +193,7 @@ fn integration_claims_inspect_cached() {
     assert!(get_hello_wasm.status.success());
 
     let remote_inspect = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             ECHO_FAKE_OCI,
@@ -222,7 +222,7 @@ fn integration_claims_inspect_cached() {
     );
 
     let remote_inspect_no_cache = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             ECHO_FAKE_OCI,
@@ -255,7 +255,7 @@ fn integration_claims_call_alias() {
     // as signing an unsigned wasm
     let logger = test_dir_file(SUBFOLDER, "logger.wasm");
     let get_wasm = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             "wasmcloud.azurecr.io/logger:0.1.0",
@@ -268,7 +268,7 @@ fn integration_claims_call_alias() {
 
     let signed_wasm_path = test_dir_file(SUBFOLDER, "logger_signed.wasm");
     let sign_logger = wash()
-        .args(&[
+        .args([
             "claims",
             "sign",
             logger.to_str().unwrap(),
@@ -299,7 +299,7 @@ fn integration_claims_call_alias() {
 
     // inspect actor
     let local_inspect = wash()
-        .args(&[
+        .args([
             "claims",
             "inspect",
             signed_wasm_path.to_str().unwrap(),

--- a/tests/integration_drain.rs
+++ b/tests/integration_drain.rs
@@ -58,7 +58,7 @@ fn integration_drain_lib() {
     std::env::set_var("TMP", test_dir.clone());
 
     let drain_basic = wash()
-        .args(&["drain", "lib", "-o", "json"])
+        .args(["drain", "lib", "-o", "json"])
         .output()
         .unwrap_or_else(|_| panic!("failed to drain {:?}", lib_dir.clone()));
     assert!(drain_basic.status.success());
@@ -97,7 +97,7 @@ fn integration_drain_oci() {
     std::env::set_var("TMP", test_dir.clone());
 
     let drain_basic = wash()
-        .args(&["drain", "oci", "-o", "json"])
+        .args(["drain", "oci", "-o", "json"])
         .output()
         .unwrap_or_else(|_| panic!("failed to drain {:?}", oci_dir.clone()));
     assert!(drain_basic.status.success());
@@ -142,7 +142,7 @@ fn integration_drain_all() {
     std::env::set_var("TMP", test_dir.clone());
 
     let drain_basic = wash()
-        .args(&["drain", "all", "-o", "json"])
+        .args(["drain", "all", "-o", "json"])
         .output()
         .unwrap_or_else(|_| panic!("failed to drain {:?}", oci_dir.clone()));
     assert!(drain_basic.status.success());
@@ -192,7 +192,7 @@ fn test_smithy_cache_drain() {
     println!("temp dir is {}", &std::env::temp_dir().display());
     let (_sys_tmp_cache, smithy_cache) = set_smithy_cache_dir();
     let drain_basic = wash()
-        .args(&["drain", "smithy", "-o", "json"])
+        .args(["drain", "smithy", "-o", "json"])
         .output()
         .unwrap_or_else(|_| panic!("failed to drain {:?}", &smithy_cache));
     assert!(drain_basic.status.success());

--- a/tests/integration_keys.rs
+++ b/tests/integration_keys.rs
@@ -10,7 +10,7 @@ use std::{
 #[test]
 fn integration_keys_gen_basic() {
     let keys_gen_account = wash()
-        .args(&["keys", "gen", "account"])
+        .args(["keys", "gen", "account"])
         .output()
         .expect("failed to generate account key");
 
@@ -25,7 +25,7 @@ fn integration_keys_gen_comprehensive() {
 
     key_gen_types.iter().for_each(|cmd| {
         let key_gen_command = wash()
-            .args(&["keys", "gen", cmd])
+            .args(["keys", "gen", cmd])
             .output()
             .unwrap_or_else(|_| panic!("failed to generate key type {} with text output", cmd));
         assert!(key_gen_command.status.success());
@@ -37,7 +37,7 @@ fn integration_keys_gen_comprehensive() {
 
     key_gen_types.iter().for_each(|cmd| {
         let key_gen_command = wash()
-            .args(&["keys", "gen", cmd, "-o", "json"])
+            .args(["keys", "gen", cmd, "-o", "json"])
             .output()
             .unwrap_or_else(|_| panic!("failed to generate key type {} with json output", cmd));
         assert!(key_gen_command.status.success());
@@ -59,7 +59,7 @@ fn integration_keys_get_basic() {
     file.write_all(KEYCONTENTS).unwrap();
 
     let key_output = wash()
-        .args(&[
+        .args([
             "keys",
             "get",
             KEYNAME,
@@ -89,7 +89,7 @@ fn integration_keys_get_comprehensive() {
     file.write_all(KEYCONTENTS).unwrap();
 
     let key_output = wash()
-        .args(&[
+        .args([
             "keys",
             "get",
             KEYNAME,
@@ -133,7 +133,7 @@ fn integration_list_comprehensive() {
     file.write_all(KEYTHREECONTENTS).unwrap();
 
     let list_output = wash()
-        .args(&[
+        .args([
             "keys",
             "list",
             "-d",
@@ -152,7 +152,7 @@ fn integration_list_comprehensive() {
     assert!(output.contains(KEYTHREE));
 
     let list_output_json = wash()
-        .args(&[
+        .args([
             "keys",
             "list",
             "-d",

--- a/tests/integration_par.rs
+++ b/tests/integration_par.rs
@@ -34,7 +34,7 @@ fn integration_par_create(issuer: &str, subject: &str, archive: &str) {
     bin_file.write_all(b"01100010 01110100 01110111").unwrap();
 
     let create = wash()
-        .args(&[
+        .args([
             "par",
             "create",
             "-a",
@@ -69,7 +69,7 @@ fn integration_par_create(issuer: &str, subject: &str, archive: &str) {
     );
 
     let inspect_created = wash()
-        .args(&["par", "inspect", archive, "-o", "json"])
+        .args(["par", "inspect", archive, "-o", "json"])
         .output()
         .expect("failed to inspect created provider archive file");
     assert!(inspect_created.status.success());
@@ -106,7 +106,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
     bin2_file.write_all(b"01101001 01101111 01110011").unwrap();
 
     let insert_bin1 = wash()
-        .args(&[
+        .args([
             "par",
             "insert",
             archive,
@@ -132,7 +132,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
         )
     );
     let inspect_after_bin1 = wash()
-        .args(&["par", "inspect", archive, "-o", "json"])
+        .args(["par", "inspect", archive, "-o", "json"])
         .output()
         .expect("failed to inspect created provider archive file");
     assert!(inspect_after_bin1.status.success());
@@ -159,7 +159,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
     assert!(targets.contains(&"x86_64-linux".to_string()));
 
     let insert_bin2 = wash()
-        .args(&[
+        .args([
             "par",
             "insert",
             archive,
@@ -186,7 +186,7 @@ fn integration_par_insert(issuer: &str, subject: &str, archive: &str) {
     );
 
     let inspect_after_bin2 = wash()
-        .args(&["par", "inspect", archive, "-o", "json"])
+        .args(["par", "inspect", archive, "-o", "json"])
         .output()
         .expect("failed to inspect created provider archive file");
     assert!(inspect_after_bin2.status.success());
@@ -227,7 +227,7 @@ fn integration_par_inspect() {
     // Pull the echo module and push to local registry to test local inspect
     let local_http_client_path = test_dir_file(SUBFOLDER, "httpclient.wasm");
     let get_http_client = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             HTTP_OCI,
@@ -238,7 +238,7 @@ fn integration_par_inspect() {
         .expect("failed to pull https server for par inspect test");
     assert!(get_http_client.status.success());
     let push_echo = wash()
-        .args(&[
+        .args([
             "reg",
             "push",
             "localhost:5000/httpclient:parinspect",
@@ -254,7 +254,7 @@ fn integration_par_inspect() {
     // This also allows tests to pass if information is _added_ but not if information is _omitted_
     // from the command output
     let local_inspect = wash()
-        .args(&[
+        .args([
             "par",
             "inspect",
             local_http_client_path.to_str().unwrap(),
@@ -273,7 +273,7 @@ fn integration_par_inspect() {
     assert_json_include!(actual: local_inspect_output, expected: inspect_expected);
 
     let local_reg_inspect = wash()
-        .args(&[
+        .args([
             "par",
             "inspect",
             "localhost:5000/httpclient:parinspect",
@@ -288,7 +288,7 @@ fn integration_par_inspect() {
     assert_json_include!(actual: local_reg_inspect_output, expected: inspect_expected);
 
     let remote_inspect = wash()
-        .args(&["par", "inspect", HTTP_OCI, "-o", "json"])
+        .args(["par", "inspect", HTTP_OCI, "-o", "json"])
         .output()
         .expect("failed to inspect local registry wasm");
     assert!(remote_inspect.status.success());
@@ -311,7 +311,7 @@ fn integration_par_inspect_cached() {
     http_client_cache_path.set_extension("bin");
 
     let get_http_client = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             HTTP_OCI,
@@ -323,7 +323,7 @@ fn integration_par_inspect_cached() {
     assert!(get_http_client.status.success());
 
     let remote_inspect = wash()
-        .args(&["par", "inspect", HTTP_FAKE_OCI, "-o", "json"])
+        .args(["par", "inspect", HTTP_FAKE_OCI, "-o", "json"])
         .output()
         .expect("failed to inspect remote cached registry");
     assert!(remote_inspect.status.success());
@@ -336,7 +336,7 @@ fn integration_par_inspect_cached() {
     assert_json_include!(actual: remote_inspect_output, expected: expected_output);
 
     let remote_inspect_no_cache = wash()
-        .args(&["par", "inspect", HTTP_FAKE_OCI, "-o", "json", "--no-cache"])
+        .args(["par", "inspect", HTTP_FAKE_OCI, "-o", "json", "--no-cache"])
         .output()
         .expect("failed to inspect remote cached registry");
 

--- a/tests/integration_reg.rs
+++ b/tests/integration_reg.rs
@@ -18,7 +18,7 @@ fn integration_pull_basic() {
     let basic_echo = test_dir_file(SUBFOLDER, "basic_echo.wasm");
 
     let pull_basic = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_WASM,
@@ -44,7 +44,7 @@ fn integration_pull_comprehensive() {
     let comprehensive_logging = test_dir_file(SUBFOLDER, "comprehensive_logging.par.gz");
 
     let pull_echo_comprehensive = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_WASM,
@@ -66,7 +66,7 @@ fn integration_pull_comprehensive() {
     assert_eq!(output, expected_json);
 
     let pull_logging_comprehensive = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             LOGGING_PAR,
@@ -99,7 +99,7 @@ fn integration_push_basic() {
 
     // Pull echo.wasm for push tests
     wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_WASM,
@@ -113,7 +113,7 @@ fn integration_push_basic() {
     let echo_push_basic = &format!("{}/echo:pushbasic", LOCAL_REGISTRY);
     let localregistry_echo_wasm = test_dir_file(SUBFOLDER, "echo_local.wasm");
     let push_echo = wash()
-        .args(&[
+        .args([
             "reg",
             "push",
             echo_push_basic,
@@ -125,7 +125,7 @@ fn integration_push_basic() {
     assert!(push_echo.status.success());
 
     let pull_local_registry_echo = wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             echo_push_basic,
@@ -151,7 +151,7 @@ fn integration_push_comprehensive() {
 
     // Pull echo.wasm and logging.par.gz for push tests
     wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             ECHO_WASM,
@@ -161,7 +161,7 @@ fn integration_push_comprehensive() {
         .output()
         .unwrap_or_else(|_| panic!("failed to pull {} for push basic", ECHO_WASM));
     wash()
-        .args(&[
+        .args([
             "reg",
             "pull",
             LOGGING_PAR,
@@ -177,7 +177,7 @@ fn integration_push_comprehensive() {
 
     let logging_push_all_options = &format!("{}/logging:alloptions", LOCAL_REGISTRY);
     let push_all_options = wash()
-        .args(&[
+        .args([
             "reg",
             "push",
             logging_push_all_options,

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -9,7 +9,7 @@ fn integration_up_can_start_wasmcloud_and_actor() {
     let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
     let mut up_cmd = wash()
-        .args(&["up", "--nats-port", "5893", "-o", "json", "--detached"])
+        .args(["up", "--nats-port", "5893", "-o", "json", "--detached"])
         .stdout(stdout)
         .spawn()
         .expect("Could not spawn wash up process");
@@ -36,7 +36,7 @@ fn integration_up_can_start_wasmcloud_and_actor() {
     }
 
     let start_echo = wash()
-        .args(&[
+        .args([
             "ctl",
             "start",
             "actor",


### PR DESCRIPTION
Pretty sure the new lints were from the latest version of clippy in Rust 1.65. This fixes all of them