### PR TITLE
bump version of wasmcloud-control-interface to include contract_id on ProviderDescription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3653aaa00c7bdfadced94c8466bb28310540e1799603f9e5130803e319ca3b8"
+checksum = "ad5d2d5412da4546c1b5ac4e648745fb8d8ccc500770482626fe4adc990db5a1"
 dependencies = [
  "async-nats",
  "cloudevents-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ which = "4.2.2"
 wash-lib = { version = "0.4.0-alpha.2", path = "./crates/wash-lib", features = ["cli"] }
 wascap = "0.8.0"
 weld-codegen = "0.6.0"
-wasmcloud-control-interface = "0.22.2"
+wasmcloud-control-interface = "0.22.3"
 wasmbus-rpc = "0.11.2"
 wasmcloud-test-util = "0.6.4"
 


### PR DESCRIPTION
New output (note `contract_id`). Also tested with an older version of the host that doesn't provide this field, and it correctly renders as an empty string
```
{
  "inventory": {
    "actors": [],
    "host_id": "NC3QD5QFTJHHE5A45D4H4DUYSIGX4DBIFONLQR43SAHT5HL3X77KHQZY",
    "labels": {
      "hostcore.arch": "aarch64",
      "hostcore.os": "macos",
      "hostcore.osfamily": "unix"
    },
    "providers": [
      {
        "annotations": {},
        "contract_id": "wasmcloud:httpserver",
        "id": "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M",
        "image_ref": "wasmcloud.azurecr.io/httpserver:0.16.2",
        "link_name": "default",
        "name": "HTTP Server",
        "revision": 1657907669
      }
    ]
  },
  "success": true
}
```

Signed-off-by: Connor Smith <connor@cosmonic.com>