### PR TITLE
Moved project build functionality to wash-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.14.0-alpha.3"
+version = "0.14.0-alpha.4"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.14.0-alpha.3"
+version = "0.14.0-alpha.4"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -1,0 +1,205 @@
+//! Build (and sign) a wasmCloud actor, provider, or interface. Depends on the "cli" feature
+//!
+
+use std::{fs, path::PathBuf, process, str::FromStr};
+
+use anyhow::{anyhow, bail, Result};
+
+use crate::cli::{
+    claims::{sign_file, ActorMetadata, SignCommand},
+    OutputKind,
+};
+use crate::parser::{
+    ActorConfig, CommonConfig, InterfaceConfig, LanguageConfig, ProjectConfig, ProviderConfig,
+    RustConfig, TinyGoConfig, TypeConfig,
+};
+
+/// Using a [ProjectConfig], usually parsed from a `wasmcloud.toml` file, build the project
+/// with the installed language toolchain. This will delegate to [build_actor] when the project is an actor,
+/// or return an error when trying to build providers or interfaces. This functionality is planned in a future release.
+///
+/// This function returns the path to the compiled artifact, a signed Wasm module, signed provider archive, or compiled
+/// interface library file.
+///
+/// # Usage
+/// ```no_run
+/// use wash_lib::{build::build_project, parser::get_config};
+/// let config = get_config(None, Some(true))?;
+/// let artifact_path = build_project(config)?;
+/// println!("Here is the signed artifact: {}", artifact_path.to_string_lossy());
+/// ```
+pub fn build_project(config: ProjectConfig) -> Result<PathBuf> {
+    match config.project_type {
+        TypeConfig::Actor(actor_config) => {
+            build_actor(actor_config, config.language, config.common, false)
+        }
+        TypeConfig::Provider(_provider_config) => Err(anyhow!(
+            "wash build has not be implemented for providers yet. Please use `make` for now!"
+        )),
+        TypeConfig::Interface(_interface_config) => Err(anyhow!(
+            "wash build has not be implemented for interfaces yet. Please use `make` for now!"
+        )),
+    }
+}
+
+/// Builds a wasmCloud actor using the installed language toolchain, then signs the actor with
+/// keys, capability claims, and additional friendly information like name, version, revision, etc.
+///
+/// # Arguments
+/// * `actor_config`: [ActorConfig] for required information to find, build, and sign an actor
+/// * `language_config`: [LanguageConfig] specifying which language the actor is written in
+/// * `common_config`: [CommonConfig] specifying common parameters like [CommonConfig::name] and [CommonConfig::version]
+/// * `no_sign`: If `true`, build the actor but don't sign. Useful for just checking build status without needing signing keys or fully referenced capabilities
+pub fn build_actor(
+    actor_config: ActorConfig,
+    language_config: LanguageConfig,
+    common_config: CommonConfig,
+    no_sign: bool,
+) -> Result<PathBuf> {
+    // Build actor based on language toolchain
+    let file_path = match language_config {
+        LanguageConfig::Rust(rust_config) => {
+            build_rust_actor(common_config.clone(), rust_config, actor_config.clone())
+        }
+        LanguageConfig::TinyGo(tinygo_config) => {
+            build_tinygo_actor(common_config.clone(), tinygo_config)
+        }
+    }?;
+
+    // Exit early if signing isn't desired
+    if no_sign {
+        Ok(file_path)
+    } else {
+        let source = file_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Could not convert file path to string"))?
+            .to_string();
+
+        let destination = format!("build/{}_s.wasm", common_config.name);
+        let destination_file = PathBuf::from_str(&destination);
+
+        let sign_options = SignCommand {
+            source,
+            destination: Some(destination),
+            metadata: ActorMetadata {
+                name: common_config.name,
+                ver: Some(common_config.version.to_string()),
+                custom_caps: actor_config.claims,
+                call_alias: actor_config.call_alias,
+                ..Default::default()
+            },
+        };
+        sign_file(sign_options, OutputKind::Json)?;
+
+        Ok(destination_file?)
+    }
+}
+
+/// Builds a rust actor and returns the path to the file.
+fn build_rust_actor(
+    common_config: CommonConfig,
+    rust_config: RustConfig,
+    actor_config: ActorConfig,
+) -> Result<PathBuf> {
+    let mut command = match rust_config.cargo_path {
+        Some(path) => process::Command::new(path),
+        None => process::Command::new("cargo"),
+    };
+
+    let result = command.args(["build", "--release"]).status()?;
+
+    if !result.success() {
+        bail!("Compiling actor failed: {}", result.to_string())
+    }
+
+    let wasm_file = PathBuf::from(format!(
+        "{}/{}/release/{}.wasm",
+        rust_config
+            .target_path
+            .unwrap_or_else(|| PathBuf::from("target"))
+            .to_string_lossy(),
+        actor_config.wasm_target,
+        common_config.name,
+    ));
+
+    if !wasm_file.exists() {
+        bail!(
+            "Could not find compiled wasm file to sign: {}",
+            wasm_file.display()
+        );
+    }
+
+    // move the file out into the build/ folder for parity with tinygo and convienience for users.
+    let copied_wasm_file = PathBuf::from(format!("build/{}.wasm", common_config.name));
+    if let Some(p) = copied_wasm_file.parent() {
+        fs::create_dir_all(p)?;
+    }
+    fs::copy(&wasm_file, &copied_wasm_file)?;
+    fs::remove_file(&wasm_file)?;
+
+    Ok(copied_wasm_file)
+}
+
+/// Builds a tinygo actor and returns the path to the file.
+fn build_tinygo_actor(common_config: CommonConfig, tinygo_config: TinyGoConfig) -> Result<PathBuf> {
+    let filename = format!("build/{}.wasm", common_config.name);
+
+    let mut command = match tinygo_config.tinygo_path {
+        Some(path) => process::Command::new(path),
+        None => process::Command::new("tinygo"),
+    };
+
+    if let Some(p) = PathBuf::from(&filename).parent() {
+        fs::create_dir_all(p)?;
+    }
+
+    let result = command
+        .args([
+            "build",
+            "-o",
+            filename.as_str(),
+            "-target",
+            "wasm",
+            "-scheduler",
+            "none",
+            "-no-debug",
+            ".",
+        ])
+        .status()?;
+
+    if !result.success() {
+        bail!("Compiling actor failed: {}", result.to_string())
+    }
+
+    let wasm_file = PathBuf::from(filename);
+
+    if !wasm_file.exists() {
+        bail!(
+            "Could not find compiled wasm file to sign: {}",
+            wasm_file.display()
+        );
+    }
+
+    Ok(wasm_file)
+}
+
+/// Placeholder for future functionality for building providers
+#[allow(unused)]
+fn build_provider(
+    _provider_config: ProviderConfig,
+    _language_config: LanguageConfig,
+    _common_config: CommonConfig,
+    _no_sign: bool,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Placeholder for future functionality for building interfaces
+#[allow(unused)]
+fn build_interface(
+    _interface_config: InterfaceConfig,
+    _language_config: LanguageConfig,
+    _common_config: CommonConfig,
+) -> Result<()> {
+    Ok(())
+}

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -107,7 +107,7 @@ pub fn build_actor(
 
         // Output the signed file in the same directory with a _s suffix
         let destination = source.replace(".wasm", "_s.wasm");
-        let destination_file = PathBuf::from_str(&destination);
+        let destination_file = PathBuf::from_str(&destination)?;
 
         let sign_options = SignCommand {
             source,
@@ -124,7 +124,7 @@ pub fn build_actor(
         };
         sign_file(sign_options, OutputKind::Json)?;
 
-        Ok(destination_file?)
+        Ok(destination_file)
     } else {
         // Exit without signing
         Ok(file_path)

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -4,6 +4,7 @@
 use std::{fs, path::PathBuf, process, str::FromStr};
 
 use anyhow::{anyhow, bail, Result};
+use clap::Parser;
 
 use crate::cli::{
     claims::{sign_file, ActorMetadata, SignCommand},
@@ -13,6 +14,37 @@ use crate::parser::{
     ActorConfig, CommonConfig, InterfaceConfig, LanguageConfig, ProjectConfig, ProviderConfig,
     RustConfig, TinyGoConfig, TypeConfig,
 };
+
+// This struct requires the `cli` feature, which this whole module is gated by. If that changes,
+// this struct needs to be adjusted with the derive macros
+#[derive(Parser, Debug, Clone)]
+pub struct SignConfig {
+    /// Location of key files for signing. Defaults to $WASH_KEYS ($HOME/.wash/keys)
+    #[clap(long = "keys-directory", env = "WASH_KEYS", hide_env_values = true)]
+    pub keys_directory: Option<PathBuf>,
+
+    /// Path to issuer seed key (account). If this flag is not provided, the will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
+    #[clap(
+        short = 'i',
+        long = "issuer",
+        env = "WASH_ISSUER_KEY",
+        hide_env_values = true
+    )]
+    pub issuer: Option<String>,
+
+    /// Path to subject seed key (module or service). If this flag is not provided, the will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
+    #[clap(
+        short = 's',
+        long = "subject",
+        env = "WASH_SUBJECT_KEY",
+        hide_env_values = true
+    )]
+    pub subject: Option<String>,
+
+    /// Disables autogeneration of keys if seed(s) are not provided
+    #[clap(long = "disable-keygen")]
+    pub disable_keygen: bool,
+}
 
 /// Using a [ProjectConfig], usually parsed from a `wasmcloud.toml` file, build the project
 /// with the installed language toolchain. This will delegate to [build_actor] when the project is an actor,
