### PR TITLE
ci: add `nix` CI

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -1,0 +1,20 @@
+name: build via Nix
+
+inputs:
+  package:
+    description: package specification to build
+    required: true
+  install-path:
+    description: path within resulting output, from which to install (e.g. `/bin/wash`)
+
+runs:
+  using: composite
+  steps:
+  - run: nix build -L '.#${{ inputs.package }}'
+    shell: bash
+  - run: nix run -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p "./result${{ inputs.install-path }}" '${{ inputs.package }}'
+    shell: bash
+  - uses: actions/upload-artifact@v3
+    with:
+      name: ${{ inputs.package }}
+      path: ${{ inputs.package }}

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -1,0 +1,21 @@
+name: install Nix
+
+inputs:
+  cachixAuthToken:
+    description: auth token for https://app.cachix.org/organization/wasmcloud/cache/wasmcloud
+
+runs:
+  using: composite
+  steps:
+  # Install Nix
+  - uses: DeterminateSystems/nix-installer-action@v2
+    with:
+      extra-conf: |
+        accept-flake-config = true
+
+  # Setup Cachix cache
+  - uses: cachix/cachix-action@v12
+    continue-on-error: true
+    with:
+      name: wasmcloud
+      authToken: '${{ inputs.cachixAuthToken }}'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,157 @@
+name: nix
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    strategy:
+      matrix:
+        config:
+        - target: aarch64-unknown-linux-musl
+          install-path: /bin/wash
+          test-bin: nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-aarch64 ./result/bin/wash --version
+          test-oci: docker load < ./result
+          # TODO: Run aarch64 binary within OCI
+
+        - target: x86_64-pc-windows-gnu
+          install-path: /bin/wash.exe
+          test-bin: nix shell --inputs-from . 'nixpkgs#wine64' -c wine64 ./result/bin/wash.exe --version
+          test-oci: docker load < ./result
+          # TODO: Run win64 binary within OCI
+
+        - target: x86_64-unknown-linux-musl
+          install-path: /bin/wash
+          test-bin: ./result/bin/wash --version
+          test-oci: |
+            docker load < ./result
+            docker run --rm wash:$(nix eval --raw .#wash-x86_64-unknown-linux-musl-oci.imageTag) wash --version
+
+    name: wash-${{ matrix.config.target }}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: ./.github/actions/build-nix
+      with:
+        package: wash-${{ matrix.config.target }}
+        install-path: ${{ matrix.config.install-path }}
+    - run: ${{ matrix.config.test-bin }}
+    - uses: ./.github/actions/build-nix
+      with:
+        package: wash-${{ matrix.config.target }}-oci
+    - run: ${{ matrix.config.test-oci }}
+
+  build-mac:
+    strategy:
+      matrix:
+        config:
+        - target: aarch64-apple-darwin
+          test: file ./result/bin/wash
+          # TODO: Run aarch64 binary on host system and via OCI
+
+        - target: x86_64-apple-darwin
+          test: ./result/bin/wash --version
+
+    name: wash-${{ matrix.config.target }}
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: ./.github/actions/build-nix
+      with:
+        package: wash-${{ matrix.config.target }}
+        install-path: /bin/wash
+    - run: ${{ matrix.config.test-bin }}
+    - uses: ./.github/actions/build-nix
+      with:
+        package: wash-${{ matrix.config.target }}-oci
+    - run: ${{ matrix.platform.test-oci }}
+    # TODO: Test OCI on Mac
+
+  build-lipo:
+    name: wash-universal-darwin
+    needs: build-mac
+    runs-on: macos-12
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: wash-aarch64-apple-darwin
+    - uses: actions/download-artifact@v3
+      with:
+        name: wash-x86_64-apple-darwin
+    - run: lipo -create ./wash-aarch64-apple-darwin ./wash-x86_64-apple-darwin -output ./wash-universal-darwin
+    - run: chmod +x ./wash-universal-darwin
+    - run: ./wash-universal-darwin --version
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wash-universal-darwin
+        path: wash-universal-darwin
+
+  test-windows:
+    runs-on: windows-2022
+    needs: build-linux
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: wash-x86_64-pc-windows-gnu
+    # TODO: Verify that this actually starts the binary
+    - run: .\wash-x86_64-pc-windows-gnu --version
+
+  cargo:
+    strategy:
+      matrix:
+        check:
+        - fmt
+        - clippy
+        - nextest
+
+    name: cargo ${{ matrix.check }}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
+
+  fmt:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix fmt
+
+  run:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix run -L . -- --version
+
+  develop:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-nix
+      with: 
+        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix develop -L --ignore-environment -c cargo pkgid

--- a/flake.lock
+++ b/flake.lock
@@ -17,28 +17,127 @@
         ]
       },
       "locked": {
-        "lastModified": 1669943300,
-        "narHash": "sha256-1adQsyh7MvtlR19cJvL0VWemVTWwVbWSKrmrfX60ztU=",
-        "owner": "ipetkov",
+        "lastModified": 1681380356,
+        "narHash": "sha256-YjO9N6QKIhoDCt67HBHPb7mM4mPgAs8+XV4uoCo7FGY=",
+        "owner": "rvolosatovs",
         "repo": "crane",
-        "rev": "fb80a689c5c517bc40d9cc1828c384c38de90dda",
+        "rev": "5395efb0534e3405be794715ccf65504488cfb60",
         "type": "github"
       },
       "original": {
-        "owner": "ipetkov",
-        "ref": "v0.10.0",
+        "owner": "rvolosatovs",
+        "ref": "feat/crate-types",
         "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679255352,
+        "narHash": "sha256-nkGwGuNkhNrnN33S4HIDV5NzkzMLU5mNStRn9sZwq8c=",
+        "owner": "rvolosatovs",
+        "repo": "crane",
+        "rev": "cec65880599a4ec6426186e24342e663464f5933",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "ref": "feat/wit",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1681280529,
+        "narHash": "sha256-WDPFJQpnkFFpWW2OSiR0hfPovmpeP004DIq89q6GyLs=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0d8c62bb906470782a4aa36d93044e660088a3f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1679552560,
+        "narHash": "sha256-L9Se/F1iLQBZFGrnQJO8c9wE5z0Mf8OiycPGP9Y96hA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "fb49a9f5605ec512da947a21cc7e4551a3950397",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -48,12 +147,30 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -64,11 +181,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1676294984,
-        "narHash": "sha256-hdLUa/3RH1VJ+gMUysQE0JGM4F2Q/tIIFbtoxAOurJQ=",
+        "lastModified": 1681154353,
+        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "fc282c5478e4141842f9644c239a41cfe9586732",
+        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
         "type": "github"
       },
       "original": {
@@ -77,21 +194,97 @@
         "type": "github"
       }
     },
