### PR TITLE
Bumped to wasmCloud 0.60.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "1.0"
 tokio = {version = "1", features = ["full"]}
 toml = "0.5"
 which = "4.2.2"
-wash-lib = { version = "0.5.1", path = "./crates/wash-lib", features = ["cli"] }
+wash-lib = { version = "0.6", path = "./crates/wash-lib", features = ["cli"] }
 wascap = "0.9.2"
 weld-codegen = "0.6.0"
 wasmcloud-control-interface = "0.22.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -4,7 +4,7 @@ use crate::up::{credsfile::parse_credsfile, NatsOpts, WasmcloudOpts};
 
 pub const DOWNLOADS_DIR: &str = "downloads";
 // NATS configuration values
-pub(crate) const NATS_SERVER_VERSION: &str = "v2.8.4";
+pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -8,7 +8,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.8.4";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.58.2";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.60.0";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/tests/integration_drain.rs
+++ b/tests/integration_drain.rs
@@ -179,11 +179,11 @@ fn set_smithy_cache_dir() -> (PathBuf, String) {
 #[cfg(target_os = "macos")]
 fn set_smithy_cache_dir() -> (PathBuf, String) {
     let tmp_dir = test_dir_with_subfolder("drain_smithy");
-    std::env::set_var("HOME", &format!("{}", &tmp_dir.display()));
+    std::env::set_var("HOME", format!("{}", &tmp_dir.display()));
     let smithy_cache = format!("{}/Library/Caches/smithy", &tmp_dir.display());
-    create_dir_all(&PathBuf::from(&smithy_cache)).unwrap();
+    create_dir_all(PathBuf::from(&smithy_cache)).unwrap();
     // write a dummy file inside the smithy cache folder
-    std::fs::write(&path_to_test_file(&smithy_cache), b"junk").unwrap();
+    std::fs::write(path_to_test_file(&smithy_cache), b"junk").unwrap();
     (tmp_dir, smithy_cache)
 }
 


### PR DESCRIPTION
This PR bumps to 0.15.0 including the wascap bump from #361 and wasmCloud 0.60.0 which are meant to interact with each other in terms of claims signing on actors.

In a separate commit I also bumped lock deps with `cargo update`, happy to back that out if desired.