### PR TITLE
Fix/aarch64 debrpm release

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -29,6 +29,9 @@ jobs:
 
   package:
     needs: [cargo_check, clippy_check]
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
     runs-on: ubuntu-20.04
     env:
       REF: ${{ github.ref }}
@@ -38,17 +41,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Compile wash
+        if: ${{ matrix.arch == "amd64"}}
         run: cargo build --release
+      - uses: wasmcloud/common-actions/install-cross@main
+        if: ${{ matrix.arch == "arm64"}}
+      - name: Compile wash
+        if: ${{ matrix.arch == "arm64"}}
+        run: |
+          cargo build --target aarch64-unknown-linux-gnu --release
       - name: Install NFPM
         run: |
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
           sudo apt update
           sudo apt install nfpm
-      - name: Package amd64 (Debian)
+      - name: Package Debian
         run: |
           export VERSION=$(echo $REF | cut -d/ -f3)
-          nfpm pkg --packager deb -f build/nfpm.amd64.yaml
-          nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
+          nfpm pkg --packager deb -f build/nfpm.${{matrix.arch}}.yaml
+          nfpm pkg --packager rpm -f build/nfpm.${{matrix.arch}}.yaml
       - name: Push amd64 (deb)
         run: |
           debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -2,6 +2,7 @@ name: Release - Deb / RPM
 
 on:
   pull_request:
+    branches: [main]
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -1,8 +1,6 @@
 name: Release - Deb / RPM
 
 on:
-  pull_request:
-    branches: [main]
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -30,7 +28,7 @@ jobs:
           args: --all-features
 
   package:
-    # needs: [cargo_check, clippy_check]
+    needs: [cargo_check, clippy_check]
     strategy:
       matrix:
         arch: [arm64, amd64]
@@ -45,8 +43,10 @@ jobs:
       - name: Compile wash
         if: ${{ matrix.arch }} == 'amd64'
         run: cargo build --release
-      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Install cross
         if: ${{ matrix.arch }} == 'arm64'
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
       - name: Compile wash
         if: ${{ matrix.arch }} == 'arm64'
         run: |
@@ -61,15 +61,15 @@ jobs:
           export VERSION=$(echo $REF | cut -d/ -f3)
           nfpm pkg --packager deb -f build/nfpm.${{matrix.arch}}.yaml
           nfpm pkg --packager rpm -f build/nfpm.${{matrix.arch}}.yaml
-      # - name: Push amd64 (deb)
-      #   run: |
-      #     debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
-      #     for distro_version in "${debs[@]}"; do
-      #       curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
-      #     done
-      # - name: Push x86_64 (rpm)
-      #   run: |
-      #     rpms=(194 204 209 216 226 231 236 239 240 244 260)
-      #     for distro_version in "${rpms[@]}"; do 
-      #       curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
-      #     done
+      - name: Push amd64 (deb)
+        run: |
+          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
+          for distro_version in "${debs[@]}"; do
+            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
+          done
+      - name: Push x86_64 (rpm)
+        run: |
+          rpms=(194 204 209 216 226 231 236 239 240 244 260)
+          for distro_version in "${rpms[@]}"; do 
+            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
+          done

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -1,6 +1,7 @@
-name: Release - amd64
+name: Release - Deb / RPM
 
 on:
+  pull_request:
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -59,15 +60,15 @@ jobs:
           export VERSION=$(echo $REF | cut -d/ -f3)
           nfpm pkg --packager deb -f build/nfpm.${{matrix.arch}}.yaml
           nfpm pkg --packager rpm -f build/nfpm.${{matrix.arch}}.yaml
-      - name: Push amd64 (deb)
-        run: |
-          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
-          for distro_version in "${debs[@]}"; do
-            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
-          done
-      - name: Push x86_64 (rpm)
-        run: |
-          rpms=(194 204 209 216 226 231 236 239 240 244 260)
-          for distro_version in "${rpms[@]}"; do 
-            curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
-          done
+      # - name: Push amd64 (deb)
+      #   run: |
+      #     debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
+      #     for distro_version in "${debs[@]}"; do
+      #       curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
+      #     done
+      # - name: Push x86_64 (rpm)
+      #   run: |
+      #     rpms=(194 204 209 216 226 231 236 239 240 244 260)
+      #     for distro_version in "${rpms[@]}"; do 
+      #       curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
+      #     done

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -46,9 +46,9 @@ jobs:
         if: ${{ matrix.arch == "amd64"}}
         run: cargo build --release
       - uses: wasmcloud/common-actions/install-cross@main
-        if: ${{ matrix.arch == "arm64"}}
+        if: ${{ matrix.arch == 'arm64' }}
       - name: Compile wash
-        if: ${{ matrix.arch == "arm64"}}
+        if: ${{ matrix.arch == 'arm64' }}
         run: |
           cargo build --target aarch64-unknown-linux-gnu --release
       - name: Install NFPM

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Compile wash
-        if: ${{ matrix.arch == "amd64"}}
+        if: ${{ matrix.arch }} == 'amd64'
         run: cargo build --release
       - uses: wasmcloud/common-actions/install-cross@main
-        if: ${{ matrix.arch == 'arm64' }}
+        if: ${{ matrix.arch }} == 'arm64'
       - name: Compile wash
-        if: ${{ matrix.arch == 'arm64' }}
+        if: ${{ matrix.arch }} == 'arm64'
         run: |
           cargo build --target aarch64-unknown-linux-gnu --release
       - name: Install NFPM

--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -30,7 +30,7 @@ jobs:
           args: --all-features
 
   package:
-    needs: [cargo_check, clippy_check]
+    # needs: [cargo_check, clippy_check]
     strategy:
       matrix:
         arch: [arm64, amd64]
@@ -50,7 +50,7 @@ jobs:
       - name: Compile wash
         if: ${{ matrix.arch }} == 'arm64'
         run: |
-          cargo build --target aarch64-unknown-linux-gnu --release
+          cross build --target aarch64-unknown-linux-gnu --release
       - name: Install NFPM
         run: |
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list

--- a/build/nfpm.amd64.yaml
+++ b/build/nfpm.amd64.yaml
@@ -9,10 +9,9 @@ section: default
 priority: extra
 maintainer: Bill Young <bill@byoung.io>
 description: |
-  wasmcloud Shell
-   A single CLI to handle all of your wasmcloud tooling needs
+  WAsmcloud SHell - the comprehensive command-line tool for wasmCloud development
 vendor: wasmcloud
-homepage: https://wasmcloud.dev
+homepage: https://wasmcloud.com
 license: Apache-2.0
 contents:
   - src: target/release/wash

--- a/build/nfpm.arm64.yaml
+++ b/build/nfpm.arm64.yaml
@@ -9,10 +9,10 @@ section: default
 priority: extra
 maintainer: Bill Young <bill@byoung.io>
 description: |
-  wasmcloud Shell
-   A single CLI to handle all of your wasmcloud tooling needs
+   WAsmcloud SHell - the comprehensive command-line tool for wasmCloud development
 vendor: wasmcloud
-homepage: https://wasmcloud.dev
+homepage: https://wasmcloud.com
 license: Apache-2.0
-files:
-  target/armv7-unknown-linux-gnueabihf/release/wash: "/usr/local/bin/wash"
+contents:
+  - src: target/aarch64-unknown-linux-gnu/release/wash
+    dst: /usr/local/bin/wash


### PR DESCRIPTION
This PR adds in the `cross build` to cross compile `wash` for aarch64 and add it to packagecloud on release. This should run in a matrix and release both amd64 and aarch64 binaries for the same deb/rpm repositories.