### PR TITLE
feat(lib): Adds new keys module to wash-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,7 @@ dependencies = [
  "dirs",
  "futures 0.3.25",
  "log",
+ "nkeys",
  "reqwest",
  "semver",
  "serde",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -28,6 +28,7 @@ config = { version = "0.13.1", features = ["toml"], optional = true }
 dirs = "4.0"
 futures = "0.3"
 log = "0.4"
+nkeys = "0.2.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 semver = { version = "1.0.12", features = ["serde"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/wash-lib/src/keys/fs.rs
+++ b/crates/wash-lib/src/keys/fs.rs
@@ -1,0 +1,251 @@
+//! A filesystem directory based implementation of a `KeyManager`
+
+use std::{
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use nkeys::KeyPair;
+
+use super::KeyManager;
+
+pub const KEY_FILE_EXTENSION: &str = "nk";
+
+pub struct KeyDir(PathBuf);
+
+impl AsRef<Path> for KeyDir {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Deref for KeyDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl KeyDir {
+    /// Creates a new KeyDir, erroring if it is unable to access or create the given directory.
+    pub fn new(path: impl AsRef<Path>) -> Result<KeyDir> {
+        let p = path.as_ref();
+        let exists = p.exists();
+        if exists && !p.is_dir() {
+            anyhow::bail!("{} is not a directory (or cannot be accessed)", p.display())
+        } else if !exists {
+            std::fs::create_dir_all(p)?;
+        }
+        // Always ensure the directory has the proper permissions, even if it exists
+        set_permissions_keys(p)?;
+        // Make sure we have the fully qualified path at this point
+        Ok(KeyDir(p.canonicalize()?))
+    }
+
+    /// Returns a list of paths to all keyfiles in the directory
+    pub fn list_paths(&self) -> Result<Vec<PathBuf>> {
+        let paths = std::fs::read_dir(&self.0)?;
+
+        Ok(paths
+            .filter_map(|p| {
+                if let Ok(entry) = p {
+                    let path = entry.path();
+                    match path.extension().map(|os| os.to_str()).unwrap_or_default() {
+                        Some(KEY_FILE_EXTENSION) => Some(path),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
+    fn generate_file_path(&self, name: &str) -> PathBuf {
+        self.0.join(format!("{}.{}", name, KEY_FILE_EXTENSION))
+    }
+}
+
+impl KeyManager for KeyDir {
+    fn get(&self, name: &str) -> Result<Option<KeyPair>> {
+        let path = self.generate_file_path(name);
+        match read_key(path) {
+            Ok(k) => Ok(Some(k)),
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("Unable to load key from disk: {}", e)),
+        }
+    }
+
+    fn list_names(&self) -> Result<Vec<String>> {
+        Ok(self
+            .list_paths()?
+            .into_iter()
+            .filter_map(|p| {
+                p.file_stem()
+                    .unwrap_or_default()
+                    .to_os_string()
+                    .into_string()
+                    .ok()
+            })
+            .collect())
+    }
+
+    fn list(&self) -> Result<Vec<KeyPair>> {
+        self.list_paths()?
+            .into_iter()
+            .map(|p| {
+                read_key(p).map_err(|e| anyhow::anyhow!("Unable to load key from disk: {}", e))
+            })
+            .collect()
+    }
+
+    fn delete(&self, name: &str) -> Result<()> {
+        match std::fs::remove_file(self.generate_file_path(name)) {
+            Ok(_) => Ok(()),
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => Ok(()),
+            Err(e) => Err(anyhow::anyhow!("Unable to delete key from disk: {}", e)),
+        }
+    }
+
+    fn save(&self, name: &str, key: &KeyPair) -> Result<()> {
+        let path = self.generate_file_path(name);
+        std::fs::write(&path, key.seed()?.as_bytes())
+            .map_err(|e| anyhow::anyhow!("Unable to write key to disk: {}", e))?;
+        set_permissions_keys(path)
+    }
+}
+
+/// Helper function for reading a key from disk
+pub fn read_key(p: impl AsRef<Path>) -> std::io::Result<KeyPair> {
+    let raw = std::fs::read_to_string(p)?;
+
+    KeyPair::from_seed(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+}
+
+#[cfg(all(unix))]
+/// Set file and folder permissions for keys.
+fn set_permissions_keys(path: impl AsRef<Path>) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = path.as_ref().metadata()?;
+    match metadata.file_type().is_dir() {
+        true => std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?,
+        false => std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?,
+    };
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn set_permissions_keys(_path: impl AsRef<Path>) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use nkeys::KeyPairType;
+
+    use super::*;
+
+    const TEST_KEY: &str = "SMAAGJ4DY4FNV4VJWA6QU7UQIL7DKJR4Z3UH7NBMNTH22V6VEIJGJUBQN4";
+
+    #[test]
+    fn round_trip_happy_path() {
+        let tempdir = tempfile::tempdir().expect("Unable to create temp dir");
+        let key_dir = KeyDir::new(&tempdir).expect("Should be able to create key dir");
+
+        let key1 = KeyPair::new(KeyPairType::Account);
+        let key2 = KeyPair::new(KeyPairType::Module);
+
+        key_dir
+            .save("foobar_account", &key1)
+            .expect("Should be able to save key");
+        key_dir
+            .save("foobar_module", &key2)
+            .expect("Should be able to save key");
+
+        assert_eq!(
+            tempdir.path().read_dir().unwrap().count(),
+            2,
+            "Directory should have 2 entries"
+        );
+
+        let names = key_dir.list_names().expect("Should be able to list names");
+        assert_eq!(names.len(), 2, "Should have listed 2 names");
+        for name in names.into_iter() {
+            assert!(
+                name == "foobar_account" || name == "foobar_module",
+                "Should only have the newly created keys in the list"
+            );
+        }
+
+        let key = key_dir
+            .get("foobar_module")
+            .expect("Shouldn't error while reading key")
+            .expect("Key should exist");
+        assert_eq!(
+            key.public_key(),
+            key2.public_key(),
+            "Should have fetched the right key from disk"
+        );
+
+        assert_eq!(
+            key_dir
+                .list()
+                .expect("Should be able to load all keys")
+                .len(),
+            2,
+            "Should have loaded 2 keys from disk"
+        );
+
+        key_dir
+            .delete("foobar_account")
+            .expect("Should be able to delete key");
+        assert_eq!(
+            tempdir.path().read_dir().unwrap().count(),
+            1,
+            "Directory should have 1 entry"
+        );
+    }
+
+    #[test]
+    fn can_read_existing() {
+        let tempdir = tempfile::tempdir().expect("Unable to create temp dir");
+        std::fs::write(tempdir.path().join("foobar_module.nk"), TEST_KEY)
+            .expect("Unable to write test file");
+        // Write a file that should be skipped
+        std::fs::write(tempdir.path().join("blah"), TEST_KEY).expect("Unable to write test file");
+
+        let key_dir = KeyDir::new(&tempdir).expect("Should be able to create key dir");
+
+        assert_eq!(
+            key_dir
+                .list_names()
+                .expect("Should be able to list existing keys")
+                .len(),
+            1,
+            "Should only have 1 key on disk"
+        );
+
+        let key = key_dir
+            .get("foobar_module")
+            .expect("Should be able to load key from disk")
+            .expect("Key should exist");
+        assert_eq!(
+            key.seed().unwrap(),
+            TEST_KEY,
+            "Should load the correct key from disk"
+        );
+    }
+
+    #[test]
+    fn delete_of_nonexistent_key_should_succeed() {
+        let tempdir = tempfile::tempdir().expect("Unable to create temp dir");
+        let key_dir = KeyDir::new(&tempdir).expect("Should be able to create key dir");
+
+        key_dir
+            .delete("foobar")
+            .expect("Non-existent key shouldn't error");
+    }
+}

--- a/crates/wash-lib/src/keys/mod.rs
+++ b/crates/wash-lib/src/keys/mod.rs
@@ -1,0 +1,28 @@
+//! A common set of types and traits for managing collections of nkeys used for wasmCloud
+
+use anyhow::Result;
+use nkeys::KeyPair;
+
+/// Convenience re-export of nkeys to make key functionality easier to manage
+pub use nkeys;
+
+pub mod fs;
+
+/// A trait that can be implemented by anything that needs to manage nkeys
+pub trait KeyManager {
+    /// Returns the named keypair. Returns None if the key doesn't exist in the manager
+    fn get(&self, name: &str) -> Result<Option<KeyPair>>;
+
+    /// List all key names available
+    fn list_names(&self) -> Result<Vec<String>>;
+
+    /// Retrieves all keys. Note that this could be an expensive operation depending on the
+    /// implementation
+    fn list(&self) -> Result<Vec<KeyPair>>;
+
+    /// Deletes a named keypair
+    fn delete(&self, name: &str) -> Result<()>;
+
+    /// Saves the given keypair with the given name
+    fn save(&self, name: &str, key: &KeyPair) -> Result<()>;
+}

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -13,3 +13,4 @@ pub mod config;
 pub mod context;
 pub mod drain;
 pub mod id;
+pub mod keys;

--- a/src/util.rs
+++ b/src/util.rs
@@ -296,24 +296,6 @@ pub fn validate_contract_id(contract_id: &str) -> Result<()> {
     }
 }
 
-#[cfg(all(unix))]
-/// Set file and folder permissions for keys.
-pub(crate) fn set_permissions_keys(path: &std::path::Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let metadata = path.metadata()?;
-    match metadata.file_type().is_dir() {
-        true => std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?,
-        false => std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?,
-    };
-    Ok(())
-}
-
-#[cfg(target_os = "windows")]
-pub(crate) fn set_permissions_keys(_path: &std::path::Path) -> Result<()> {
-    Ok(())
-}
-
 mod test {
     #[test]
     fn test_safe_base64_parse_option() {

--- a/tests/integration_keys.rs
+++ b/tests/integration_keys.rs
@@ -49,7 +49,7 @@ fn integration_keys_gen_comprehensive() {
 
 #[test]
 fn integration_keys_get_basic() {
-    const KEYCONTENTS: &[u8] = b"SMAGCRMDVSCIK5TGBAESKJUTWNJKCRRWJK5FQXQZ2POTYWA3JSS63HILFU";
+    const KEYCONTENTS: &[u8] = b"SMAAGJ4DY4FNV4VJWA6QU7UQIL7DKJR4Z3UH7NBMNTH22V6VEIJGJUBQN4";
     const KEYNAME: &str = "keys_get_basic.nk";
     const TESTDIR: &str = "integration_get_basic";
 
@@ -79,7 +79,7 @@ fn integration_keys_get_basic() {
 
 #[test]
 fn integration_keys_get_comprehensive() {
-    const KEYCONTENTS: &[u8] = b"SMAGCRMDVSCKDLSJBAESKJUTWNJKCRRWJK5FQXQZ2POTYWA3JSS63HILFU";
+    const KEYCONTENTS: &[u8] = b"SMAAGJ4DY4FNV4VJWA6QU7UQIL7DKJR4Z3UH7NBMNTH22V6VEIJGJUBQN4";
     const KEYNAME: &str = "keys_get_comprehensive.nk";
     const TESTDIR: &str = "integration_get_comprehensive";
 
@@ -112,18 +112,18 @@ fn integration_keys_get_comprehensive() {
 
 #[test]
 fn integration_list_comprehensive() {
-    const KEYONE: &str = "listcomprehensive_test_keyone.nk";
-    const KEYTWO: &str = "listcomprehensive_test_keytwo.nk";
-    const KEYTHREE: &str = "listcomprehensive_test_keythree.nk";
-    const KEYONECONTENTS: &[u8] = b"SMAGCRMDVSCKDLSJBAESKJUTWNJKCRRWJK5FQXQZ2POTYWA3JSS63HILFU";
-    const KEYTWOCONTENTS: &[u8] = b"SMAGCRMDVSCKDLSJBAESKJUTWNJKCRRWJK5FQXQZ2POTYWA3JSS63HILFU";
-    const KEYTHREECONTENTS: &[u8] = b"SMAGCRMDVSCKDLSJBAESKJUTWNJKCRRWJK5FQXQZ2POTYWA3JSS63HILFU";
+    const KEYONE: &str = "listcomprehensive_test_keyone";
+    const KEYTWO: &str = "listcomprehensive_test_keytwo";
+    const KEYTHREE: &str = "listcomprehensive_test_keythree";
+    const KEYONECONTENTS: &[u8] = b"SMAPZS3ZZB5IEVTFKIYVMHTQ7GWTA6K5DC47LRVVWQW2WXRRUISA63Q2DA";
+    const KEYTWOCONTENTS: &[u8] = b"SMACCDXTF7C4Q4AV7UU2U7J6PRLDQ4DTSVJNATO53RDIQCIZQ2JSLGYQRI";
+    const KEYTHREECONTENTS: &[u8] = b"SMANLG7XYYUWLMZSNHG2I7XWFS67RDRRDV632XCUKD4W6IQEJ33HAG6P74";
     const TESTDIR: &str = "integration_list_comprehensive";
 
     let list_comprehensive_dir = test_dir_with_subfolder(TESTDIR);
-    let keyonefile = test_dir_file(TESTDIR, KEYONE);
-    let keytwofile = test_dir_file(TESTDIR, KEYTWO);
-    let keythreefile = test_dir_file(TESTDIR, KEYTHREE);
+    let keyonefile = test_dir_file(TESTDIR, &format!("{}.nk", KEYONE));
+    let keytwofile = test_dir_file(TESTDIR, &format!("{}.nk", KEYTWO));
+    let keythreefile = test_dir_file(TESTDIR, &format!("{}.nk", KEYTHREE));
 
     let mut file = File::create(keyonefile).unwrap();
     file.write_all(KEYONECONTENTS).unwrap();

--- a/tests/integration_par.rs
+++ b/tests/integration_par.rs
@@ -62,7 +62,7 @@ fn integration_par_create(issuer: &str, subject: &str, archive: &str) {
         ])
         .output()
         .expect("failed to create provider archive file");
-    println!("Output: {:?}", create);
+
     assert!(create.status.success());
     assert_eq!(
         output_to_string(create).unwrap(),

--- a/tests/integration_par.rs
+++ b/tests/integration_par.rs
@@ -62,6 +62,7 @@ fn integration_par_create(issuer: &str, subject: &str, archive: &str) {
         ])
         .output()
         .expect("failed to create provider archive file");
+    println!("Output: {:?}", create);
     assert!(create.status.success());
     assert_eq!(
         output_to_string(create).unwrap(),


### PR DESCRIPTION
Please note that this introduces one small breaking change to output that removes the `.nk` suffix from the list of keys. However, there is backward compatibility for providing <key_name>.nk to `wash keys get` so it will still function as it did previously. This change was specifically made because the key name is more important than the suffix. If desired, I can back out that change, but it seemed to make more sense to make it less like a wash-specific `ls` of a directory