### PR TITLE
feat(lib): Moves claims and registry code into wash lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,13 +537,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 4.0.18",
+ "clap_derive 4.0.21",
  "clap_lex 0.3.0",
  "once_cell",
  "strsim 0.10.0",
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -3961,7 +3961,7 @@ dependencies = [
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
- "clap 4.0.18",
+ "clap 4.0.26",
  "cloudevents-sdk",
  "cmd_lib",
  "console",
@@ -4018,24 +4018,28 @@ dependencies = [
  "anyhow",
  "async-compression",
  "claims",
- "clap 4.0.18",
+ "clap 4.0.26",
  "command-group",
  "config",
  "dirs",
  "futures 0.3.25",
  "log",
  "nkeys",
+ "oci-distribution",
+ "provider-archive",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
  "serde_with",
  "tempfile",
+ "term-table",
  "test-case",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tar",
+ "wascap",
  "weld-codegen",
 ]
 

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = {status = "actively-developed"}
 default = ["start", "parser"]
 start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
-cli = ["clap"]
+cli = ["clap", "term-table"]
 
 [dependencies]
 anyhow = "1.0.58"
@@ -29,6 +29,8 @@ dirs = "4.0"
 futures = "0.3"
 log = "0.4"
 nkeys = "0.2.0"
+oci-distribution = { version = "0.9.1", default-features = false, features = ["rustls-tls"] }
+provider-archive = "0.6.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 semver = { version = "1.0.12", features = ["serde"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -36,9 +38,11 @@ serde_json = { version = "1.0.82", optional = true }
 serde_with = "2.0.0"
 test-case = "2.2.1"
 thiserror = "1.0"
+term-table = { version = "1.3.1", optional = true }
 tokio = { version = "1", default-features = false, features = ["process"] }
 tokio-stream = "0.1"
 tokio-tar = "0.3"
+wascap = "0.8.0"
 weld-codegen = "0.5.0"
 
 [dev-dependencies]

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -1,0 +1,271 @@
+//! A common set of helpers for writing your own CLI with wash-lib. This functionality is entirely
+//! optional. Also included in this module are several submodules with key bits of reusable
+//! functionality. This functionality is only suitable for CLIs and not for normal code, but it is
+//! likely to be helpful to anyone who doesn't want to rewrite things like the signing and claims
+//! subcommand
+//!
+//! PLEASE NOTE: This module is the most likely to change of any of the modules. We may decide to
+//! pull some of this code out and back in to the wash CLI only. We will try to communicate these
+//! changes as clearly as possible
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::Result;
+use nkeys::{KeyPair, KeyPairType};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::config::cfg_dir;
+use crate::keys::{
+    fs::{read_key, KeyDir},
+    KeyManager,
+};
+
+pub mod claims;
+
+/// Used for displaying human-readable output vs JSON format
+#[derive(Debug, Copy, Clone, Eq, Serialize, Deserialize, PartialEq)]
+pub enum OutputKind {
+    Text,
+    Json,
+}
+
+impl FromStr for OutputKind {
+    type Err = OutputParseErr;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(OutputKind::Json),
+            "text" => Ok(OutputKind::Text),
+            _ => Err(OutputParseErr),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputParseErr;
+
+impl Error for OutputParseErr {}
+
+impl std::fmt::Display for OutputParseErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "error parsing output type, see help for the list of accepted outputs"
+        )
+    }
+}
+
+pub struct CommandOutput {
+    pub map: std::collections::HashMap<String, serde_json::Value>,
+    pub text: String,
+}
+
+impl CommandOutput {
+    pub fn new<S: Into<String>>(
+        text: S,
+        map: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Self {
+        CommandOutput {
+            map,
+            text: text.into(),
+        }
+    }
+
+    /// shorthand to create a new CommandOutput with a single key-value pair for JSON, and simply the text for text output.
+    pub fn from_key_and_text<K: Into<String>, S: Into<String>>(key: K, text: S) -> Self {
+        let text_string: String = text.into();
+        let mut map = std::collections::HashMap::new();
+        map.insert(key.into(), serde_json::Value::String(text_string.clone()));
+        CommandOutput {
+            map,
+            text: text_string,
+        }
+    }
+}
+
+impl From<String> for CommandOutput {
+    /// Create a basic CommandOutput from a String. Puts the string a a "result" key in the JSON output.
+    fn from(text: String) -> Self {
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            "result".to_string(),
+            serde_json::Value::String(text.clone()),
+        );
+        CommandOutput { map, text }
+    }
+}
+
+impl From<&str> for CommandOutput {
+    /// Create a basic CommandOutput from a &str. Puts the string a a "result" key in the JSON output.
+    fn from(text: &str) -> Self {
+        CommandOutput::from(text.to_string())
+    }
+}
+
+impl Default for CommandOutput {
+    fn default() -> Self {
+        CommandOutput {
+            map: std::collections::HashMap::new(),
+            text: "".to_string(),
+        }
+    }
+}
+
+/// Helper function to locate and extract keypair from user input and generate a key for the user if
+/// needed
+///
+/// Returns the loaded or generated keypair
+pub fn extract_keypair(
+    input: Option<String>,
+    module_path: Option<String>,
+    directory: Option<PathBuf>,
+    keygen_type: KeyPairType,
+    disable_keygen: bool,
+    output_kind: OutputKind,
+) -> Result<KeyPair> {
+    if let Some(input_str) = input {
+        match read_key(&input_str) {
+            // User provided file path to seed as argument
+            Ok(k) => Ok(k),
+            // User provided seed as an argument
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => {
+                KeyPair::from_seed(&input_str).map_err(anyhow::Error::from)
+            }
+            // There was an actual error reading the file
+            Err(e) => Err(e.into()),
+        }
+    } else if let Some(module) = module_path {
+        // No seed value provided, attempting to source from provided or default directory
+        let key_dir = KeyDir::new(determine_directory(directory)?)?;
+        // Account key should be re-used, and will attempt to generate based on the terminal USER
+        let module_name = match keygen_type {
+            KeyPairType::Account => std::env::var("USER").unwrap_or_else(|_| "user".to_string()),
+            _ => PathBuf::from(module)
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
+        };
+        let keyname = format!(
+            "{}_{}",
+            module_name,
+            keypair_type_to_string(keygen_type.clone())
+        );
+        let path = key_dir.join(format!("{}{}", keyname, ".nk"));
+        match key_dir.get(&keyname)? {
+            // Default key found
+            Some(k) => Ok(k),
+            // No default key, generating for user
+            None if !disable_keygen => {
+                match output_kind {
+                    OutputKind::Text => println!(
+                        "No keypair found in \"{}\".
+                    We will generate one for you and place it there.
+                    If you'd like to use alternative keys, you can supply them as a flag.\n",
+                        path.display()
+                    ),
+                    OutputKind::Json => {
+                        println!(
+                            "{}",
+                            json!({"status": "No keypair found", "path": path, "keygen": "true"})
+                        )
+                    }
+                }
+
+                let kp = KeyPair::new(keygen_type);
+                key_dir.save(&keyname, &kp)?;
+                Ok(kp)
+            }
+            None => {
+                anyhow::bail!(
+                    "No keypair found in {}, please ensure key exists or supply one as a flag",
+                    path.display()
+                );
+            }
+        }
+    } else {
+        anyhow::bail!("Keypair path or string not supplied. Ensure provided keypair is valid");
+    }
+}
+
+/// Transforms a list of labels in the form of (label=value) to a hashmap
+pub fn labels_vec_to_hashmap(constraints: Vec<String>) -> Result<HashMap<String, String>> {
+    let mut hm: HashMap<String, String> = HashMap::new();
+    for constraint in constraints {
+        match constraint.split_once('=') {
+            Some((key, value)) => {
+                hm.insert(key.to_string(), value.to_string());
+            }
+            None => {
+                anyhow::bail!("Constraints were not properly formatted. Ensure they are formatted as label=value")
+            }
+        };
+    }
+    Ok(hm)
+}
+
+fn determine_directory(directory: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(d) = directory {
+        Ok(d)
+    } else {
+        let d = cfg_dir()?.join("keys");
+        Ok(d)
+    }
+}
+
+fn keypair_type_to_string(keypair_type: KeyPairType) -> String {
+    use KeyPairType::*;
+    match keypair_type {
+        Account => "account".to_string(),
+        Cluster => "cluster".to_string(),
+        Service => "service".to_string(),
+        Module => "module".to_string(),
+        Server => "server".to_string(),
+        Operator => "operator".to_string(),
+        User => "user".to_string(),
+    }
+}
+
+pub(crate) fn configure_table_style(table: &mut term_table::Table<'_>) {
+    table.style = empty_table_style();
+    table.separate_rows = false;
+}
+
+fn empty_table_style() -> term_table::TableStyle {
+    term_table::TableStyle {
+        top_left_corner: ' ',
+        top_right_corner: ' ',
+        bottom_left_corner: ' ',
+        bottom_right_corner: ' ',
+        outer_left_vertical: ' ',
+        outer_right_vertical: ' ',
+        outer_bottom_horizontal: ' ',
+        outer_top_horizontal: ' ',
+        intersection: ' ',
+        vertical: ' ',
+        horizontal: ' ',
+    }
+}
+
+pub const OCI_CACHE_DIR: &str = "wasmcloud_ocicache";
+
+/// Given an oci reference, returns a path to a cache file for an artifact
+pub fn cached_oci_file(img: &str) -> PathBuf {
+    let path = std::env::temp_dir();
+    let path = path.join(OCI_CACHE_DIR);
+    let _ = ::std::fs::create_dir_all(&path);
+    // should produce a file like wasmcloud_azurecr_io_kvcounter_v1.bin
+    let mut path = path.join(img_name_to_file_name(img));
+    path.set_extension("bin");
+
+    path
+}
+
+fn img_name_to_file_name(img: &str) -> String {
+    img.replace([':', '/', '.'], "_")
+}

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -9,8 +9,12 @@ pub mod start;
 #[cfg(feature = "parser")]
 pub mod parser;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 pub mod config;
 pub mod context;
 pub mod drain;
 pub mod id;
 pub mod keys;
