### PR TITLE
use client builder to support querying KV bucket directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,13 +4175,15 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5d2d5412da4546c1b5ac4e648745fb8d8ccc500770482626fe4adc990db5a1"
+checksum = "d923646e6fdea603c7d8187c850dd60624a6d71d57e8120733ec058b01e80ca6"
 dependencies = [
  "async-nats",
  "cloudevents-sdk",
+ "data-encoding",
  "futures",
+ "ring",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ which = "4.2.2"
 wash-lib = { version = "0.6", path = "./crates/wash-lib", features = ["cli"] }
 wascap = "0.9.2"
 weld-codegen = "0.6.0"
-wasmcloud-control-interface = "0.22.3"
+wasmcloud-control-interface = "0.23"
 wasmbus-rpc = "0.11.2"
 wasmcloud-test-util = "0.6.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -64,6 +64,14 @@ pub(crate) struct ConnectionOpts {
     #[clap(long = "ctl-credsfile", env = "WASH_CTL_CREDS", hide_env_values = true)]
     pub(crate) ctl_credsfile: Option<PathBuf>,
 
+    /// JS domain for wasmcloud control interface. Defaults to None
+    #[clap(
+        long = "js-domain",
+        env = "WASMCLOUD_JS_DOMAIN",
+        hide_env_values = true
+    )]
+    pub(crate) js_domain: Option<String>,
+
     /// Lattice prefix for wasmcloud control interface, defaults to "default"
     #[clap(short = 'x', long = "lattice-prefix", env = "WASMCLOUD_LATTICE_PREFIX")]
     pub(crate) lattice_prefix: Option<String>,
@@ -90,6 +98,7 @@ impl Default for ConnectionOpts {
             ctl_jwt: None,
             ctl_seed: None,
             ctl_credsfile: None,
+            js_domain: None,
             lattice_prefix: Some(DEFAULT_LATTICE_PREFIX.to_string()),
             timeout_ms: DEFAULT_NATS_TIMEOUT_MS,
             context: None,
@@ -1190,6 +1199,18 @@ async fn ctl_client_from_opts(
         .rpc_timeout(Duration::from_millis(opts.timeout_ms))
         .auction_timeout(Duration::from_millis(auction_timeout_ms));
 
+    let opts_js_domain = opts.js_domain;
+    let ctx_js_domain = ctx.and_then(|c| c.js_domain);
+    let js_domain = match (opts_js_domain, ctx_js_domain) {
+        (Some(opts_domain), _) => Some(opts_domain), // flag takes priority
+        (None, Some(ctx_domain)) => Some(ctx_domain),
+        _ => None,
+    };
+
+    if let Some(js_domain) = js_domain {
+        builder = builder.js_domain(js_domain);
+    }
+
     if let Ok(topic_prefix) = std::env::var("WASMCLOUD_CTL_TOPIC_PREFIX") {
         builder = builder.topic_prefix(topic_prefix);
     }
@@ -1216,6 +1237,7 @@ mod test {
     const CTL_HOST: &str = "127.0.0.1";
     const CTL_PORT: &str = "4222";
     const LATTICE_PREFIX: &str = "default";
+    const JS_DOMAIN: &str = "custom-domain";
 
     const ACTOR_ID: &str = "MDPDJEYIAK6MACO67PRFGOSSLODBISK4SCEYDY3HEOY4P5CVJN6UCWUK";
     const PROVIDER_ID: &str = "VBKTSBG2WKP6RJWLQ5O7RDVIIB4LMW6U5R67A7QMIDBZDGZWYTUE3TSI";
@@ -1448,6 +1470,8 @@ mod test {
             CTL_PORT,
             "--timeout-ms",
             "2001",
+            "--js-domain",
+            JS_DOMAIN,
         ])?;
         match get_claims_all.command {
             CtlCliCommand::Get(GetCommand::Claims(GetClaimsCommand { opts })) => {
@@ -1455,6 +1479,7 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
+                assert_eq!(opts.js_domain.unwrap(), JS_DOMAIN);
             }
             cmd => panic!("ctl get claims constructed incorrect command {cmd:?}"),
         }


### PR DESCRIPTION
# Feature or Problem
Wash is currently using v0.22 of the control interface client. v0.23 added support for querying the `LATTICEDATA_{latticeID}` KV bucket, which is now the source of truth for link definitions and claims

# Related Issues
N/A, but I can file one if desired

# Release Information
Soon ™️ / next release ASAP

# Consumer Impact
N/A. This version of the control interface client is backwards-compatible. If the KV bucket doesn't exist, the client falls back on querying the host's control interface topics

# Testing
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


## Platforms
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)
I added a unit test to confirm the new `js_domain` flag is picked up.

## Acceptance or Integration
None

## Manual Verification
I ran manual tests of the following form:
```bash
RUST_LOG=debug target/release/wash ctl link query # use default context
RUST_LOG=debug target/release/wash ctl link query --context another-context # override context with js_domain
RUST_LOG=debug target/release/wash ctl link query --js-domain custom-domain # override js_domain specifically
```

`RUST_LOG=debug` causes the control interface client to emit one of two messages after it attempts to construct a KV store:
- `[2023-02-23T19:37:46Z DEBUG wasmcloud_control_interface::kv] Using direct bucket access for lattice metadata queries`
- `[2023-02-23T19:33:28Z DEBUG wasmcloud_control_interface::kv] Using deprecated control interface commands for lattice metadata queries`

I used this output to validate the expected behavior based off the input

