### PR TITLE
fix(down): Makes sure we can actually shutdown a detached process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3233,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3941,6 +3965,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2 0.10.6",
+ "sysinfo",
  "tempfile",
  "term-table",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -65,6 +65,7 @@ test_bin = "0.4.0"
 assert-json-diff = "2.0.1"
 scopeguard = "1.1.0"
 serial_test = "0.9.0"
+sysinfo = "0.27"
 
 [[bin]]
 bench = true

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::up::{credsfile::parse_credsfile, NatsOpts, WasmcloudOpts};
 
 pub const DOWNLOADS_DIR: &str = "downloads";
+pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 // NATS configuration values
 pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,8 +1,11 @@
 mod common;
 use common::{output_to_string, test_dir_with_subfolder, wash};
+use serial_test::serial;
 use std::fs::{read_to_string, remove_dir_all};
+use sysinfo::{ProcessExt, SystemExt};
 
 #[test]
+#[serial]
 fn integration_up_can_start_wasmcloud_and_actor() {
     let dir = test_dir_with_subfolder("can_start_wasmcloud");
     let path = dir.join("washup.log");
@@ -57,6 +60,65 @@ fn integration_up_can_start_wasmcloud_and_actor() {
         .args(vec![down])
         .output()
         .expect("Could not spawn wash down process");
+
+    remove_dir_all(dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn can_stop_detached_host() {
+    let dir = test_dir_with_subfolder("can_stop_wasmcloud");
+    let path = dir.join("washup.log");
+    let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
+
+    let mut up_cmd = wash()
+        .args(["up", "--nats-port", "5894", "-o", "json", "--detached"])
+        .stdout(stdout)
+        .spawn()
+        .expect("Could not spawn wash up process");
+
+    let status = up_cmd.wait().expect("up command failed to complete");
+
+    assert!(status.success());
+    let out = read_to_string(&path).expect("could not read output of wash up");
+
+    let (kill_cmd, wasmcloud_log) = match serde_json::from_str::<serde_json::Value>(&out) {
+        Ok(v) => (v["kill_cmd"].to_owned(), v["wasmcloud_log"].to_owned()),
+        Err(_e) => panic!("Unable to parse kill cmd from wash up output"),
+    };
+
+    // Wait until the host starts
+    let mut tries = 30;
+    while !read_to_string(wasmcloud_log.to_string().trim_matches('"'))
+        .expect("could not read output")
+        .contains("Started wasmCloud OTP Host Runtime")
+    {
+        tries -= 1;
+        assert!(tries >= 0);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    let kill_cmd = kill_cmd.to_string();
+    let (_wash, down) = kill_cmd.trim_matches('"').split_once(' ').unwrap();
+    wash()
+        .args(vec![down])
+        .output()
+        .expect("Could not spawn wash down process");
+
+    // Check to see if process was removed
+    let mut info = sysinfo::System::new_with_specifics(
+        sysinfo::RefreshKind::new().with_processes(sysinfo::ProcessRefreshKind::new()),
+    );
+
+    info.refresh_processes();
+
+    assert!(
+        !info
+            .processes()
+            .values()
+            .any(|p| p.exe().to_string_lossy().contains("beam.smp")),
+        "No wasmcloud process should be running"
+    );
 
     remove_dir_all(dir).unwrap();
 }


### PR DESCRIPTION
The down command was creating its own path to the binary which didn't take into account the new versioned paths