### PR TITLE
fix: use lib.name from cargo.toml for rust wasm binary name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,12 +437,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.3"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.7.2",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.10",
  "yaml-rust",
 ]
 
@@ -1881,6 +1881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,6 +2864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,6 +3458,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+]
+
+[[package]]
 name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +3895,7 @@ dependencies = [
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
+ "chrono",
  "clap 4.0.32",
  "cloudevents-sdk",
  "console",
@@ -3876,7 +3929,7 @@ dependencies = [
  "test_bin",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.10",
  "wascap 0.9.2",
  "wash-lib",
  "wasmbus-rpc",
@@ -3922,7 +3975,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "toml",
+ "toml 0.5.10",
  "walkdir",
  "wascap 0.9.2",
  "weld-codegen 0.6.0",
@@ -4079,7 +4132,7 @@ dependencies = [
  "thiserror",
  "time 0.3.17",
  "tokio",
- "toml",
+ "toml 0.5.10",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -4144,7 +4197,7 @@ dependencies = [
  "serde_json",
  "termcolor",
  "tokio",
- "toml",
+ "toml 0.5.10",
  "wasmbus-rpc",
  "wasmcloud-interface-testing",
 ]
@@ -4220,7 +4273,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -4250,7 +4303,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ test_bin = { workspace = true }
 assert-json-diff = { workspace = true }
 scopeguard = { workspace = true }
 sysinfo = { workspace = true }
+chrono = { workspace = true }
 
 [[bin]]
 bench = true
@@ -82,7 +83,7 @@ async-nats = "0.23.0"
 atelier_core = "0.2"
 bytes = "1.4"
 cargo_atelier = "0.2"
-cargo_toml = "0.13.0"
+cargo_toml = "0.15.2"
 claims = "0.7.1"
 clap = "4"
 cloudevents-sdk = "0.6.0"
@@ -136,3 +137,4 @@ wasmcloud-control-interface = "0.23"
 wasmcloud-test-util = "0.6.4"
 weld-codegen = "0.6.0"
 which = "4.2.2"
+chrono = "0.4.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ assert-json-diff = { workspace = true }
 scopeguard = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
+serial_test = { workspace = true }
 
 [[bin]]
 bench = true

--- a/Makefile
+++ b/Makefile
@@ -28,17 +28,29 @@ build-watch: ## Continuously build the project
 
 ##@ Testing
 
-test: ## Run the entire unit test suite
-	@$(CARGO) nextest run --no-fail-fast -p wash-lib
-	@$(CARGO) nextest run --no-fail-fast --bin wash
+# Target to focus on for tests (enables running only one test)
+CARGO_TEST_TARGET ?= ""
+
+test: ## Run unit test suite
+	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
+	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
+
+test-watch: ## Run unit tests continously, can optionally specify a target test filter.
+	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
 
 test-integration: ## Run the entire integration test suite
 	@$(DOCKER) compose -f ./tools/docker-compose.yml up --detach
 	@$(CARGO) nextest run --profile integration -E 'kind(test)'
 	@$(DOCKER) compose -f ./tools/docker-compose.yml down
 
-test-watch: ## Run unit tests continously, can optionally specify a target test filter.
-	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
+test-integration-watch: ## Run integration test suite continuously
+	@$(CARGO) watch -- $(MAKE) test-integration
+
+test-unit: ## Run one or more unit tests
+	@$(CARGO) nextest $(CARGO_TEST_TARGET)
+
+test-unit-watch: ## Run tests continuously
+	@$(CARGO) watch -- $(MAKE) test-unit
 
 rust-check: ## Run rust checks
 	@$(CARGO) fmt --all --check

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -134,6 +134,12 @@ fn build_rust_actor(
         bail!("Compiling actor failed: {}", result.to_string())
     }
 
+    // Determine the wasm binary name
+    let wasm_bin_name = common_config
+        .wasm_bin_name
+        .as_ref()
+        .unwrap_or(&common_config.name);
+
     let wasm_file = PathBuf::from(format!(
         "{}/{}/release/{}.wasm",
         rust_config
@@ -142,7 +148,7 @@ fn build_rust_actor(
             .unwrap_or_else(|| PathBuf::from("target"))
             .to_string_lossy(),
         actor_config.wasm_target,
-        common_config.name,
+        wasm_bin_name,
     ));
 
     if !wasm_file.exists() {
@@ -153,7 +159,7 @@ fn build_rust_actor(
     }
 
     // move the file out into the build/ folder for parity with tinygo and convienience for users.
-    let copied_wasm_file = PathBuf::from(format!("build/{}.wasm", common_config.name));
+    let copied_wasm_file = PathBuf::from(format!("build/{}.wasm", wasm_bin_name));
     if let Some(p) = copied_wasm_file.parent() {
         fs::create_dir_all(p)?;
     }

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -44,7 +44,8 @@ fn rust_actor() {
             version: Version::parse("0.1.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap()
+                .unwrap(),
+            wasm_bin_name: None,
         }
     );
 }
@@ -85,7 +86,8 @@ fn tinygo_actor() {
             version: Version::parse("0.1.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap()
+                .unwrap(),
+            wasm_bin_name: None,
         }
     );
 }
@@ -266,7 +268,8 @@ fn minimal_rust_actor() {
             version: Version::parse("0.1.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap()
+                .unwrap(),
+            wasm_bin_name: None,
         }
     )
 }
@@ -310,7 +313,8 @@ fn cargo_toml_actor() {
             version: Version::parse("0.200.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
-                .unwrap()
+                .unwrap(),
+            wasm_bin_name: None,
         }
     )
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -31,11 +31,21 @@ pub(crate) fn get_json_output(output: std::process::Output) -> Result<serde_json
 
 #[allow(unused)]
 /// Creates a subfolder in the test directory for use with a specific test
+pub(crate) fn test_dir() -> PathBuf {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+    let test_dir = PathBuf::from(manifest_dir).join("tests/fixtures");
+    remove_dir_all(&test_dir);
+    create_dir_all(&test_dir);
+    test_dir
+}
+
+#[allow(unused)]
+/// Creates a subfolder in the test directory for use with a specific test
 /// It's preferred that the same test that calls this function also
 /// uses std::fs::remove_dir_all to remove the subdirectory
 pub(crate) fn test_dir_with_subfolder(subfolder: &str) -> PathBuf {
-    let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
-    let with_subfolder = PathBuf::from(format!("{root_dir}/tests/fixtures/{subfolder}"));
+    let test_dir = test_dir();
+    let with_subfolder = test_dir.join(subfolder);
     remove_dir_all(with_subfolder.clone());
     create_dir_all(with_subfolder.clone());
     with_subfolder
@@ -46,6 +56,5 @@ pub(crate) fn test_dir_with_subfolder(subfolder: &str) -> PathBuf {
 /// to the test fixtures directory. This does _not_ create the file,
 /// so the test is responsible for initialization and modification of this file
 pub(crate) fn test_dir_file(subfolder: &str, file: &str) -> PathBuf {
-    let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
-    PathBuf::from(format!("{root_dir}/tests/fixtures/{subfolder}/{file}"))
+    test_dir_with_subfolder(subfolder).join(file)
 }

--- a/tests/integration_build.rs
+++ b/tests/integration_build.rs
@@ -2,13 +2,8 @@ use anyhow::Result;
 
 mod common;
 use common::wash;
-use scopeguard::defer;
 use serial_test::serial;
-use std::{
-    env::temp_dir,
-    fs::{create_dir_all, remove_dir_all, File},
-    path::PathBuf,
-};
+use std::{fs::File, path::PathBuf};
 use tempfile::TempDir;
 
 #[test]

--- a/tests/integration_build.rs
+++ b/tests/integration_build.rs
@@ -2,7 +2,13 @@ use anyhow::Result;
 
 mod common;
 use common::wash;
-use std::path::PathBuf;
+use scopeguard::defer;
+use serial_test::serial;
+use std::{
+    env::temp_dir,
+    fs::{create_dir_all, remove_dir_all, File},
+    path::PathBuf,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -136,4 +142,39 @@ fn init_actor_from_template(actor_name: &str, template_name: &str) -> Result<Pat
 
     let project_dir = std::env::current_dir()?.join(actor_name);
     Ok(project_dir)
+}
+
+#[test]
+#[serial]
+fn integration_build_handles_dashed_names() -> Result<()> {
+    let actor_name = "dashed-actor";
+    // This tests runs against a temp directory since cargo gets confused
+    // about workspace projects if done from within wash
+    let root_dir = tempfile::tempdir()?;
+    let actor_dir = root_dir.path().join(actor_name);
+    let stdout_path = root_dir
+        .path()
+        .join(format!("wash-test.{actor_name}.stdout.log"));
+    let stdout = File::create(stdout_path)?;
+
+    // Execute wash new to create an actor with the given name
+    let mut new_cmd = wash()
+        .args(["new", "actor", "dashed-actor", "-t", "hello"])
+        .current_dir(&root_dir)
+        .stdout(stdout.try_clone()?)
+        .spawn()?;
+    assert!(new_cmd.wait()?.success());
+
+    // Ensure that the actor dir was created as expected
+    assert!(actor_dir.exists());
+
+    let mut build_cmd = wash()
+        .args(["build"])
+        .stdout(stdout)
+        .current_dir(&actor_dir)
+        .spawn()?;
+
+    assert!(build_cmd.wait()?.success());
+
+    Ok(())
 }


### PR DESCRIPTION
This PR adds code to use `lib.name` from `Cargo.toml` for Rust projects, to avoid issues with Rust project builds when actor name does not match Rust's requirements on output artifact names. 

See #341 for for more discussion around this issue, and the [RFC on naming](https://github.com/wasmCloud/wasmCloud/issues/271) that should standardize naming across libraries in the future.