### PR TITLE
release(wash-lib): v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2939,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +3960,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "serial_test",
  "sha2 0.10.6",
  "sysinfo",
  "tempfile",
@@ -3941,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,9 +3371,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "7125661431c26622a80ca5051a2f936c9a678318e0351007b0cc313143024e5c"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,8 @@ term-table = "1.3.1"
 test-case = "2.2.1"
 test_bin = "0.4.0"
 thiserror = "1.0"
-tokio = { version = "1", default-features = false }
+# DO NOT UPDATE - https://github.com/wasmCloud/wash/issues/382
+tokio = { version = "=1.24.0", default-features = false }
 tokio-stream = "0.1"
 tokio-tar = "0.3"
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ tokio-tar = "0.3"
 toml = "0.5"
 walkdir = "2.3"
 wascap = "0.9.2"
-wash-lib = { version = "0.6", path = "./crates/wash-lib" }
+wash-lib = { version = "0.6.1", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.11.2"
 wasmcloud-control-interface = "0.23"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -31,21 +31,11 @@ pub(crate) fn get_json_output(output: std::process::Output) -> Result<serde_json
 
 #[allow(unused)]
 /// Creates a subfolder in the test directory for use with a specific test
-pub(crate) fn test_dir() -> PathBuf {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
-    let test_dir = PathBuf::from(manifest_dir).join("tests/fixtures");
-    remove_dir_all(&test_dir);
-    create_dir_all(&test_dir);
-    test_dir
-}
-
-#[allow(unused)]
-/// Creates a subfolder in the test directory for use with a specific test
 /// It's preferred that the same test that calls this function also
 /// uses std::fs::remove_dir_all to remove the subdirectory
 pub(crate) fn test_dir_with_subfolder(subfolder: &str) -> PathBuf {
-    let test_dir = test_dir();
-    let with_subfolder = test_dir.join(subfolder);
+    let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+    let with_subfolder = PathBuf::from(format!("{root_dir}/tests/fixtures/{subfolder}"));
     remove_dir_all(with_subfolder.clone());
     create_dir_all(with_subfolder.clone());
     with_subfolder
@@ -56,5 +46,6 @@ pub(crate) fn test_dir_with_subfolder(subfolder: &str) -> PathBuf {
 /// to the test fixtures directory. This does _not_ create the file,
 /// so the test is responsible for initialization and modification of this file
 pub(crate) fn test_dir_file(subfolder: &str, file: &str) -> PathBuf {
-    test_dir_with_subfolder(subfolder).join(file)
+    let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+    PathBuf::from(format!("{root_dir}/tests/fixtures/{subfolder}/{file}"))
 }


### PR DESCRIPTION
## Feature or Problem
Release `wash-lib` v0.6.1 and bump dependency in `wash`

## Related Issues

Contains fix for #341 (issues with dashed names in actors)

## Release Information

`wash-lib` `0.6.1`

## Consumer Impact

Consumers will be able to create actors with dashes in their names where that previously caused failures during build.

## Testing

Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

N/A

### Acceptance or Integration

N/A

### Manual Verification

Manually verified locally
