### PR TITLE
Refactored folders to be tmpdirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2939,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +3960,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "serial_test",
  "sha2 0.10.6",
  "sysinfo",
  "tempfile",

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,5 @@
 use anyhow::{Context, Result};
-use std::{
-    env,
-    fs::{create_dir_all, remove_dir_all},
-    path::PathBuf,
-};
+use std::{env, fs::create_dir_all};
 use tempfile::{Builder, NamedTempFile, TempDir};
 
 #[allow(unused)]

--- a/tests/integration_keys.rs
+++ b/tests/integration_keys.rs
@@ -1,6 +1,6 @@
 mod common;
 use assert_json_diff::assert_json_include;
-use common::{get_json_output, output_to_string, test_dir_file, test_dir_with_subfolder, wash};
+use common::{get_json_output, output_to_string, tmp_test_dir_with_subfolder, tmp_test_file, wash};
 use serde_json::json;
 use std::{
     fs::{remove_dir_all, File},
@@ -53,8 +53,8 @@ fn integration_keys_get_basic() {
     const KEYNAME: &str = "keys_get_basic.nk";
     const TESTDIR: &str = "integration_get_basic";
 
-    let get_basic_dir = test_dir_with_subfolder(TESTDIR);
-    let keyfile = test_dir_file(TESTDIR, KEYNAME);
+    let get_basic_dir = tmp_test_dir_with_subfolder(TESTDIR);
+    let keyfile = tmp_test_file(&get_basic_dir, KEYNAME);
     let mut file = File::create(keyfile).unwrap();
     file.write_all(KEYCONTENTS).unwrap();
 
@@ -64,7 +64,7 @@ fn integration_keys_get_basic() {
             "get",
             KEYNAME,
             "-d",
-            get_basic_dir.to_str().unwrap(),
+            get_basic_dir.path().to_str().unwrap(),
         ])
         .output()
         .expect("failed to read key with keys get");
@@ -83,8 +83,8 @@ fn integration_keys_get_comprehensive() {
     const KEYNAME: &str = "keys_get_comprehensive.nk";
     const TESTDIR: &str = "integration_get_comprehensive";
 
-    let get_comprehensive_dir = test_dir_with_subfolder(TESTDIR);
-    let keyfile = test_dir_file(TESTDIR, KEYNAME);
+    let get_comprehensive_dir = tmp_test_dir_with_subfolder(TESTDIR);
+    let keyfile = tmp_test_file(&get_comprehensive_dir, KEYNAME);
     let mut file = File::create(keyfile).unwrap();
     file.write_all(KEYCONTENTS).unwrap();
 
@@ -94,7 +94,7 @@ fn integration_keys_get_comprehensive() {
             "get",
             KEYNAME,
             "-d",
-            get_comprehensive_dir.to_str().unwrap(),
+            get_comprehensive_dir.path().to_str().unwrap(),
             "-o",
             "json",
         ])
@@ -120,10 +120,10 @@ fn integration_list_comprehensive() {
     const KEYTHREECONTENTS: &[u8] = b"SMANLG7XYYUWLMZSNHG2I7XWFS67RDRRDV632XCUKD4W6IQEJ33HAG6P74";
     const TESTDIR: &str = "integration_list_comprehensive";
 
-    let list_comprehensive_dir = test_dir_with_subfolder(TESTDIR);
-    let keyonefile = test_dir_file(TESTDIR, &format!("{KEYONE}.nk"));
-    let keytwofile = test_dir_file(TESTDIR, &format!("{KEYTWO}.nk"));
-    let keythreefile = test_dir_file(TESTDIR, &format!("{KEYTHREE}.nk"));
+    let list_comprehensive_dir = tmp_test_dir_with_subfolder(TESTDIR);
+    let keyonefile = tmp_test_file(&list_comprehensive_dir, &format!("{KEYONE}.nk"));
+    let keytwofile = tmp_test_file(&list_comprehensive_dir, &format!("{KEYTWO}.nk"));
+    let keythreefile = tmp_test_file(&list_comprehensive_dir, &format!("{KEYTHREE}.nk"));
 
     let mut file = File::create(keyonefile).unwrap();
     file.write_all(KEYONECONTENTS).unwrap();
@@ -137,7 +137,7 @@ fn integration_list_comprehensive() {
             "keys",
             "list",
             "-d",
-            list_comprehensive_dir.to_str().unwrap(),
+            list_comprehensive_dir.path().to_str().unwrap(),
         ])
         .output()
         .expect("failed to list keys with keys list");
@@ -145,7 +145,7 @@ fn integration_list_comprehensive() {
     let output = output_to_string(list_output).unwrap();
     assert!(output.contains(&format!(
         "====== Keys found in {} ======",
-        list_comprehensive_dir.to_str().unwrap()
+        list_comprehensive_dir.path().to_str().unwrap()
     )));
     assert!(output.contains(KEYONE));
     assert!(output.contains(KEYTWO));
@@ -156,7 +156,7 @@ fn integration_list_comprehensive() {
             "keys",
             "list",
             "-d",
-            list_comprehensive_dir.to_str().unwrap(),
+            list_comprehensive_dir.path().to_str().unwrap(),
             "-o",
             "json",
         ])

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,10 +1,10 @@
 use std::{
     fs::{read_to_string, remove_dir_all},
-    path::PathBuf,
+    path::Path,
 };
 
 use anyhow::{anyhow, Result};
-use common::{test_dir_with_subfolder, wash};
+use common::{tmp_test_dir_with_subfolder, wash};
 use sysinfo::{ProcessExt, SystemExt};
 use tokio::process::Child;
 use wash_lib::start::{ensure_nats_server, start_nats_server, NatsConfig};
@@ -13,8 +13,8 @@ mod common;
 
 #[test]
 fn integration_up_can_start_wasmcloud_and_actor() {
-    let dir = test_dir_with_subfolder("can_start_wasmcloud");
-    let path = dir.join("washup.log");
+    let dir = tmp_test_dir_with_subfolder("can_start_wasmcloud");
+    let path = dir.path().join("washup.log");
     let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
     let mut up_cmd = wash()
@@ -77,8 +77,8 @@ fn integration_up_can_start_wasmcloud_and_actor() {
 
 #[test]
 fn can_stop_detached_host() {
-    let dir = test_dir_with_subfolder("can_stop_wasmcloud");
-    let path = dir.join("washup.log");
+    let dir = tmp_test_dir_with_subfolder("can_stop_wasmcloud");
+    let path = dir.path().join("washup.log");
     let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
     let mut up_cmd = wash()
@@ -135,11 +135,11 @@ fn can_stop_detached_host() {
 
 #[tokio::test]
 async fn doesnt_kill_unowned_nats() -> Result<()> {
-    let dir = test_dir_with_subfolder("doesnt_kill_unowned_nats");
-    let path = dir.join("washup.log");
+    let dir = tmp_test_dir_with_subfolder("doesnt_kill_unowned_nats");
+    let path = dir.path().join("washup.log");
     let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
-    let mut nats = start_nats(5895, &dir).await?;
+    let mut nats = start_nats(5895, dir.path()).await?;
 
     let mut up_cmd = wash()
         .args([
@@ -202,7 +202,7 @@ async fn doesnt_kill_unowned_nats() -> Result<()> {
     Ok(())
 }
 
-async fn start_nats(port: u16, nats_install_dir: &PathBuf) -> Result<Child> {
+async fn start_nats(port: u16, nats_install_dir: &Path) -> Result<Child> {
     let nats_binary = ensure_nats_server("v2.8.4", nats_install_dir).await?;
     let config = NatsConfig::new_standalone("127.0.0.1", port, None);
     start_nats_server(nats_binary, std::process::Stdio::null(), config).await


### PR DESCRIPTION
## Feature or Problem
Occasionally, test flakes occur because of resources not cleaning up after tests run. This PR refactors the helper functions we use to create directories and files to the `tempfile` crate which has `Drop` implementations.

## Related Issues
#405 

## Release Information
next

## Consumer Impact
Should improve the experience of running `wash` tests locally!

## Testing
Testing locally with `make test` just like our CI uses

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
None

### Acceptance or Integration
Many integration tests were modified to use `TempDir`s and `NamedTempFile`s instead of PathBufs

### Manual Verification
- [ ] WIP: Some tests are still failing and need to be modified to work, likely an issue with blanket refactoring and some intricacies of the test suite.
