### PR TITLE
Updated list of linux distributions to release for

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -51,13 +51,13 @@ jobs:
           nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
         run: |
-          debs=(35 200 203 206 207 210 215 219 220 221 222 223 229 232 233 235 237 238 259 261)
+          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
           for distro_version in "${debs[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done
       - name: Push x86_64 (rpm)
         run: |
-          rpms=(194 204 209 216 225 226 231 236 239 240 243 244 260)
+          rpms=(194 204 209 216 226 231 236 239 240 244 260)
           for distro_version in "${rpms[@]}"; do 
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -51,13 +51,13 @@ jobs:
           nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
         run: |
-          debs=(35 150 155 156 190 200 203 206 207 210 215 219 220 221 222 223 229 232 233 235 237 238 259 261)
+          debs=(35 200 203 206 207 210 215 219 220 221 222 223 229 232 233 235 237 238 259 261)
           for distro_version in "${debs[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done
       - name: Push x86_64 (rpm)
         run: |
-          rpms=(140 141 146 181 186 194 198 204 205 209 214 216 218 225 226 231 234 236 239 240 243 244 260)
+          rpms=(194 204 209 216 225 226 231 236 239 240 243 244 260)
           for distro_version in "${rpms[@]}"; do 
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -51,13 +51,13 @@ jobs:
           nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
       - name: Push amd64 (deb)
         run: |
-          debs=(35 150 155 156 190 203 206 207 210 215 219)
+          debs=(35 150 155 156 190 200 203 206 207 210 215 219 220 221 222 223 229 232 233 235 237 238 259 261)
           for distro_version in "${debs[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done
       - name: Push x86_64 (rpm)
         run: |
-          rpms=(140 141 146 194 204 205 209 216)
+          rpms=(140 141 146 181 186 194 198 204 205 209 214 216 218 225 226 231 234 236 239 240 243 244 260)
           for distro_version in "${rpms[@]}"; do 
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done


### PR DESCRIPTION
Fixes #348
Partially Fixes #335
Fixes #260 

This PR updates the list of distributions that we release `wash` for to release for the following amd64 distros:
- DEB
	- Ubuntu
		- 19.04 Bionic Beaver - 22.10 Kinetic Kudu
	- Debian
		- 11 bullseye - 13 Trixie
	- Raspbian
		- 11 bullseye
- RPM
	- RHEL
		- Enterprise Linux 9.0
	- Fedora
		- 30 - 37
	- Oracle Linux
		- 8.0-9.0

We also release a `deb` for the `any/any` distribution, but sometimes this doesn't always get selected for a repository we don't officially release for.

As a follow-on PR, I'd love to add the aarch64 wash binary so that we can release an `apt` install target for aarch64 linux as well.

edit: I got this list by querying the packagecloud API: https://packagecloud.io/docs/api#resource_distributions
edit2: I'm currently running through a few compatibility checks, I want to ensure that we aren't introducing any unfulfillable dynamic links with this list of supported OS-es.
edit3: removed some older distro versions that do not have new enough versions of glibc