### PR TITLE
build(nix): rework flake via `nixify`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ docker-compose.yml
 *.par
 *.par.gz
 *.gz
-flake.lock
 .vscode
 
 # Host config files

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ brew install wasmcloud wash
 choco install wash
 ```
 
-### NixOS
+### Nix
 
 ```
 nix run github:wasmCloud/wash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,167 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "nixify",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669943300,
+        "narHash": "sha256-1adQsyh7MvtlR19cJvL0VWemVTWwVbWSKrmrfX60ztU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fb80a689c5c517bc40d9cc1828c384c38de90dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.10.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1676294984,
+        "narHash": "sha256-hdLUa/3RH1VJ+gMUysQE0JGM4F2Q/tIIFbtoxAOurJQ=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "fc282c5478e4141842f9644c239a41cfe9586732",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixify": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixlib": "nixlib",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1677589210,
+        "narHash": "sha256-PNRKrPXoxR+JjaF1TPeiOVea3AfoZyFVOXnbgkP5Pik=",
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "rev": "9f0b4162fc1e6cd10e3279c807147894d09fda8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1677373009,
+        "narHash": "sha256-kxhz4QUP8tXa/yVSpEzDDZSEp9FvhzRqZzb+SeUaekw=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c9d4f2476046c6a7a2ce3c2118c48455bf0272ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677367679,
+        "narHash": "sha256-pOMXi7F9tcHls06Qv+7XCPASTJeXu47Jhd0Pk9du8T4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ea736343e4d4a052e023d54b23334cf685de479c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixify": "nixify"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677465082,
+        "narHash": "sha256-b82PmPWkt0pAsxmc477Yowq1Ez1VyjA5wnxE+yoIOWg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2924bfce2fadc1ded4a2b8cfce7f2fd4ef41c36f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
1st commit:
`Nix` is cross-platform and not tied to a particular OS, it runs on
arbitrary x86_64 or aarch64 Linux and Darwin hosts, as well as Windows
in WSL, among various others

2nd commit:
`flake.lock` is the file containing the "state of the world" that was
used to build the package, which allows the build to be deterministic
and reproducible anywhere by anyone, omitting this file from the
repository prevents doing that, which makes the Nix flake much less
useful (note, that reproducibility is the whole purpose of Nix).

3rd commit:
- Simplify
- Remove multiple unnecessary dependencies
- Add missing `protobuf` dependency
- Add `debug` (`dev`) profile builds
- Provide support for OCI image builds (via `nixify`)
- Add support for clippy, nextest and rustfmt (via `nixify`)
- Improve caching performance
- Add cross-compilation support

