### PR TITLE
Added devcontainer for wash

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,7 @@
+# wash devcontainer
+
+A simple devcontainer that has `rust` installed. Try it out with `devcontainer open` at the root of this repository!
+
+## Prerequisites
+- [devcontainer CLI](https://code.visualstudio.com/docs/devcontainers/devcontainer-cli#_installation)
+- VSCode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "wash",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest"
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/wash,type=bind,consistency=cached",
+	"workspaceFolder": "/wash"
+}


### PR DESCRIPTION
Simple devcontainer that installs `rust` and bind mounts this project into a container. Should work with codespaces and make it easy to develop `wash` even on machines with no Rust tooling!