+    "nix-filter_2": {
+      "locked": {
+        "lastModified": 1678109515,
+        "narHash": "sha256-C2X+qC80K2C1TOYZT8nabgo05Dw2HST/pSn6s+n6BO8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "aa9ff6ce4a7f19af6415fb3721eaa513ea6c763c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-flake-tests": {
+      "locked": {
+        "lastModified": 1677844186,
+        "narHash": "sha256-ErJZ/Gs1rxh561CJeWP5bohA2IcTq1rDneu1WT6CVII=",
+        "owner": "antifuchs",
+        "repo": "nix-flake-tests",
+        "rev": "bbd9216bd0f6495bb961a8eb8392b7ef55c67afb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "antifuchs",
+        "repo": "nix-flake-tests",
+        "type": "github"
+      }
+    },
+    "nix-log": {
+      "inputs": {
+        "nix-flake-tests": "nix-flake-tests",
+        "nixify": "nixify_2",
+        "nixlib": "nixlib_2"
+      },
+      "locked": {
+        "lastModified": 1680772615,
+        "narHash": "sha256-RgOhQ6Wf1REMOfGkn1wX1/2Yki9oidonPaFMv2k/eSs=",
+        "owner": "rvolosatovs",
+        "repo": "nix-log",
+        "rev": "96e31031c7fbe028b0367fa568afaa4495f94218",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nix-log",
+        "type": "github"
+      }
+    },
     "nixify": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
+        "nix-log": "nix-log",
+        "nixlib": "nixlib_3",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1683654123,
+        "narHash": "sha256-XhxO62tGmjuii1q/iTWVlVFnUDYZCvrsxJgWZmq006M=",
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "rev": "bcf06ce2aea11c906d393a0c67ac81c7ce614a4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "type": "github"
+      }
+    },
+    "nixify_2": {
+      "inputs": {
+        "crane": "crane_2",
+        "fenix": "fenix_2",
+        "flake-utils": "flake-utils_2",
+        "nix-filter": "nix-filter_2",
         "nixlib": "nixlib",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1677589210,
-        "narHash": "sha256-PNRKrPXoxR+JjaF1TPeiOVea3AfoZyFVOXnbgkP5Pik=",
+        "lastModified": 1679748566,
+        "narHash": "sha256-yA4yIJjNCOLoUh0py9S3SywwbPnd/6NPYbXad+JeOl0=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "9f0b4162fc1e6cd10e3279c807147894d09fda8a",
+        "rev": "80e823959511a42dfec4409fef406a14ae8240f3",
         "type": "github"
       },
       "original": {
@@ -102,11 +295,41 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1677373009,
-        "narHash": "sha256-kxhz4QUP8tXa/yVSpEzDDZSEp9FvhzRqZzb+SeUaekw=",
+        "lastModified": 1679187309,
+        "narHash": "sha256-H8udmkg5wppL11d/05MMzOMryiYvc403axjDNZy1/TQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c9d4f2476046c6a7a2ce3c2118c48455bf0272ea",
+        "rev": "44214417fe4595438b31bdb9469be92536a61455",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_2": {
+      "locked": {
+        "lastModified": 1679791877,
+        "narHash": "sha256-tTV1Mf0hPWIMtqyU16Kd2JUBDWvfHlDC9pF57vcbgpQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "cc060ddbf652a532b54057081d5abd6144d01971",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_3": {
+      "locked": {
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
         "type": "github"
       },
       "original": {
@@ -117,11 +340,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677367679,
-        "narHash": "sha256-pOMXi7F9tcHls06Qv+7XCPASTJeXu47Jhd0Pk9du8T4=",
+        "lastModified": 1679577639,
+        "narHash": "sha256-7u7bsNP0ApBnLgsHVROQ5ytoMqustmMVMgtaFS/P7EU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea736343e4d4a052e023d54b23334cf685de479c",
+        "rev": "8f1bcd72727c5d4cd775545595d068be410f2a7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681349002,
+        "narHash": "sha256-9Ckc2WvSwuYrPfk3ZXgPasM1ir/cgs6UV0EpIWyPGZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2b1bba76a13ed39c7abc0a6e8f74f9e168cf3c7c",
         "type": "github"
       },
       "original": {
@@ -136,7 +375,70 @@
         "nixify": "nixify"
       }
     },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681234995,
+        "narHash": "sha256-QQxQAG5QZG8z/uRREhWnq4215Asl7Gh6a8zj7swDyP4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "7501d3b721560637e27f904d9fce79182c41bef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679520343,
+        "narHash": "sha256-AJGSGWRfoKWD5IVTu1wEsR990wHbX0kIaolPqNMEh0c=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "eb791f31e688ae00908eb75d4c704ef60c430a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
     "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679537973,
+        "narHash": "sha256-R6borgcKeyMIjjPeeYsfo+mT8UdS+OwwbhhStdCfEjg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fbc7ae3f14d32e78c0e8d7865f865cc28a46b232",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "flake-utils": [
           "nixify",
@@ -148,16 +450,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1677465082,
-        "narHash": "sha256-b82PmPWkt0pAsxmc477Yowq1Ez1VyjA5wnxE+yoIOWg=",
+        "lastModified": 1681352318,
+        "narHash": "sha256-+kwy7bTsuW8GYrRqWRQ8T5hg6duZb5IJiHlKo1J+v9g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2924bfce2fadc1ded4a2b8cfce7f2fd4ef41c36f",
+        "rev": "aeaa11c65a5c5cebaa51652353ab3c497b9a7bbf",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,8 @@
         name = "wash";
         src = ./.;
 
+        targets.wasm32-wasi = false; # `wash` does not compile for WASI
+
         buildOverrides = {
           pkgs,
           buildInputs ? [],

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,33 @@
 
         buildOverrides = {
           pkgs,
+          buildInputs ? [],
           nativeBuildInputs ? [],
+          depsBuildBuild ? [],
           ...
-        }: {
-          nativeBuildInputs =
-            nativeBuildInputs
-            ++ [
-              pkgs.protobuf # build dependency of prost-build v0.9.0
-            ];
-        };
+        } @ args:
+          with pkgs.lib;
+          with (args.pkgsCross or pkgs); {
+            buildInputs =
+              buildInputs
+              ++ optionals stdenv.hostPlatform.isDarwin [
+                pkgs.darwin.apple_sdk.frameworks.Security
+                pkgs.libiconv
+              ];
+
+            depsBuildBuild =
+              depsBuildBuild
+              ++ optionals stdenv.hostPlatform.isDarwin [
+                darwin.apple_sdk.frameworks.CoreFoundation
+                libiconv
+              ];
+
+            nativeBuildInputs =
+              nativeBuildInputs
+              ++ [
+                pkgs.protobuf # build dependency of prost-build v0.9.0
+              ];
+          };
 
         withDevShells = {
           pkgs,

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
 
         targets.wasm32-wasi = false; # `wash` does not compile for WASI
 
+        doCheck = false; # testing is performed in checks via `nextest`
+
         buildOverrides = {
           pkgs,
           pkgsCross ? pkgs,

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,16 @@
 
         buildOverrides = {
           pkgs,
+          pkgsCross ? pkgs,
+          ...
+        }: {
           buildInputs ? [],
           nativeBuildInputs ? [],
           depsBuildBuild ? [],
           ...
         } @ args:
-          with pkgs.lib;
-          with (args.pkgsCross or pkgs); {
+          with pkgsCross;
+          with pkgs.lib; {
             buildInputs =
               buildInputs
               ++ optionals stdenv.hostPlatform.isDarwin [

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           ".github"
           ".gitignore"
           ".pre-commit-config.yaml"
+          "Completions.md"
           "Dockerfile"
           "flake.lock"
           "flake.nix"
@@ -50,6 +51,7 @@
           "Makefile"
           "README.md"
           "rust-toolchain.toml"
+          "sample-manifest.yaml"
           "snap"
           "tools"
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,15 @@
 {
+  nixConfig.extra-substituters = [
+    "https://wasmcloud.cachix.org"
+    "https://nix-community.cachix.org"
+    "https://cache.garnix.io"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "wasmcloud.cachix.org-1:9gRBzsKh+x2HbVVspreFg/6iFRiD4aOcUQfXVDl3hiM="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+  ];
+
   description = "wash - wasmCloud Shell";
 
   inputs.nixify.url = github:rvolosatovs/nixify;

--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,13 @@
           # - external services running, which would require a more involved setup
           "tests/integration_build.rs"
           "tests/integration_claims.rs"
+          "tests/integration_inspect.rs"
+          "tests/integration_keys.rs"
+          "tests/integration_link.rs"
           "tests/integration_par.rs"
           "tests/integration_reg.rs"
+          "tests/integration_start.rs"
+          "tests/integration_stop.rs"
           "tests/integration_up.rs"
         ];
       };


### PR DESCRIPTION
- Build, test and upload as artifacts:
    - Statically-linked (towards Musl) x86_64 and aarch64 Linux `wash` binaries
    - Darwin x86_64, aarch64 and "universal" binaries
    - Windows x86_64
    - OCI images containing the above
- Lint the `nix` flake
- Run `clippy`, `nextest` and `fmt` via `nix`

Note how fast the nix CI jobs have finished (most under 1 minute), that is due to the caching from previous runs

# Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

Blocked by #408 
This includes #584 and will prevent issues like #564 from occurring in the future

# Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

# Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

# Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [x] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

## Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

## Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Open a workflow run summary, e.g. https://github.com/wasmCloud/wash/actions/runs/4303159397

Pull appropriate artifact, e.g. https://github.com/wasmCloud/wash/suites/11277959533/artifacts/578333825 for x86_64 Linux OCI

Then:
```
$ unzip wash-x86_64-unknown-linux-musl-oci.zip 
Archive:  wash-x86_64-unknown-linux-musl-oci.zip
  inflating: wash-x86_64-unknown-linux-musl-oci  
$ podman load < wash-x86_64-unknown-linux-musl-oci 
Getting image source signatures
Copying blob 4246f70d4a5d done  
Copying config 64d39d429d done  
Writing manifest to image destination
Storing signatures
Loaded image: localhost/wash:0.16.0
$ podman run --rm localhost/wash:0.16.0           

_________________________________________________________________________________
                               _____ _                 _    _____ _          _ _
                              / ____| |               | |  / ____| |        | | |
 __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
 \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
_________________________________________________________________________________

A single CLI to handle all of your wasmCloud tooling needs


Usage: wash [OPTIONS] <COMMAND>

Commands:
  app       Manage declarative applications and deployments (wadm) (experimental)
  build     Build (and sign) a wasmCloud actor, provider, or interface
  call      Invoke a wasmCloud actor
  claims    Generate and manage JWTs for wasmCloud actors
  ctl       Interact with a wasmCloud control interface
  ctx       Manage wasmCloud host configuration contexts
  down      Tear down a wasmCloud environment launched with wash up
  drain     Manage contents of local wasmCloud caches
  gen       Generate code from smithy IDL files
  keys      Utilities for generating and managing keys
  lint      Perform lint checks on smithy models
  new       Create a new project from template
  par       Create, inspect, and modify capability provider archive files
  reg       Interact with OCI compliant registries
  up        Bootstrap a wasmCloud environment
  validate  Perform validation checks on smithy models
  help      Print this message or the help of the given subcommand(s)

Options:
  -o, --output <OUTPUT>  Specify output format (text or json) [default: text]
  -h, --help             Print help information
  -V, --version          Print version information
```

Alternatively, e.g. aarch64 Linux musl binary (https://github.com/wasmCloud/wash/suites/11277959533/artifacts/578333818), run via QEMU:
```
$ unzip wash-aarch64-unknown-linux-musl.zip         
Archive:  wash-aarch64-unknown-linux-musl.zip
  inflating: wash-aarch64-unknown-linux-musl
$ chmod +x wash-aarch64-unknown-linux-musl
$ file ./wash-aarch64-unknown-linux-musl
./wash-aarch64-unknown-linux-musl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
$ ./wash-aarch64-unknown-linux-musl help
_________________________________________________________________________________
                               _____ _                 _    _____ _          _ _
                              / ____| |               | |  / ____| |        | | |
 __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
 \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
_________________________________________________________________________________

A single CLI to handle all of your wasmCloud tooling needs


Usage: wash-aarch64-unknown-linux-musl [OPTIONS] <COMMAND>

Commands:
  app       Manage declarative applications and deployments (wadm) (experimental)
  build     Build (and sign) a wasmCloud actor, provider, or interface
  call      Invoke a wasmCloud actor
  claims    Generate and manage JWTs for wasmCloud actors
  ctl       Interact with a wasmCloud control interface
  ctx       Manage wasmCloud host configuration contexts
  down      Tear down a wasmCloud environment launched with wash up
  drain     Manage contents of local wasmCloud caches
  gen       Generate code from smithy IDL files
  keys      Utilities for generating and managing keys
  lint      Perform lint checks on smithy models
  new       Create a new project from template
  par       Create, inspect, and modify capability provider archive files
  reg       Interact with OCI compliant registries
  up        Bootstrap a wasmCloud environment
  validate  Perform validation checks on smithy models
  help      Print this message or the help of the given subcommand(s)

Options:
  -o, --output <OUTPUT>  Specify output format (text or json) [default: text]
  -h, --help             Print help information
  -V, --version          Print version information
```