```
$ nix flake show
├───apps
│   ├───aarch64-darwin
│   │   ├───default: app
│   │   ├───wash: app
│   │   └───wash-debug: app
│   ├───aarch64-linux
│   │   ├───default: app
│   │   ├───wash: app
│   │   └───wash-debug: app
│   ├───x86_64-darwin
│   │   ├───default: app
│   │   ├───wash: app
│   │   └───wash-debug: app
│   └───x86_64-linux
│       ├───default: app
│       ├───wash: app
│       └───wash-debug: app
├───checks
│   ├───aarch64-darwin
│   │   ├───clippy: derivation 'wash-clippy-0.16.0'
│   │   ├───fmt: derivation 'wash-fmt-0.16.0'
│   │   └───nextest: derivation 'wash-nextest-0.16.0'
│   ├───aarch64-linux
│   │   ├───clippy: derivation 'wash-clippy-0.16.0'
│   │   ├───fmt: derivation 'wash-fmt-0.16.0'
│   │   └───nextest: derivation 'wash-nextest-0.16.0'
│   ├───x86_64-darwin
│   │   ├───clippy: derivation 'wash-clippy-0.16.0'
│   │   ├───fmt: derivation 'wash-fmt-0.16.0'
│   │   └───nextest: derivation 'wash-nextest-0.16.0'
│   └───x86_64-linux
│       ├───clippy: derivation 'wash-clippy-0.16.0'
│       ├───fmt: derivation 'wash-fmt-0.16.0'
│       └───nextest: derivation 'wash-nextest-0.16.0'
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin: package 'alejandra-3.0.0'
│   ├───aarch64-linux: package 'alejandra-3.0.0'
│   ├───x86_64-darwin: package 'alejandra-3.0.0'
│   └───x86_64-linux: package 'alejandra-3.0.0'
├───overlays
│   ├───default: Nixpkgs overlay
│   ├───rust: Nixpkgs overlay
│   └───wash: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    │   ├───default: package 'wash-0.16.0'
    │   ├───wash: package 'wash-0.16.0'
    │   ├───wash-aarch64-apple-darwin: package 'wash-0.16.0'
    │   ├───wash-aarch64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug: package 'wash-0.16.0'
    │   ├───wash-debug-aarch64-apple-darwin: package 'wash-0.16.0'
    │   ├───wash-debug-aarch64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug-wasm32-wasi: package 'wash-0.16.0'
    │   ├───wash-debug-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-wasm32-wasi: package 'wash-0.16.0'
    │   └───wash-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    ├───aarch64-linux
    │   ├───default: package 'wash-0.16.0'
    │   ├───wash: package 'wash-0.16.0'
    │   ├───wash-aarch64-unknown-linux-musl: package 'wash-0.16.0'
    │   ├───wash-aarch64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug: package 'wash-0.16.0'
    │   ├───wash-debug-aarch64-unknown-linux-musl: package 'wash-0.16.0'
    │   ├───wash-debug-aarch64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug-wasm32-wasi: package 'wash-0.16.0'
    │   ├───wash-debug-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug-x86_64-unknown-linux-musl: package 'wash-x86_64-unknown-linux-gnu-0.16.0'
    │   ├───wash-debug-x86_64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-wasm32-wasi: package 'wash-0.16.0'
    │   ├───wash-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-x86_64-unknown-linux-musl: package 'wash-x86_64-unknown-linux-gnu-0.16.0'
    │   └───wash-x86_64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
    ├───x86_64-darwin
    │   ├───default: package 'wash-0.16.0'
    │   ├───wash: package 'wash-0.16.0'
    │   ├───wash-aarch64-apple-darwin: package 'wash-aarch64-apple-darwin-0.16.0'
    │   ├───wash-aarch64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug: package 'wash-0.16.0'
    │   ├───wash-debug-aarch64-apple-darwin: package 'wash-aarch64-apple-darwin-0.16.0'
    │   ├───wash-debug-aarch64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug-wasm32-wasi: package 'wash-0.16.0'
    │   ├───wash-debug-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-debug-x86_64-apple-darwin: package 'wash-0.16.0'
    │   ├───wash-debug-x86_64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-wasm32-wasi: package 'wash-0.16.0'
    │   ├───wash-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
    │   ├───wash-x86_64-apple-darwin: package 'wash-0.16.0'
    │   └───wash-x86_64-apple-darwin-oci: package 'docker-image-wash.tar.gz'
    └───x86_64-linux
        ├───default: package 'wash-0.16.0'
        ├───wash: package 'wash-0.16.0'
        ├───wash-aarch64-unknown-linux-musl: package 'wash-aarch64-unknown-linux-gnu-0.16.0'
        ├───wash-aarch64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
        ├───wash-debug: package 'wash-0.16.0'
        ├───wash-debug-aarch64-unknown-linux-musl: package 'wash-aarch64-unknown-linux-gnu-0.16.0'
        ├───wash-debug-aarch64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
        ├───wash-debug-wasm32-wasi: package 'wash-0.16.0'
        ├───wash-debug-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
        ├───wash-debug-x86_64-unknown-linux-musl: package 'wash-0.16.0'
        ├───wash-debug-x86_64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
        ├───wash-wasm32-wasi: package 'wash-0.16.0'
        ├───wash-wasm32-wasi-oci: package 'docker-image-wash.tar.gz'
        ├───wash-x86_64-unknown-linux-musl: package 'wash-0.16.0'
        └───wash-x86_64-unknown-linux-musl-oci: package 'docker-image-wash.tar.gz'
```

# Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

# Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

# Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

# Testing
<!---
Declare the testing information for this pull request
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


## Platforms
<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

## Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

## Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Too many to mention all, but `nix flake check` is the main one here

Mostly verified by CI in #429