### PR TITLE
fixed 352, added js_domain to context

### DIFF
--- a/crates/wash-lib/src/context/fs.rs
+++ b/crates/wash-lib/src/context/fs.rs
@@ -188,7 +188,7 @@ mod test {
 
         let mut orig_ctx = WashContext {
             name: "happy_path".to_string(),
-            rpc_lattice_prefix: "foobar".to_string(),
+            lattice_prefix: "foobar".to_string(),
             ..Default::default()
         };
 
@@ -219,14 +219,13 @@ mod test {
             .load_context("happy_path")
             .expect("Should be able to load context from disk");
         assert!(
-            orig_ctx.name == loaded.name
-                && orig_ctx.rpc_lattice_prefix == loaded.rpc_lattice_prefix,
+            orig_ctx.name == loaded.name && orig_ctx.lattice_prefix == loaded.lattice_prefix,
             "Should have loaded the correct context from disk"
         );
 
         // Save one more context
         orig_ctx.name = "happy_gilmore".to_string();
-        orig_ctx.rpc_lattice_prefix = "baz".to_string();
+        orig_ctx.lattice_prefix = "baz".to_string();
         ctx_dir
             .save_context(&orig_ctx)
             .expect("Should be able to save second context");
@@ -254,8 +253,7 @@ mod test {
             .load_default_context()
             .expect("Should be able to load default context from disk");
         assert!(
-            orig_ctx.name == loaded.name
-                && orig_ctx.rpc_lattice_prefix == loaded.rpc_lattice_prefix,
+            orig_ctx.name == loaded.name && orig_ctx.lattice_prefix == loaded.lattice_prefix,
             "Should have loaded the correct context from disk"
         );
 

--- a/crates/wash-lib/src/context/mod.rs
+++ b/crates/wash-lib/src/context/mod.rs
@@ -74,7 +74,9 @@ pub struct WashContext {
     pub ctl_timeout: u64,
 
     #[serde(default = "default_lattice_prefix")]
-    pub ctl_lattice_prefix: String,
+    pub lattice_prefix: String,
+
+    pub js_domain: Option<String>,
 
     #[serde(default = "default_nats_host")]
     pub rpc_host: String,
@@ -88,9 +90,6 @@ pub struct WashContext {
     /// rpc timeout in milliseconds
     #[serde(default = "default_timeout_ms")]
     pub rpc_timeout: u64,
-
-    #[serde(default = "default_lattice_prefix")]
-    pub rpc_lattice_prefix: String,
 }
 
 impl WashContext {
@@ -114,14 +113,14 @@ impl Default for WashContext {
             ctl_seed: None,
             ctl_credsfile: None,
             ctl_timeout: DEFAULT_NATS_TIMEOUT_MS,
-            ctl_lattice_prefix: DEFAULT_LATTICE_PREFIX.to_string(),
+            lattice_prefix: DEFAULT_LATTICE_PREFIX.to_string(),
+            js_domain: None,
             rpc_host: DEFAULT_NATS_HOST.to_string(),
             rpc_port: DEFAULT_NATS_PORT.parse().unwrap(),
             rpc_jwt: None,
             rpc_seed: None,
             rpc_credsfile: None,
             rpc_timeout: DEFAULT_NATS_TIMEOUT_MS,
-            rpc_lattice_prefix: DEFAULT_LATTICE_PREFIX.to_string(),
         }
     }
 }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1077,7 +1077,7 @@ async fn ctl_client_from_opts(
 
     let lattice_prefix = opts.lattice_prefix.unwrap_or_else(|| {
         ctx.as_ref()
-            .map(|c| c.ctl_lattice_prefix.clone())
+            .map(|c| c.lattice_prefix.clone())
             .unwrap_or_else(|| DEFAULT_LATTICE_PREFIX.to_string())
     });
 

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -360,7 +360,7 @@ fn prompt_for_context() -> Result<WashContext> {
     )?;
 
     let js_domain = match user_question(
-        "What JetStream domain will th host be running, if any?",
+        "What JetStream domain will the host be running, if any?",
         &Some("".to_string()),
     ) {
         Ok(s) if s.is_empty() => None,

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -311,7 +311,7 @@ fn prompt_for_context() -> Result<WashContext> {
 
     let cluster_seed = match user_question(
         "What cluster seed do you want to use to sign invocations?",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s.parse::<ClusterSeed>()?),
@@ -327,7 +327,7 @@ fn prompt_for_context() -> Result<WashContext> {
     )?;
     let ctl_jwt = match user_question(
         "Enter your JWT that you use to authenticate to the control interface connection, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -335,7 +335,7 @@ fn prompt_for_context() -> Result<WashContext> {
     };
     let ctl_seed = match user_question(
         "Enter your user seed that you use to authenticate to the control interface connection, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -343,7 +343,7 @@ fn prompt_for_context() -> Result<WashContext> {
     };
     let ctl_credsfile = match user_question(
         "Enter the absolute path to control interface connection credsfile, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -361,7 +361,7 @@ fn prompt_for_context() -> Result<WashContext> {
 
     let js_domain = match user_question(
         "What JetStream domain will the host be running, if any?",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -378,7 +378,7 @@ fn prompt_for_context() -> Result<WashContext> {
     )?;
     let rpc_jwt = match user_question(
         "Enter your JWT that you use to authenticate to the RPC connection, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -386,7 +386,7 @@ fn prompt_for_context() -> Result<WashContext> {
     };
     let rpc_seed = match user_question(
         "Enter your user seed that you use to authenticate to the RPC connection, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),
@@ -394,7 +394,7 @@ fn prompt_for_context() -> Result<WashContext> {
     };
     let rpc_credsfile = match user_question(
         "Enter the absolute path to RPC connection credsfile, if applicable",
-        &Some("".to_string()),
+        &Some(String::new()),
     ) {
         Ok(s) if s.is_empty() => None,
         Ok(s) => Some(s),

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -353,10 +353,21 @@ fn prompt_for_context() -> Result<WashContext> {
         "What should the control interface timeout be (in milliseconds)?",
         &Some(DEFAULT_NATS_TIMEOUT_MS.to_string()),
     )?;
-    let ctl_lattice_prefix = user_question(
-        "What is the control interface connection lattice prefix?",
+
+    let lattice_prefix = user_question(
+        "What is the lattice prefix that the host will communicate on?",
         &Some(DEFAULT_LATTICE_PREFIX.to_string()),
     )?;
+
+    let js_domain = match user_question(
+        "What JetStream domain will th host be running, if any?",
+        &Some("".to_string()),
+    ) {
+        Ok(s) if s.is_empty() => None,
+        Ok(s) => Some(s),
+        _ => None,
+    };
+
     let rpc_host = user_question(
         "What is the RPC host?",
         &Some(DEFAULT_NATS_HOST.to_string()),
@@ -393,10 +404,6 @@ fn prompt_for_context() -> Result<WashContext> {
         "What should the RPC timeout be (in milliseconds)?",
         &Some(DEFAULT_NATS_TIMEOUT_MS.to_string()),
     )?;
-    let rpc_lattice_prefix = user_question(
-        "What is the RPC connection lattice prefix?",
-        &Some(DEFAULT_LATTICE_PREFIX.to_string()),
-    )?;
 
     Ok(WashContext {
         name,
@@ -407,14 +414,14 @@ fn prompt_for_context() -> Result<WashContext> {
         ctl_seed,
         ctl_credsfile: ctl_credsfile.map(PathBuf::from),
         ctl_timeout: ctl_timeout.parse()?,
-        ctl_lattice_prefix,
+        lattice_prefix,
+        js_domain,
         rpc_host,
         rpc_port: rpc_port.parse().unwrap_or_default(),
         rpc_jwt,
         rpc_seed,
         rpc_credsfile: rpc_credsfile.map(PathBuf::from),
         rpc_timeout: rpc_timeout.parse()?,
-        rpc_lattice_prefix,
     })
 }
 


### PR DESCRIPTION
Fixes #352 

This PR also adds parsing the `js_domain` to the Context, which will be useful after https://github.com/wasmCloud/wasmcloud-otp/pull/513 and the control interface client has Jetstream domain support