### PR TITLE
Allow prerelease tags with warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -49,7 +49,7 @@ thiserror = "1.0"
 tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 which = "4.2.2"
-wash-lib = { version = "0.5.0", path = "./crates/wash-lib", features = ["cli"] }
+wash-lib = { version = "0.5.1", path = "./crates/wash-lib", features = ["cli"] }
 wascap = "0.9.2"
 weld-codegen = "0.6.0"
 wasmcloud-control-interface = "0.22.3"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
Fixes #374 

This PR allows prerelease tags as defined by semver (the portion after the vX.Y.Z, separated by a dash, then the prerelease type, then the number) of wasmCloud as valid versions to specify. This will let users of wash test out prerelease versions if they so choose, with a warning log.

Just a general note, wash default wasmCloud versions should _not_ be prereleases, this functionality should only be exercised by manually specifying the prerelease version