### PR TITLE
fix(wash-up): grant execute permission to `mac_listener` for hot-reloading

### DIFF
--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -337,10 +337,8 @@ mod test {
         NATS_SERVER_BINARY,
     };
     use reqwest::StatusCode;
-    #[cfg(target_family = "unix")]
-    use std::os::unix::prelude::PermissionsExt;
     use std::{collections::HashMap, env::temp_dir};
-    use tokio::fs::{create_dir_all, remove_dir_all, File};
+    use tokio::fs::{create_dir_all, remove_dir_all};
     const WASMCLOUD_VERSION: &str = "v0.57.1";
 
     #[tokio::test]
@@ -360,12 +358,16 @@ mod test {
         }
     }
 
+    #[cfg(target_family = "unix")]
+    use std::os::unix::prelude::PermissionsExt;
+
     #[tokio::test]
     async fn can_download_wasmcloud_tarball() {
         let download_dir = temp_dir().join("can_download_wasmcloud_tarball");
         let res =
             ensure_wasmcloud_for_os_arch_pair("macos", "aarch64", WASMCLOUD_VERSION, &download_dir)
                 .await;
+
         assert!(res.is_ok());
         assert!(is_wasmcloud_installed(&download_dir).await);
 
@@ -373,10 +375,10 @@ mod test {
         #[cfg(target_family = "unix")]
         {
             let mut fs_dir: Option<std::path::PathBuf> = None;
-            let lib_dir = download_dir.join("lib");
+            let mut entries = tokio::fs::read_dir(download_dir.join("lib")).await.unwrap();
 
-            for entry in std::fs::read_dir(lib_dir).unwrap() {
-                let dir = entry.unwrap().path();
+            while let Some(entry) = entries.next_entry().await.unwrap() {
+                let dir = entry.path();
                 let file_name = dir.file_name().unwrap().to_string_lossy();
 
                 if file_name.contains("file_system") {
@@ -386,7 +388,7 @@ mod test {
             }
 
             let path = fs_dir.unwrap().join("priv/mac_listener");
-            let file = File::open(path).await.unwrap();
+            let file = tokio::fs::File::open(path).await.unwrap();
             let metadata = file.metadata().await.unwrap();
             let perms = metadata.permissions();
 

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -182,6 +182,7 @@ where
                             || file_name.eq("iex")
                             || file_name.eq("elixir")
                             || file_name.eq("wasmcloud_host")
+                            || file_name.eq("mac_listener")
                         {
                             let mut perms = wasmcloud_file.metadata().await?.permissions();
                             perms.set_mode(0o755);
@@ -336,8 +337,10 @@ mod test {
         NATS_SERVER_BINARY,
     };
     use reqwest::StatusCode;
+    #[cfg(target_family = "unix")]
+    use std::os::unix::prelude::PermissionsExt;
     use std::{collections::HashMap, env::temp_dir};
-    use tokio::fs::{create_dir_all, remove_dir_all};
+    use tokio::fs::{create_dir_all, remove_dir_all, File};
     const WASMCLOUD_VERSION: &str = "v0.57.1";
 
     #[tokio::test]
@@ -365,6 +368,31 @@ mod test {
                 .await;
         assert!(res.is_ok());
         assert!(is_wasmcloud_installed(&download_dir).await);
+
+        // Permit execution of file-watching on macos.
+        #[cfg(target_family = "unix")]
+        {
+            let mut fs_dir: Option<std::path::PathBuf> = None;
+            let lib_dir = download_dir.join("lib");
+
+            for entry in std::fs::read_dir(lib_dir).unwrap() {
+                let dir = entry.unwrap().path();
+                let file_name = dir.file_name().unwrap().to_string_lossy();
+
+                if file_name.contains("file_system") {
+                    fs_dir = Some(dir);
+                    break;
+                }
+            }
+
+            let path = fs_dir.unwrap().join("priv/mac_listener");
+            let file = File::open(path).await.unwrap();
+            let metadata = file.metadata().await.unwrap();
+            let perms = metadata.permissions();
+
+            assert_eq!(perms.mode(), 0o100755);
+        }
+
         let _ = remove_dir_all(download_dir).await;
     }
 


### PR DESCRIPTION
PR to demonstrate the essence of a fix for hot reloading actors on my system.
```
11:51:56.091 [info] Starting actor MDPJTMU43XXM5KWADFSEI7LM7IL3SSVU565DXIJXCH457TPPI2VU7WCT
11:51:56.211 [error] GenServer :actor_watcher terminating
** (MatchError) no match of right hand side value: :ignore
    (wasmcloud_host 0.57.1) lib/wasmcloud_host/actor_watcher.ex:91: WasmcloudHost.ActorWatcher.handle_call/3
    (stdlib 4.0.1) gen_server.erl:1146: :gen_server.try_handle_call/4
    (stdlib 4.0.1) gen_server.erl:1175: :gen_server.handle_msg/6
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.2272.0>): {:hotwatch_actor, "/path/to/myactor_s.wasm", 1}
11:51:56.212 [error] GenServer #PID<0.2272.0> terminating
** (stop) exited in: GenServer.call(:actor_watcher, {:hotwatch_actor, "/path/to/myactor_s.wasm", 1}, 60000)
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: :ignore
            (wasmcloud_host 0.57.1) lib/wasmcloud_host/actor_watcher.ex:91: WasmcloudHost.ActorWatcher.handle_call/3
            (stdlib 4.0.1) gen_server.erl:1146: :gen_server.try_handle_call/4
            (stdlib 4.0.1) gen_server.erl:1175: :gen_server.handle_msg/6
            (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
    (elixir 1.13.4) lib/gen_server.ex:1030: GenServer.call/3
    (wasmcloud_host 0.57.1) lib/wasmcloud_host_web/live/components/start_actor_component.ex:69: StartActorComponent.handle_event/3
    (phoenix_live_view 0.16.4) lib/phoenix_live_view/channel.ex:553: anonymous fn/4 in Phoenix.LiveView.Channel.inner_component_handle_event/4
    (telemetry 0.4.3) /Users/brooks/github.com/wasmcloud/wasmcloud-otp/wasmcloud_host/deps/telemetry/src/telemetry.erl:272: :telemetry.span/3
    (phoenix_live_view 0.16.4) lib/phoenix_live_view/diff.ex:199: Phoenix.LiveView.Diff.write_component/4
    (phoenix_live_view 0.16.4) lib/phoenix_live_view/channel.ex:483: Phoenix.LiveView.Channel.component_handle_event/6
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
Last message: %Phoenix.Socket.Message{event: "event", join_ref: "4", payload: %{"cid" => 1, "event" => "start_actor_file_hotreload", "type" => "form", "value" => "_csrf_token=YS9dPRszDlsDfmAYU3UhMz87YB4vYQw_SIoUVFdjM9USgCFVOy6gk49m&path=%2Fpath%2Fto%2Fmyactor_s.wasm&count=1"}, ref: "8", topic: "lv:phx-Fzbamyqx_P2RtwAi"}
11:52:27.703 [info] Elixir.Gnat.ConsumerSupervisor starting graceful shutdown
11:52:28.204 [info] Elixir.Gnat.ConsumerSupervisor finished graceful shutdown
```
Demonstrating the site of the error by running `./bin/wasmcloud_host remote` and:
```
iex> {:ok, backend} = FileSystem.Backend.backend(:fs_mac)
{:ok, FileSystem.Backends.FSMac}
iex> args = [worker_pid: self(), dirs: ["/path/to/myactor_s.wasm"]]
[
  worker_pid: #PID<0.2308.0>,
  dirs: ["/path/to/myactor_s.wasm"]
]
iex> memo = backend.start_link(args)
** (EXIT from #PID<0.2308.0>) shell process exited with reason: an exception was raised:
    ** (ErlangError) Erlang error: :eacces
        :erlang.open_port({:spawn_executable, '/Users/me/.wash/downloads/lib/file_system-0.2.10/priv/mac_listener'}, [:stream, :exit_status, {:line, 16384}, {:args, ['-F', '/Users/me/Desktop/src/personal/verbalcode/build/verbalcode_s.wasm']}, {:cd, "/var/folders/r5/0kbwx40j3r55w4gbc2klj4300000gn/T/"}])
        (file_system 0.2.10) lib/file_system/backends/fs_mac.ex:143: FileSystem.Backends.FSMac.init/1
        (stdlib 4.0.1) gen_server.erl:848: :gen_server.init_it/2
        (stdlib 4.0.1) gen_server.erl:811: :gen_server.init_it/6
        (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```
Which is fixed by manually changing permissions: `chmod a+x lib/file_system-0.2.10/priv/mac_listener`