### PR TITLE
[fix] add better error handling for empty tags when --allow-latest is false

### DIFF
--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = {status = "actively-developed"}
 default = ["start", "parser"]
 start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
-cli = ["clap", "term-table", "console", "dialoguer", "heck", "ignore", "indicatif", "path-absolutize", "regex"]
+cli = ["clap", "term-table", "console", "dialoguer", "heck", "ignore", "indicatif", "path-absolutize"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -37,7 +37,7 @@ nkeys = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
 path-absolutize = { workspace = true, features = ["once_cell_cache"], optional = true }
 provider-archive = { workspace = true }
-regex = { workspace = true, optional = true }
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 semver = { workspace = true, features = ["serde"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }


### PR DESCRIPTION
I originally went to address issue #273, when I fell down a small rabbit hole.

**tl;dr** 1) is my hacky way to parse the user's specified tag OK? 2) how should we be smart about looking for images on disk vs. a registry

We have this `--allow-latest` flag which defaults to false, that I'm assuming is for CI purposes. We'd like to be able to inspect claims for actors and providers on disk, in a registry or from a cache. We'd like to be "smart" about it and infer what the user wants with decent fallbacks. We'd like to give the user helpful error messages when they try wonky stuff.

Firstly, if `--allow-latest` is false, we shouldn't default the tag to "latest" when it's not specified and then give the user an error message that what we did behind the scenes isn't allowed. We should tell the user that they need to specify a tag. If the user specifies the "latest" tag explicitly, then we should show the error about not allowing it. This is what my initial commit addresses. Unfortunately, the logic that parses OCI reference strings and the logic that defaults the tag value are both behind the same API, and in order to parse out the input tag in the most consistent way possible, I had to steal some code [from the `oci_distribution` dep](https://github.com/krustlet/oci-distribution). So it's a little hacky, and maybe peeps won't dig it. I suppose we could work with the maintainers of the crate but I'll let future us worry about that.

Secondly, being "smart" about checking local or remote is a tad tricky because, to my knowledge, there is no hard-and-fast disambiguation b/w valid OCI registry URLs and valid file paths (at least in UNIX). A path that looks like a registry reference would be "weird" but valid, and a registry reference could easily look path-ish. I'm being real neurotic here, but I can make a local relative file "localhost:5001/my_actor:tag_s.wasm" and have an image in a registry with the same reference. In this funky case, the user can't inspect the claims in the registry, since the system defaults to looking on disk and finds the .wasm file.
 
There are a few possible solutions that come to mind:
 - be a little smart and if the user happens to make a local wasm/par file that exactly matches a registry URL and they want to check the registry, then out of luck they be
 - be a little smart but give an escape hatch flag (like `--no-local` or `--reg-only`) if the user wants to host an image at a reference like "myreg:5000/myimage:tag_s.wasm"
 - don't be smart and have an opt-in flag (like `--local` or `--on-disk`) for checking local files
 - create a convention that wasmCloud OCI reference URLs MUST NOT end with ".wasm" or ".par" or ".par.gz" and enforce this in wash and wasmCloud, then we can be real smrt

In all cases, a more informative output specifying exactly where we found the bits would be helpful.

Happy nitpicking! :D

P.S. Maybe we could be smarter on Windows since paths are more strict?
P.P.S Also relates to #305