+pub mod registry;

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -87,7 +87,7 @@ pub async fn get_oci_artifact(
 
 /// Pull down the artifact from the given url and additional options
 pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<Vec<u8>> {
-    let image: Reference = url.parse()?;
+    let image: Reference = url.to_lowercase().parse()?;
 
     if image.tag().unwrap_or("latest") == "latest" && !options.allow_latest {
         bail!("Pulling artifacts with tag 'latest' is prohibited.");
@@ -143,7 +143,7 @@ pub async fn push_oci_artifact(
     artifact: impl AsRef<Path>,
     options: OciPushOptions,
 ) -> Result<()> {
-    let image: Reference = url.parse()?;
+    let image: Reference = url.to_lowercase().parse()?;
 
     if image.tag().unwrap() == "latest" && !options.allow_latest {
         bail!("Pushing artifacts with tag 'latest' is prohibited");

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -1,0 +1,238 @@
+//! Utilities for pulling and pushing artifacts to various registries
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Result};
+use oci_distribution::manifest::OciImageManifest;
+use oci_distribution::{client::*, secrets::RegistryAuth, Reference};
+use provider_archive::ProviderArchive;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+const PROVIDER_ARCHIVE_MEDIA_TYPE: &str = "application/vnd.wasmcloud.provider.archive.layer.v1+par";
+const PROVIDER_ARCHIVE_CONFIG_MEDIA_TYPE: &str =
+    "application/vnd.wasmcloud.provider.archive.config";
+const WASM_MEDIA_TYPE: &str = "application/vnd.module.wasm.content.layer.v1+wasm";
+const WASM_CONFIG_MEDIA_TYPE: &str = "application/vnd.wasmcloud.actor.archive.config";
+const OCI_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
+
+/// Additional options for pulling an OCI artifact
+#[derive(Default)]
+pub struct OciPullOptions {
+    /// The digest of the content you expect to receive. This is used for validation purposes only
+    pub digest: Option<String>,
+    /// By default, we do not allow latest tags in wasmCloud. This overrides that setting
+    pub allow_latest: bool,
+    /// An optional username to use for authentication.
+    pub user: Option<String>,
+    /// An optional password to use for authentication
+    pub password: Option<String>,
+    /// Whether or not to allow pulling from non-https registries
+    pub insecure: bool,
+}
+
+/// Additional options for pushing an OCI artifact
+#[derive(Default)]
+pub struct OciPushOptions {
+    /// A path to an optional OCI configuration
+    pub config: Option<PathBuf>,
+    /// By default, we do not allow latest tags in wasmCloud. This overrides that setting
+    pub allow_latest: bool,
+    /// An optional username to use for authentication.
+    pub user: Option<String>,
+    /// An optional password to use for authentication.
+    pub password: Option<String>,
+    /// Whether or not to allow pulling from non-https registries
+    pub insecure: bool,
+    /// Optional annotations you'd like to add to the pushed artifact
+    pub annotations: Option<HashMap<String, String>>,
+}
+
+/// The types of artifacts that wash supports
+pub enum SupportedArtifacts {
+    /// A par.gz (i.e. parcheezy) file containing capability providers
+    Par,
+    /// WebAssembly modules
+    Wasm,
+}
+
+// NOTE(thomastaylor312): In later refactors, we might want to consider making some sort of puller
+// and pusher structs that can take optional implementations of a `Cache` trait that does all the
+// cached file handling. But for now, this should be good enough
+
+/// Attempts to return a local artifact, then a cached file (if cache_file is set).
+///
+/// Falls back to pull from registry if neither is found.
+pub async fn get_oci_artifact(
+    url_or_file: String,
+    cache_file: Option<PathBuf>,
+    options: OciPullOptions,
+) -> Result<Vec<u8>> {
+    if let Ok(mut local_artifact) = File::open(&url_or_file).await {
+        let mut buf = Vec::new();
+        local_artifact.read_to_end(&mut buf).await?;
+        return Ok(buf);
+    } else if let Some(cache_path) = cache_file {
+        if let Ok(mut cached_artifact) = File::open(cache_path).await {
+            let mut buf = Vec::new();
+            cached_artifact.read_to_end(&mut buf).await?;
+            return Ok(buf);
+        }
+    }
+    pull_oci_artifact(url_or_file, options).await
+}
+
+/// Pull down the artifact from the given url and additional options
+pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<Vec<u8>> {
+    let image: Reference = url.parse()?;
+
+    if image.tag().unwrap_or("latest") == "latest" && !options.allow_latest {
+        bail!("Pulling artifacts with tag 'latest' is prohibited.");
+    };
+
+    let mut client = Client::new(ClientConfig {
+        protocol: if options.insecure {
+            ClientProtocol::Http
+        } else {
+            ClientProtocol::Https
+        },
+        ..Default::default()
+    });
+
+    let auth = match (options.user, options.password) {
+        (Some(user), Some(password)) => RegistryAuth::Basic(user, password),
+        _ => RegistryAuth::Anonymous,
+    };
+
+    let image_data = client
+        .pull(
+            &image,
+            &auth,
+            vec![PROVIDER_ARCHIVE_MEDIA_TYPE, WASM_MEDIA_TYPE, OCI_MEDIA_TYPE],
+        )
+        .await?;
+
+    // Reformatting digest in case the sha256: prefix is left off
+    let digest = match options.digest {
+        Some(d) if d.starts_with("sha256:") => Some(d),
+        Some(d) => Some(format!("sha256:{}", d)),
+        None => None,
+    };
+
+    match (digest, image_data.digest) {
+        (Some(digest), Some(image_digest)) if digest != image_digest => {
+            return Err(anyhow!(
+                "Image digest did not match provided digest, aborting"
+            ))
+        }
+        _ => (),
+    };
+
+    Ok(image_data
+        .layers
+        .iter()
+        .flat_map(|l| l.data.clone())
+        .collect::<Vec<_>>())
+}
+
+pub async fn push_oci_artifact(
+    url: String,
+    artifact: impl AsRef<Path>,
+    options: OciPushOptions,
+) -> Result<()> {
+    let image: Reference = url.parse()?;
+
+    if image.tag().unwrap() == "latest" && !options.allow_latest {
+        bail!("Pushing artifacts with tag 'latest' is prohibited");
+    };
+
+    let mut artifact_buf = vec![];
+    let mut f = File::open(artifact).await?;
+    f.read_to_end(&mut artifact_buf).await?;
+
+    let (artifact_media_type, config_media_type) = match validate_artifact(&artifact_buf).await? {
+        SupportedArtifacts::Wasm => (WASM_MEDIA_TYPE, WASM_CONFIG_MEDIA_TYPE),
+        SupportedArtifacts::Par => (
+            PROVIDER_ARCHIVE_MEDIA_TYPE,
+            PROVIDER_ARCHIVE_CONFIG_MEDIA_TYPE,
+        ),
+    };
+
+    let mut config_buf = vec![];
+    match options.config {
+        Some(config_file) => {
+            let mut f = File::open(config_file).await?;
+            f.read_to_end(&mut config_buf).await?;
+        }
+        None => {
+            // If no config provided, send blank config
+            config_buf = b"{}".to_vec();
+        }
+    };
+    let config = Config {
+        data: config_buf,
+        media_type: config_media_type.to_string(),
+        annotations: None,
+    };
+
+    let layer = vec![ImageLayer {
+        data: artifact_buf,
+        media_type: artifact_media_type.to_string(),
+        annotations: None,
+    }];
+
+    let mut client = Client::new(ClientConfig {
+        protocol: if options.insecure {
+            ClientProtocol::Http
+        } else {
+            ClientProtocol::Https
+        },
+        ..Default::default()
+    });
+
+    let auth = match (options.user, options.password) {
+        (Some(user), Some(password)) => RegistryAuth::Basic(user, password),
+        _ => RegistryAuth::Anonymous,
+    };
+
+    let manifest = OciImageManifest::build(&layer, &config, options.annotations);
+
+    client
+        .push(&image, &layer, config, &auth, Some(manifest))
+        .await?;
+    Ok(())
+}
+
+/// Helper function to determine artifact type and validate that it is
+/// a supported artifact type
+pub async fn validate_artifact(artifact: &[u8]) -> Result<SupportedArtifacts> {
+    match validate_actor_module(artifact) {
+        Ok(_) => Ok(SupportedArtifacts::Wasm),
+        Err(_) => match validate_provider_archive(artifact).await {
+            Ok(_) => Ok(SupportedArtifacts::Par),
+            Err(_) => bail!("Unsupported artifact type"),
+        },
+    }
+}
+
+/// Attempts to inspect the claims of an actor module
+/// Will fail without actor claims, or if the artifact is invalid
+fn validate_actor_module(artifact: &[u8]) -> Result<()> {
+    match wascap::wasm::extract_claims(artifact) {
+        Ok(Some(_token)) => Ok(()),
+        Ok(None) => bail!("No capabilities discovered in actor module"),
+        Err(e) => Err(anyhow!("{}", e)),
+    }
+}
+
+/// Attempts to unpack a provider archive
+/// Will fail without claims or if the archive is invalid
+async fn validate_provider_archive(artifact: &[u8]) -> Result<()> {
+    match ProviderArchive::try_load(artifact).await {
+        Ok(_par) => Ok(()),
+        Err(e) => bail!("Invalid provider archive: {}", e),
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,8 @@ use async_nats::Client;
 use clap::{Args, Subcommand};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use wash_lib::cli::{CommandOutput, OutputKind};
+use wash_lib::config::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use wash_lib::context::{
     fs::{load_context, ContextDir},
     ContextManager,
@@ -14,7 +16,6 @@ use crate::{
     appearance::spinner::Spinner,
     ctl::ConnectionOpts,
     ctx::{context_dir, ensure_host_config_context},
-    util::{CommandOutput, OutputKind, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT},
 };
 
 mod output;

--- a/src/appearance/spinner.rs
+++ b/src/appearance/spinner.rs
@@ -1,6 +1,6 @@
-use crate::util::OutputKind;
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
+use wash_lib::cli::OutputKind;
 
 // For more spinners check out the cli-spinners project:
 // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,15 +1,16 @@
 use std::{collections::HashMap, fs, path::PathBuf, process};
 
-use crate::{
-    claims::{sign_file, ActorMetadata, SignCommand},
-    util::{CommandOutput, OutputKind},
-};
 use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use serde_json::json;
 use wash_lib::parser::{
     ActorConfig, CommonConfig, InterfaceConfig, LanguageConfig, ProviderConfig, RustConfig,
     TinyGoConfig, TypeConfig,
+};
+
+use wash_lib::cli::{
+    claims::{sign_file, ActorMetadata, SignCommand},
+    CommandOutput, OutputKind,
 };
 
 /// Build (and sign) a wasmCloud actor, provider, or interface

--- a/src/call.rs
+++ b/src/call.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 use anyhow::{bail, Context, Result};
 use clap::Args;
 use log::{debug, error};
+use wash_lib::cli::CommandOutput;
+use wash_lib::config::{DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use wash_lib::context::{
     fs::{load_context, ContextDir},
     ContextManager,
@@ -15,8 +17,7 @@ use crate::{
     ctx::{context_dir, ensure_host_config_context},
     util::{
         default_timeout_ms, extract_arg_value, json_str_to_msgpack_bytes, msgpack_to_json_val,
-        nats_client_from_opts, CommandOutput, DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST,
-        DEFAULT_NATS_PORT,
+        nats_client_from_opts,
     },
 };
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::{bail, Result};
 use clap::{Args, Parser, Subcommand};
 use wash_lib::{
+    cli::{labels_vec_to_hashmap, CommandOutput, OutputKind},
     config::{
         DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT_MS,
         DEFAULT_START_ACTOR_TIMEOUT_MS, DEFAULT_START_PROVIDER_TIMEOUT_MS,
@@ -25,10 +26,7 @@ use crate::{
     appearance::spinner::Spinner,
     ctl::manifest::HostManifest,
     ctx::{context_dir, ensure_host_config_context},
-    util::{
-        convert_error, default_timeout_ms, labels_vec_to_hashmap, validate_contract_id,
-        CommandOutput, OutputKind,
-    },
+    util::{convert_error, default_timeout_ms, validate_contract_id},
 };
 pub(crate) use output::*;
 use wait::{

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -3,10 +3,11 @@ use std::collections::HashMap;
 use anyhow::{bail, Result};
 use serde_json::json;
 use term_table::{row::Row, table_cell::*, Table};
+use wash_lib::cli::CommandOutput;
 use wash_lib::id::{ModuleId, ServiceId};
 use wasmcloud_control_interface::*;
 
-use crate::util::{format_optional, CommandOutput};
+use crate::util::format_optional;
 
 pub(crate) fn get_hosts_output(hosts: Vec<Host>) -> CommandOutput {
     let mut map = HashMap::new();

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -10,6 +10,7 @@ use clap::{Args, Subcommand};
 use log::warn;
 use serde_json::json;
 use wash_lib::{
+    cli::CommandOutput,
     config::{
         cfg_dir, DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT,
         DEFAULT_NATS_TIMEOUT_MS,
@@ -21,12 +22,9 @@ use wash_lib::{
     id::ClusterSeed,
 };
 
-use crate::{
-    generate::{
-        interactive::{prompt_for_choice, user_question},
-        project_variables::StringEntry,
-    },
-    util::CommandOutput,
+use crate::generate::{
+    interactive::{prompt_for_choice, user_question},
+    project_variables::StringEntry,
 };
 
 const CTX_DIR_NAME: &str = "contexts";

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use clap::Parser;
 use serde_json::json;
 use tokio::process::Command;
+use wash_lib::cli::{CommandOutput, OutputKind};
+use wash_lib::start::*;
 
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::up::DOWNLOADS_DIR;
-use crate::util::{CommandOutput, OutputKind};
-use wash_lib::start::*;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct DownCommand {}

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use serde_json::json;
+use wash_lib::cli::CommandOutput;
 use wash_lib::drain::Drain;
-
-use crate::util::CommandOutput;
 
 pub(crate) fn handle_command(cmd: Drain) -> Result<CommandOutput> {
     let paths = cmd.drain()?;

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -3,6 +3,12 @@
 //! This module contains code for `wash new ...` commands
 //! to creating a new project from a template.
 //!
+use std::{
+    borrow::Borrow,
+    fmt, fs,
+    path::{Path, PathBuf},
+};
+
 use anyhow::{anyhow, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use config::{Config, CONFIG_FILE_NAME};
@@ -10,16 +16,12 @@ use console::style;
 use indicatif::MultiProgress;
 use project_variables::*;
 use serde::Serialize;
-use std::{
-    borrow::Borrow,
-    fmt, fs,
-    path::{Path, PathBuf},
-};
 use tempfile::TempDir;
 use tokio::process::Command;
+use wash_lib::cli::CommandOutput;
 use weld_codegen::render::Renderer;
 
-use crate::{appearance::emoji, util::CommandOutput};
+use crate::appearance::emoji;
 
 mod config;
 mod favorites;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use app::AppCliCommand;
 use build::BuildCommand;
 use call::CallCli;
-use claims::ClaimsCliCommand;
 use clap::{Parser, Subcommand};
 use ctl::CtlCliCommand;
 use ctx::CtxCommand;
@@ -16,17 +15,15 @@ use reg::RegCliCommand;
 use serde_json::json;
 use smithy::{GenerateCli, LintCli, ValidateCli};
 use up::UpCommand;
-use util::CommandOutput;
+use wash_lib::cli::claims::ClaimsCliCommand;
+use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::drain::Drain as DrainSelection;
-
-use crate::util::OutputKind;
 
 mod app;
 mod appearance;
 mod build;
 mod call;
 mod cfg;
-mod claims;
 mod ctl;
 mod ctx;
 mod down;
@@ -132,7 +129,9 @@ async fn main() {
         CliCommand::App(app_cli) => app::handle_command(app_cli, output_kind).await,
         CliCommand::Build(build_cli) => build::handle_command(build_cli, output_kind),
         CliCommand::Call(call_cli) => call::handle_command(call_cli.command()).await,
-        CliCommand::Claims(claims_cli) => claims::handle_command(claims_cli, output_kind).await,
+        CliCommand::Claims(claims_cli) => {
+            wash_lib::cli::claims::handle_command(claims_cli, output_kind).await
+        }
         CliCommand::Ctl(ctl_cli) => ctl::handle_command(ctl_cli, output_kind).await,
         CliCommand::Ctx(ctx_cli) => ctx::handle_command(ctx_cli).await,
         CliCommand::Down(down_cli) => down::handle_command(down_cli, output_kind).await,

--- a/src/smithy.rs
+++ b/src/smithy.rs
@@ -1,15 +1,18 @@
 //! smithy model lint and validation
 //!
-use crate::{appearance::emoji, util::CommandOutput};
+use std::path::PathBuf;
+
 use anyhow::{anyhow, bail, Result};
 use atelier_core::model::Model;
 use clap::Parser;
 use console::style;
-use std::path::PathBuf;
+use wash_lib::cli::CommandOutput;
 use weld_codegen::{
     config::{CodegenConfig, ModelSource, OutputLanguage},
     sources_to_model,
 };
+
+use crate::appearance::emoji;
 
 type TomlValue = toml::Value;
 const CODEGEN_CONFIG_FILE: &str = "codegen.toml";

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -1,6 +1,3 @@
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::Path;
@@ -10,18 +7,24 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use serde_json::json;
+
 use tokio::fs::create_dir_all;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::Child,
 };
+use wash_lib::cli::{CommandOutput, OutputKind};
+use wash_lib::start::*;
 
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::down::stop_nats;
 use crate::down::stop_wasmcloud;
-use crate::util::{CommandOutput, OutputKind};
-use wash_lib::start::*;
+
 mod config;
 mod credsfile;
 pub use config::DOWNLOADS_DIR;


### PR DESCRIPTION
Sorry for the big PR here, but due to a bunch of codependent code,
I had to move a bunch of stuff at once. There are two main threads
to this PR. First, I noticed that the claims code is all CLI specific,
but it is likely that anyone building a CLI will not want to rewrite that
again. If you are doing this purely in code, you can just use the
wascap library. To make this work, I started added the CLI specific stuff
to the `cli` module of wash lib. There will probably be other things we
add to it as we finish this refactor

Second, this moves the reusable registry bits into its own module, which
is super handy even for those not doing a CLI as it avoids direct
interaction with the lower level OCI crates