@@ -28,10 +60,13 @@ use crate::parser::{
 /// let artifact_path = build_project(config)?;
 /// println!("Here is the signed artifact: {}", artifact_path.to_string_lossy());
 /// ```
-pub fn build_project(config: ProjectConfig) -> Result<PathBuf> {
-    match config.project_type {
+/// # Arguments
+/// * `config`: [ProjectConfig] for required information to find, build, and sign an actor
+/// * `signing`: Optional [SignConfig] for signing the actor
+pub fn build_project(config: &ProjectConfig, signing: Option<SignConfig>) -> Result<PathBuf> {
+    match &config.project_type {
         TypeConfig::Actor(actor_config) => {
-            build_actor(actor_config, config.language, config.common, false)
+            build_actor(actor_config, &config.language, &config.common, signing)
         }
         TypeConfig::Provider(_provider_config) => Err(anyhow!(
             "wash build has not be implemented for providers yet. Please use `make` for now!"
@@ -51,60 +86,64 @@ pub fn build_project(config: ProjectConfig) -> Result<PathBuf> {
 /// * `common_config`: [CommonConfig] specifying common parameters like [CommonConfig::name] and [CommonConfig::version]
 /// * `no_sign`: If `true`, build the actor but don't sign. Useful for just checking build status without needing signing keys or fully referenced capabilities
 pub fn build_actor(
-    actor_config: ActorConfig,
-    language_config: LanguageConfig,
-    common_config: CommonConfig,
-    no_sign: bool,
+    actor_config: &ActorConfig,
+    language_config: &LanguageConfig,
+    common_config: &CommonConfig,
+    signing_config: Option<SignConfig>,
 ) -> Result<PathBuf> {
     // Build actor based on language toolchain
     let file_path = match language_config {
         LanguageConfig::Rust(rust_config) => {
-            build_rust_actor(common_config.clone(), rust_config, actor_config.clone())
+            build_rust_actor(common_config, rust_config, actor_config)
         }
-        LanguageConfig::TinyGo(tinygo_config) => {
-            build_tinygo_actor(common_config.clone(), tinygo_config)
-        }
+        LanguageConfig::TinyGo(tinygo_config) => build_tinygo_actor(common_config, tinygo_config),
     }?;
 
-    // Exit early if signing isn't desired
-    if no_sign {
-        Ok(file_path)
-    } else {
+    if let Some(config) = signing_config {
         let source = file_path
             .to_str()
             .ok_or_else(|| anyhow!("Could not convert file path to string"))?
             .to_string();
 
-        let destination = format!("build/{}_s.wasm", common_config.name);
+        // Output the signed file in the same directory with a _s suffix
+        let destination = source.replace(".wasm", "_s.wasm");
         let destination_file = PathBuf::from_str(&destination);
 
         let sign_options = SignCommand {
             source,
             destination: Some(destination),
             metadata: ActorMetadata {
-                name: common_config.name,
+                name: common_config.name.clone(),
                 ver: Some(common_config.version.to_string()),
-                custom_caps: actor_config.claims,
-                call_alias: actor_config.call_alias,
+                custom_caps: actor_config.claims.clone(),
+                call_alias: actor_config.call_alias.clone(),
+                issuer: config.issuer,
+                subject: config.subject,
                 ..Default::default()
             },
         };
         sign_file(sign_options, OutputKind::Json)?;
 
         Ok(destination_file?)
+    } else {
+        // Exit without signing
+        Ok(file_path)
     }
 }
 
 /// Builds a rust actor and returns the path to the file.
 fn build_rust_actor(
-    common_config: CommonConfig,
-    rust_config: RustConfig,
-    actor_config: ActorConfig,
+    common_config: &CommonConfig,
+    rust_config: &RustConfig,
+    actor_config: &ActorConfig,
 ) -> Result<PathBuf> {
-    let mut command = match rust_config.cargo_path {
+    let mut command = match rust_config.cargo_path.as_ref() {
         Some(path) => process::Command::new(path),
         None => process::Command::new("cargo"),
     };
+
+    // Change directory into the project directory
+    std::env::set_current_dir(&common_config.path)?;
 
     let result = command.args(["build", "--release"]).status()?;
 
@@ -116,6 +155,7 @@ fn build_rust_actor(
         "{}/{}/release/{}.wasm",
         rust_config
             .target_path
+            .clone()
             .unwrap_or_else(|| PathBuf::from("target"))
             .to_string_lossy(),
         actor_config.wasm_target,
@@ -124,7 +164,7 @@ fn build_rust_actor(
 
     if !wasm_file.exists() {
         bail!(
-            "Could not find compiled wasm file to sign: {}",
+            "Could not find compiled wasm file, please ensure {} exists",
             wasm_file.display()
         );
     }
@@ -137,14 +177,21 @@ fn build_rust_actor(
     fs::copy(&wasm_file, &copied_wasm_file)?;
     fs::remove_file(&wasm_file)?;
 
-    Ok(copied_wasm_file)
+    // Return the full path to the compiled Wasm file
+    Ok(common_config.path.join(&copied_wasm_file))
 }
 
 /// Builds a tinygo actor and returns the path to the file.
-fn build_tinygo_actor(common_config: CommonConfig, tinygo_config: TinyGoConfig) -> Result<PathBuf> {
+fn build_tinygo_actor(
+    common_config: &CommonConfig,
+    tinygo_config: &TinyGoConfig,
+) -> Result<PathBuf> {
     let filename = format!("build/{}.wasm", common_config.name);
 
-    let mut command = match tinygo_config.tinygo_path {
+    // Change directory into the project directory
+    std::env::set_current_dir(&common_config.path)?;
+
+    let mut command = match &tinygo_config.tinygo_path {
         Some(path) => process::Command::new(path),
         None => process::Command::new("tinygo"),
     };
@@ -180,7 +227,7 @@ fn build_tinygo_actor(common_config: CommonConfig, tinygo_config: TinyGoConfig) 
         );
     }
 
-    Ok(wasm_file)
+    Ok(common_config.path.join(wasm_file))
 }
 
 /// Placeholder for future functionality for building providers

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -1,10 +1,8 @@
 //! Build (and sign) a wasmCloud actor, provider, or interface. Depends on the "cli" feature
-//!
 
 use std::{fs, path::PathBuf, process, str::FromStr};
 
 use anyhow::{anyhow, bail, Result};
-use clap::Parser;
 
 use crate::cli::{
     claims::{sign_file, ActorMetadata, SignCommand},
@@ -15,34 +13,19 @@ use crate::parser::{
     RustConfig, TinyGoConfig, TypeConfig,
 };
 
-// This struct requires the `cli` feature, which this whole module is gated by. If that changes,
-// this struct needs to be adjusted with the derive macros
-#[derive(Parser, Debug, Clone)]
+/// Configuration for signing an artifact (actor or provider) including issuer and subject key, the path to where keys can be found, and an option to
+/// disable automatic key generation if keys cannot be found.
 pub struct SignConfig {
-    /// Location of key files for signing. Defaults to $WASH_KEYS ($HOME/.wash/keys)
-    #[clap(long = "keys-directory", env = "WASH_KEYS", hide_env_values = true)]
+    /// Location of key files for signing
     pub keys_directory: Option<PathBuf>,
 
-    /// Path to issuer seed key (account). If this flag is not provided, the will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
-    #[clap(
-        short = 'i',
-        long = "issuer",
-        env = "WASH_ISSUER_KEY",
-        hide_env_values = true
-    )]
+    /// Path to issuer seed key (account). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
     pub issuer: Option<String>,
 
-    /// Path to subject seed key (module or service). If this flag is not provided, the will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
-    #[clap(
-        short = 's',
-        long = "subject",
-        env = "WASH_SUBJECT_KEY",
-        hide_env_values = true
-    )]
+    /// Path to subject seed key (module or service). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
     pub subject: Option<String>,
 
     /// Disables autogeneration of keys if seed(s) are not provided
-    #[clap(long = "disable-keygen")]
     pub disable_keygen: bool,
 }
 
@@ -62,7 +45,7 @@ pub struct SignConfig {
 /// ```
 /// # Arguments
 /// * `config`: [ProjectConfig] for required information to find, build, and sign an actor
-/// * `signing`: Optional [SignConfig] for signing the actor
+/// * `signing`: Optional [SignConfig] with information for signing the project artifact. If omitted, the artifact will only be built
 pub fn build_project(config: &ProjectConfig, signing: Option<SignConfig>) -> Result<PathBuf> {
     match &config.project_type {
         TypeConfig::Actor(actor_config) => {
@@ -84,7 +67,7 @@ pub fn build_project(config: &ProjectConfig, signing: Option<SignConfig>) -> Res
 /// * `actor_config`: [ActorConfig] for required information to find, build, and sign an actor
 /// * `language_config`: [LanguageConfig] specifying which language the actor is written in
 /// * `common_config`: [CommonConfig] specifying common parameters like [CommonConfig::name] and [CommonConfig::version]
-/// * `no_sign`: If `true`, build the actor but don't sign. Useful for just checking build status without needing signing keys or fully referenced capabilities
+/// * `signing`: Optional [SignConfig] with information for signing the actor. If omitted, the actor will only be built
 pub fn build_actor(
     actor_config: &ActorConfig,
     language_config: &LanguageConfig,

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -10,6 +10,8 @@ pub mod start;
 pub mod parser;
 
 #[cfg(feature = "cli")]
+pub mod build;
+#[cfg(feature = "cli")]
 pub mod cli;
 
 pub mod config;

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -42,6 +42,9 @@ fn rust_actor() {
         CommonConfig {
             name: "testactor".to_string(),
             version: Version::parse("0.1.0").unwrap(),
+            path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap()
         }
     );
 }
@@ -80,6 +83,9 @@ fn tinygo_actor() {
         CommonConfig {
             name: "testactor".to_string(),
             version: Version::parse("0.1.0").unwrap(),
+            path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap()
         }
     );
 }
@@ -258,6 +264,9 @@ fn minimal_rust_actor() {
         CommonConfig {
             name: "testactor".to_string(),
             version: Version::parse("0.1.0").unwrap(),
+            path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap()
         }
     )
 }
@@ -299,6 +308,9 @@ fn cargo_toml_actor() {
         CommonConfig {
             name: "withcargotoml".to_string(),
             version: Version::parse("0.200.0").unwrap(),
+            path: PathBuf::from("./tests/parser/files/withcargotoml")
+                .canonicalize()
+                .unwrap()
         }
     )
 }

--- a/sample-manifest.yaml
+++ b/sample-manifest.yaml
@@ -1,13 +1,13 @@
 ---
   actors:
-    - "wasmcloud.azurecr.io/echo:0.2.0"
+    - wasmcloud.azurecr.io/echo:0.3.4
   capabilities:
-    - image_ref: wasmcloud.azurecr.io/httpserver:0.13.1
+    - image_ref: wasmcloud.azurecr.io/httpserver:0.16.3
       link_name: default
   links:
     - actor: ${ECHO_ACTOR:MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5}
-      provider_id: "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
-      contract_id: "wasmcloud:httpserver"
+      provider_id: VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M
+      contract_id: wasmcloud:httpserver
       link_name: default
       values:
         PORT: 8080

--- a/src/build.rs
+++ b/src/build.rs
@@ -54,20 +54,38 @@ pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 #[cfg(test)]
 mod test {
 
-    // use super::*;
-    // use clap::Parser;
+    use super::*;
+    use clap::Parser;
 
     #[test]
     fn test_build_comprehensive() {
-        // let cmd: BuildCommand = Parser::try_parse_from(["build", "--push"]).unwrap();
-        // assert!(cmd.push);
+        let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
+        assert!(cmd.config_path.is_none());
+        assert!(!cmd.signing_config.disable_keygen);
+        assert!(cmd.signing_config.issuer.is_none());
+        assert!(cmd.signing_config.subject.is_none());
+        assert!(cmd.signing_config.keys_directory.is_none());
 
-        // let cmd: BuildCommand = Parser::try_parse_from(["build", "--no-sign"]).unwrap();
-        // assert!(cmd.no_sign);
-
-        // let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
-        // assert!(!cmd.push);
-        // assert!(!cmd.no_sign);
-        assert!(true)
+        let cmd: BuildCommand = Parser::try_parse_from([
+            "build",
+            "-p",
+            "/",
+            "--disable-keygen",
+            "--issuer",
+            "/tmp/iss.nk",
+            "--subject",
+            "/tmp/sub.nk",
+            "--keys-directory",
+            "/tmp",
+        ])
+        .unwrap();
+        assert_eq!(cmd.config_path, Some(PathBuf::from("/")));
+        assert!(cmd.signing_config.disable_keygen);
+        assert_eq!(cmd.signing_config.issuer, Some("/tmp/iss.nk".to_string()));
+        assert_eq!(cmd.signing_config.subject, Some("/tmp/sub.nk".to_string()));
+        assert_eq!(
+            cmd.signing_config.keys_directory,
+            Some(PathBuf::from("/tmp"))
+        );
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -16,10 +16,36 @@ pub(crate) struct BuildCommand {
     /// Path to the wasmcloud.toml file or parent folder to use for building
     #[clap(short = 'p', long = "config-path")]
     config_path: Option<PathBuf>,
-    //TODO(brooksmtownsend): In the future, when we support building capability providers
-    //for build, this will need to merge with the provider create options for a seamless build
-    #[clap(flatten)]
-    signing_config: SignConfig,
+
+    /// Location of key files for signing. Defaults to $WASH_KEYS ($HOME/.wash/keys)
+    #[clap(long = "keys-directory", env = "WASH_KEYS", hide_env_values = true)]
+    pub keys_directory: Option<PathBuf>,
+
+    /// Path to issuer seed key (account). If this flag is not provided, the seed will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
+    #[clap(
+        short = 'i',
+        long = "issuer",
+        env = "WASH_ISSUER_KEY",
+        hide_env_values = true
+    )]
+    pub issuer: Option<String>,
+
+    /// Path to subject seed key (module or service). If this flag is not provided, the seed will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found.
+    #[clap(
+        short = 's',
+        long = "subject",
+        env = "WASH_SUBJECT_KEY",
+        hide_env_values = true
+    )]
+    pub subject: Option<String>,
+
+    /// Disables autogeneration of keys if seed(s) are not provided
+    #[clap(long = "disable-keygen")]
+    pub disable_keygen: bool,
+
+    /// Skip signing the artifact and only use the native toolchain to build
+    #[clap(long = "build-only")]
+    pub build_only: bool,
 }
 
 pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
@@ -27,16 +53,32 @@ pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref _actor_config) => {
-            let actor_path = build_project(&config, Some(command.signing_config))?;
+            let actor_path = build_project(
+                &config,
+                if command.build_only {
+                    None
+                } else {
+                    Some(SignConfig {
+                        keys_directory: command.keys_directory,
+                        issuer: command.issuer,
+                        subject: command.subject,
+                        disable_keygen: command.disable_keygen,
+                    })
+                },
+            )?;
             let json_output = HashMap::from([
                 ("actor_path".to_string(), json!(actor_path)),
-                ("signed".to_string(), json!(true)),
+                ("signed".to_string(), json!(command.build_only)),
             ]);
             Ok(CommandOutput::new(
-                format!(
-                    "Actor built and signed and can be found at {:?}",
-                    actor_path
-                ),
+                if command.build_only {
+                    format!("Actor built and can be found at {:?}", actor_path)
+                } else {
+                    format!(
+                        "Actor built and signed and can be found at {:?}",
+                        actor_path
+                    )
+                },
                 json_output,
             ))
         }
@@ -61,10 +103,10 @@ mod test {
     fn test_build_comprehensive() {
         let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
         assert!(cmd.config_path.is_none());
-        assert!(!cmd.signing_config.disable_keygen);
-        assert!(cmd.signing_config.issuer.is_none());
-        assert!(cmd.signing_config.subject.is_none());
-        assert!(cmd.signing_config.keys_directory.is_none());
+        assert!(!cmd.disable_keygen);
+        assert!(cmd.issuer.is_none());
+        assert!(cmd.subject.is_none());
+        assert!(cmd.keys_directory.is_none());
 
         let cmd: BuildCommand = Parser::try_parse_from([
             "build",
@@ -80,12 +122,9 @@ mod test {
         ])
         .unwrap();
         assert_eq!(cmd.config_path, Some(PathBuf::from("/")));
-        assert!(cmd.signing_config.disable_keygen);
-        assert_eq!(cmd.signing_config.issuer, Some("/tmp/iss.nk".to_string()));
-        assert_eq!(cmd.signing_config.subject, Some("/tmp/sub.nk".to_string()));
-        assert_eq!(
-            cmd.signing_config.keys_directory,
-            Some(PathBuf::from("/tmp"))
-        );
+        assert!(cmd.disable_keygen);
+        assert_eq!(cmd.issuer, Some("/tmp/iss.nk".to_string()));
+        assert_eq!(cmd.subject, Some("/tmp/sub.nk".to_string()));
+        assert_eq!(cmd.keys_directory, Some(PathBuf::from("/tmp")));
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
 use serde_json::json;
 
-use wash_lib::build::{build_actor, build_project};
+use wash_lib::build::{build_project, SignConfig};
 use wash_lib::cli::CommandOutput;
 use wash_lib::parser::{get_config, TypeConfig};
 
@@ -12,29 +13,24 @@ use wash_lib::parser::{get_config, TypeConfig};
 #[derive(Debug, Parser, Clone)]
 #[clap(name = "build")]
 pub(crate) struct BuildCommand {
-    /// If set, pushes the signed actor to the registry.
-    #[clap(short = 'p', long = "push")]
-    pub(crate) push: bool,
-
-    /// If set, skips signing the actor. Cannot be used with --push, as an actor has to be signed to push it to the registry.
-    #[clap(long = "no-sign", conflicts_with = "push")]
-    pub(crate) no_sign: bool,
+    /// Path to the wasmcloud.toml file or parent folder to use for building
+    #[clap(short = 'p', long = "config-path")]
+    config_path: Option<PathBuf>,
+    //TODO(brooksmtownsend): In the future, when we support building capability providers
+    //for build, this will need to merge with the provider create options for a seamless build
+    #[clap(flatten)]
+    signing_config: SignConfig,
 }
 
 pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
-    let config = get_config(None, Some(true))?;
+    let config = get_config(command.config_path, Some(true))?;
 
     match config.project_type {
-        TypeConfig::Actor(actor_config) => {
-            let actor_path = build_actor(
-                actor_config,
-                config.language,
-                config.common,
-                command.no_sign,
-            )?;
+        TypeConfig::Actor(ref _actor_config) => {
+            let actor_path = build_project(&config, Some(command.signing_config))?;
             let json_output = HashMap::from([
                 ("actor_path".to_string(), json!(actor_path)),
-                ("signed".to_string(), json!(!command.no_sign)),
+                ("signed".to_string(), json!(true)),
             ]);
             Ok(CommandOutput::new(
                 format!(
@@ -45,8 +41,8 @@ pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
             ))
         }
         _ => {
-            let path = build_project(config)?;
             // Until providers and interfaces have build support, this codepath won't be exercised
+            let path = build_project(&config, None)?;
             Ok(CommandOutput::new(
                 format!("Built artifact can be found at {:?}", path),
                 HashMap::from([("path".to_string(), json!(path))]),
@@ -58,19 +54,20 @@ pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-    use clap::Parser;
+    // use super::*;
+    // use clap::Parser;
 
     #[test]
     fn test_build_comprehensive() {
-        let cmd: BuildCommand = Parser::try_parse_from(["build", "--push"]).unwrap();
-        assert!(cmd.push);
+        // let cmd: BuildCommand = Parser::try_parse_from(["build", "--push"]).unwrap();
+        // assert!(cmd.push);
 
-        let cmd: BuildCommand = Parser::try_parse_from(["build", "--no-sign"]).unwrap();
-        assert!(cmd.no_sign);
+        // let cmd: BuildCommand = Parser::try_parse_from(["build", "--no-sign"]).unwrap();
+        // assert!(cmd.no_sign);
 
-        let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
-        assert!(!cmd.push);
-        assert!(!cmd.no_sign);
+        // let cmd: BuildCommand = Parser::try_parse_from(["build"]).unwrap();
+        // assert!(!cmd.push);
+        // assert!(!cmd.no_sign);
+        assert!(true)
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,17 +1,12 @@
-use std::{collections::HashMap, fs, path::PathBuf, process};
+use std::collections::HashMap;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::Result;
 use clap::Parser;
 use serde_json::json;
-use wash_lib::parser::{
-    ActorConfig, CommonConfig, InterfaceConfig, LanguageConfig, ProviderConfig, RustConfig,
-    TinyGoConfig, TypeConfig,
-};
 
-use wash_lib::cli::{
-    claims::{sign_file, ActorMetadata, SignCommand},
-    CommandOutput, OutputKind,
-};
+use wash_lib::build::{build_actor, build_project};
+use wash_lib::cli::CommandOutput;
+use wash_lib::parser::{get_config, TypeConfig};
 
 /// Build (and sign) a wasmCloud actor, provider, or interface
 #[derive(Debug, Parser, Clone)]
@@ -26,216 +21,38 @@ pub(crate) struct BuildCommand {
     pub(crate) no_sign: bool,
 }
 
-pub(crate) fn handle_command(
-    command: BuildCommand,
-    output_kind: OutputKind,
-) -> Result<CommandOutput> {
-    let config = wash_lib::parser::get_config(None, Some(true))?;
+pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
+    let config = get_config(None, Some(true))?;
 
     match config.project_type {
-        TypeConfig::Actor(actor_config) => build_actor(
-            command,
-            output_kind,
-            actor_config,
-            config.language,
-            config.common,
-        ),
-        TypeConfig::Provider(provider_config) => build_provider(
-            command,
-            output_kind,
-            provider_config,
-            config.language,
-            config.common,
-        ),
-        TypeConfig::Interface(interface_config) => build_interface(
-            command,
-            output_kind,
-            interface_config,
-            config.language,
-            config.common,
-        ),
-    }
-}
-
-fn build_actor(
-    command: BuildCommand,
-    output_kind: OutputKind,
-    actor_config: ActorConfig,
-    language_config: LanguageConfig,
-    common_config: CommonConfig,
-) -> Result<CommandOutput> {
-    // build it
-    println!("Building actor...");
-    let file_path = match language_config {
-        LanguageConfig::Rust(rust_config) => {
-            build_rust_actor(common_config.clone(), rust_config, actor_config.clone())
+        TypeConfig::Actor(actor_config) => {
+            let actor_path = build_actor(
+                actor_config,
+                config.language,
+                config.common,
+                command.no_sign,
+            )?;
+            let json_output = HashMap::from([
+                ("actor_path".to_string(), json!(actor_path)),
+                ("signed".to_string(), json!(!command.no_sign)),
+            ]);
+            Ok(CommandOutput::new(
+                format!(
+                    "Actor built and signed and can be found at {:?}",
+                    actor_path
+                ),
+                json_output,
+            ))
         }
-        LanguageConfig::TinyGo(tinygo_config) => {
-            build_tinygo_actor(common_config.clone(), tinygo_config)
+        _ => {
+            let path = build_project(config)?;
+            // Until providers and interfaces have build support, this codepath won't be exercised
+            Ok(CommandOutput::new(
+                format!("Built artifact can be found at {:?}", path),
+                HashMap::from([("path".to_string(), json!(path))]),
+            ))
         }
-    }?;
-    println!("Done building actor");
-
-    if command.no_sign {
-        let mut hash_map = HashMap::new();
-        hash_map.insert("file".to_string(), json!(file_path.display().to_string()));
-
-        return Ok(CommandOutput::new(
-            format!("Unsigned actor built at {}", file_path.display()),
-            hash_map,
-        ));
     }
-
-    // sign it
-    println!("Signing actor...");
-    let file_path_string = file_path
-        .to_str()
-        .ok_or_else(|| anyhow!("Could not convert file path to string"))?
-        .to_string();
-
-    let sign_options = SignCommand {
-        source: file_path_string,
-        destination: Some(format!("build/{}_s.wasm", common_config.name)),
-        metadata: ActorMetadata {
-            name: common_config.name,
-            ver: Some(common_config.version.to_string()),
-            custom_caps: actor_config.claims,
-            call_alias: actor_config.call_alias,
-            ..Default::default()
-        },
-    };
-    let sign_output = sign_file(sign_options, output_kind)?;
-
-    if !command.push {
-        return Ok(sign_output);
-    }
-
-    println!("Signed actor: {}", sign_output.text);
-
-    // push it
-    Ok(CommandOutput::from_key_and_text(
-        "result",
-        "Pushing has not be implemented yet, please use wash reg push.".to_string(),
-    ))
-}
-
-/// Builds a rust actor and returns the path to the file.
-pub fn build_rust_actor(
-    common_config: CommonConfig,
-    rust_config: RustConfig,
-    actor_config: ActorConfig,
-) -> Result<PathBuf> {
-    let mut command = match rust_config.cargo_path {
-        Some(path) => process::Command::new(path),
-        None => process::Command::new("cargo"),
-    };
-
-    let result = command.args(["build", "--release"]).status()?;
-
-    if !result.success() {
-        bail!("Compiling actor failed: {}", result.to_string())
-    }
-
-    let wasm_file = PathBuf::from(format!(
-        "{}/{}/release/{}.wasm",
-        rust_config
-            .target_path
-            .unwrap_or_else(|| PathBuf::from("target"))
-            .to_string_lossy(),
-        actor_config.wasm_target,
-        common_config.name,
-    ));
-
-    if !wasm_file.exists() {
-        bail!(
-            "Could not find compiled wasm file to sign: {}",
-            wasm_file.display()
-        );
-    }
-
-    // move the file out into the build/ folder for parity with tinygo and convienience for users.
-    let copied_wasm_file = PathBuf::from(format!("build/{}.wasm", common_config.name));
-    if let Some(p) = copied_wasm_file.parent() {
-        fs::create_dir_all(p)?;
-    }
-    fs::copy(&wasm_file, &copied_wasm_file)?;
-    fs::remove_file(&wasm_file)?;
-
-    Ok(copied_wasm_file)
-}
-
-/// Builds a tinygo actor and returns the path to the file.
-pub fn build_tinygo_actor(
-    common_config: CommonConfig,
-    tinygo_config: TinyGoConfig,
-) -> Result<PathBuf> {
-    let filename = format!("build/{}.wasm", common_config.name);
-
-    let mut command = match tinygo_config.tinygo_path {
-        Some(path) => process::Command::new(path),
-        None => process::Command::new("tinygo"),
-    };
-
-    if let Some(p) = PathBuf::from(&filename).parent() {
-        fs::create_dir_all(p)?;
-    }
-
-    let result = command
-        .args([
-            "build",
-            "-o",
-            filename.as_str(),
-            "-target",
-            "wasm",
-            "-scheduler",
-            "none",
-            "-no-debug",
-            ".",
-        ])
-        .status()?;
-
-    if !result.success() {
-        bail!("Compiling actor failed: {}", result.to_string())
-    }
-
-    let wasm_file = PathBuf::from(filename);
-
-    if !wasm_file.exists() {
-        bail!(
-            "Could not find compiled wasm file to sign: {}",
-            wasm_file.display()
-        );
-    }
-
-    Ok(wasm_file)
-}
-
-fn build_provider(
-    _command: BuildCommand,
-    _output_kind: OutputKind,
-    _provider_config: ProviderConfig,
-    _language_config: LanguageConfig,
-    _common_config: CommonConfig,
-) -> Result<CommandOutput> {
-    Ok(CommandOutput::from_key_and_text(
-        "result",
-        "wash build has not be implemented for providers yet. Please use `make` for now!"
-            .to_string(),
-    ))
-}
-
-fn build_interface(
-    _command: BuildCommand,
-    _output_kind: OutputKind,
-    _interface_config: InterfaceConfig,
-    _language_config: LanguageConfig,
-    _common_config: CommonConfig,
-) -> Result<CommandOutput> {
-    Ok(CommandOutput::from_key_and_text(
-        "result",
-        "wash build has not be implemented for interfaces yet. Please use `make` for now!"
-            .to_string(),
-    ))
 }
 
 #[cfg(test)]

--- a/src/build.rs
+++ b/src/build.rs
@@ -53,19 +53,18 @@ pub(crate) fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref _actor_config) => {
-            let actor_path = build_project(
-                &config,
-                if command.build_only {
-                    None
-                } else {
-                    Some(SignConfig {
-                        keys_directory: command.keys_directory,
-                        issuer: command.issuer,
-                        subject: command.subject,
-                        disable_keygen: command.disable_keygen,
-                    })
-                },
-            )?;
+            let sign_config = if command.build_only {
+                None
+            } else {
+                Some(SignConfig {
+                    keys_directory: command.keys_directory,
+                    issuer: command.issuer,
+                    subject: command.subject,
+                    disable_keygen: command.disable_keygen,
+                })
+            };
+
+            let actor_path = build_project(&config, sign_config)?;
             let json_output = HashMap::from([
                 ("actor_path".to_string(), json!(actor_path)),
                 ("signed".to_string(), json!(command.build_only)),

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -257,7 +257,6 @@ pub(crate) fn ensure_host_config_context(context_dir: &ContextDir) -> Result<()>
 
 /// Load the host configuration file and create a context called `host_config` from it
 fn create_host_config_context(context_dir: &ContextDir) -> Result<()> {
-    println!("My context dir is: {}", context_dir.display());
     let host_config_ctx = WashContext {
         name: HOST_CONFIG_NAME.to_string(),
         ..load_context(cfg_dir()?.join(format!("{}.json", HOST_CONFIG_NAME)))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ async fn main() {
 
     let res: Result<CommandOutput> = match cli.command {
         CliCommand::App(app_cli) => app::handle_command(app_cli, output_kind).await,
-        CliCommand::Build(build_cli) => build::handle_command(build_cli, output_kind),
+        CliCommand::Build(build_cli) => build::handle_command(build_cli),
         CliCommand::Call(call_cli) => call::handle_command(call_cli.command()).await,
         CliCommand::Claims(claims_cli) => {
             wash_lib::cli::claims::handle_command(claims_cli, output_kind).await

--- a/tests/integration_build.rs
+++ b/tests/integration_build.rs
@@ -48,7 +48,7 @@ fn build_new_project(template: &str, subdir: &str, build_result: &str, signed: b
     if signed {
         run_cmd!( $wash build )
     } else {
-        run_cmd!( $wash build --no-sign )
+        run_cmd!( $wash build --build-only )
     }
     .map_err(|e| anyhow!("wash build failed: {}", e))?;
 


### PR DESCRIPTION
This PR moves majority of the `build` module's functionality into `wash-lib`, exposing two functions:
- `build_project` that simply takes a parsed wasmcloud.toml and builds based on the project
- `build_actor` that takes actor, language, and common config to build an actor (along with another option `no_sign`). I removed `push` as an option since we may not implement it at all, and it would be a breaking change to add either way.

I also chose to gate this behind the `cli` field for now to safe effort on refactoring `cli/claims.rs` to a different module. The only reason why this is behind the `cli` flag anyways is to reuse the `sign_file` function.

This PR also adds in a few more flags into the `wash build` command which allow you to sign an actor/provider with provided issuer or subject keys, just like `wash claims sign` allows