### PR TITLE
release: wash v0.16.0, wash-lib v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.16.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -134,7 +134,7 @@ tokio-tar = "0.3"
 toml = "0.5"
 walkdir = "2.3"
 wascap = "0.9.2"
-wash-lib = { version = "0.6", path = "./crates/wash-lib" }
+wash-lib = { version = "0.6.1", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.11.2"
 wasmcloud-control-interface = "0.23"
 wasmcloud-test-util = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.16.1"
+version = "0.16.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
## Feature or Problem

Third time's the charm.

- Release `wash-lib` v0.6.1
- Release `wash` v0.16.0

## Related Issues

Contains fix for #341 (issues with dashed names in actors)

## Release Information

`wash` `0.16.0`

## Consumer Impact

Consumers will be able to create actors with dashes in their names where that previously caused failures during build.

## Testing

Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

N/A

### Acceptance or Integration

N/A

### Manual Verification

Manually verified locally