### PR TITLE
Create default context if host_config not found

### DIFF
--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -135,7 +135,7 @@ fn validate(project: &Project) -> Result<()> {
         && (project.git.is_some() || project.subfolder.is_some() || project.branch.is_some())
     {
         return Err(anyhow!("Error in 'new {}' options: You may use --path or --git ( --branch, --subfolder ) to specify a template source, but not both. If neither is specified, you will be prompted to select a project template.",
-            &ProjectKind::from(project.kind)
+            project.kind
         ));
     }
     if let Some(name) = &project.project_name {

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -285,7 +285,7 @@ pub fn get_config(opt_path: Option<PathBuf>, use_env: Option<bool>) -> Result<Pr
     let raw_project_config: RawProjectConfig = serde_json::from_value(json_value)?;
 
     raw_project_config
-        .convert(project_path.clone())
+        .convert(project_path)
         .map_err(|e: anyhow::Error| anyhow!("{} in {}", e, wasmcloud_path.display()))
 }
 

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -259,7 +259,8 @@ pub(crate) fn ensure_host_config_context(context_dir: &ContextDir) -> Result<()>
 fn create_host_config_context(context_dir: &ContextDir) -> Result<()> {
     let host_config_ctx = WashContext {
         name: HOST_CONFIG_NAME.to_string(),
-        ..load_context(cfg_dir()?.join(format!("{}.json", HOST_CONFIG_NAME)))?
+        ..load_context(cfg_dir()?.join(format!("{}.json", HOST_CONFIG_NAME)))
+            .unwrap_or_else(|_| WashContext::default())
     };
     context_dir.save_context(&host_config_ctx)?;
     // Set the default context if it isn't set yet

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -259,7 +259,7 @@ pub(crate) fn ensure_host_config_context(context_dir: &ContextDir) -> Result<()>
 fn create_host_config_context(context_dir: &ContextDir) -> Result<()> {
     let host_config_ctx = WashContext {
         name: HOST_CONFIG_NAME.to_string(),
-        ..load_context(cfg_dir()?.join(format!("{}.json", HOST_CONFIG_NAME)))
+        ..load_context(cfg_dir()?.join(format!("{HOST_CONFIG_NAME}.json")))
             .unwrap_or_else(|_| WashContext::default())
     };
     context_dir.save_context(&host_config_ctx)?;


### PR DESCRIPTION
Fixes #371 

Basically, instead of bubbling up when we can't find `~/.wash/host_config.json`, we will create default values and proceed as normal.

An alternative fix to this would be not creating the default context at all, which I considered but generally involved more steps to manage the state of no host_config