### PR TITLE
Replaced "valid" deb release yaml with the thing I wanted to do

### DIFF
--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64, amd64]
-        with:
+        include:
           - arch: arm64
             rpmarch: aarch64
           - arch: amd64


### PR DESCRIPTION
Turns out `with` for some reason is totally valid syntax here but what I wanted was to _include_ a variable alongside the current matrix instead of creating a new combination. You can see in https://github.com/wasmCloud/wash/actions/runs/3856094055 that it incorrectly creates 4 combinations instead of just running the two