### PR TITLE
Feat/wash inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inspect"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ffe1795f3bb174cb0068e89f829ac8fbef920d8bc1d1a78112c5990bb56c0c"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,6 +4013,7 @@ dependencies = [
  "heck 0.4.0",
  "ignore",
  "indicatif",
+ "inspect",
  "log",
  "nkeys",
  "oci-distribution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ futures = "0.3"
 heck = "0.4"
 ignore = "0.4"
 indicatif = "0.17.0"
+inspect = "0.1.0"
 log = "0.4"
 nkeys = "0.2.0"
 oci-distribution = { version = "0.9.1", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,9 @@ build-watch: ## Continuously build the project
 
 ##@ Testing
 
-# Target to focus on for tests (enables running only one test)
-CARGO_TEST_TARGET ?= ""
-
 test: ## Run unit test suite
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
+	@$(CARGO) nextest run --no-fail-fast --bin wash
+	@$(CARGO) nextest run --no-fail-fast -p wash-lib
 
 test-watch: ## Run unit tests continously, can optionally specify a target test filter.
 	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
@@ -47,7 +44,7 @@ test-integration-watch: ## Run integration test suite continuously
 	@$(CARGO) watch -- $(MAKE) test-integration
 
 test-unit: ## Run one or more unit tests
-	@$(CARGO) nextest $(CARGO_TEST_TARGET)
+	@$(CARGO) nextest run
 
 test-unit-watch: ## Run tests continuously
 	@$(CARGO) watch -- $(MAKE) test-unit

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -57,6 +57,7 @@ cargo_toml = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }
+inspect = { workspace = true }
 dirs = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -5,20 +5,14 @@ use std::{
     path::PathBuf,
 };
 
-use crate::registry::OciPullOptions;
-
 use super::{extract_keypair, CommandOutput, OutputKind};
+use crate::cli::inspect;
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
 use log::warn;
 use nkeys::{KeyPair, KeyPairType};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use term_table::{
-    row::Row,
-    table_cell::{Alignment, TableCell},
-    Table,
-};
 use wascap::{
     caps::capability_name,
     jwt::{
@@ -48,15 +42,15 @@ pub struct InspectCommand {
 
     /// Extract the raw JWT from the file and print to stdout
     #[clap(name = "jwt_only", long = "jwt-only")]
-    jwt_only: bool,
+    pub(crate) jwt_only: bool,
 
     /// Digest to verify artifact against (if OCI URL is provided for <module>)
     #[clap(short = 'd', long = "digest")]
-    digest: Option<String>,
+    pub(crate) digest: Option<String>,
 
     /// Allow latest artifact tags (if OCI URL is provided for <module>)
     #[clap(long = "allow-latest")]
-    allow_latest: bool,
+    pub(crate) allow_latest: bool,
 
     /// OCI username, if omitted anonymous authentication will be used
     #[clap(
@@ -65,7 +59,7 @@ pub struct InspectCommand {
         env = "WASH_REG_USER",
         hide_env_values = true
     )]
-    user: Option<String>,
+    pub(crate) user: Option<String>,
 
     /// OCI password, if omitted anonymous authentication will be used
     #[clap(
@@ -74,15 +68,15 @@ pub struct InspectCommand {
         env = "WASH_REG_PASSWORD",
         hide_env_values = true
     )]
-    password: Option<String>,
+    pub(crate) password: Option<String>,
 
     /// Allow insecure (HTTP) registry connections
     #[clap(long = "insecure")]
-    insecure: bool,
+    pub(crate) insecure: bool,
 
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
-    no_cache: bool,
+    pub(crate) no_cache: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -304,12 +298,30 @@ pub struct ActorMetadata {
     pub common: GenerateCommon,
 }
 
+impl From<InspectCommand> for inspect::InspectCliCommand {
+    fn from(cmd: InspectCommand) -> Self {
+        inspect::InspectCliCommand {
+            target: cmd.module,
+            jwt_only: cmd.jwt_only,
+            digest: cmd.digest,
+            allow_latest: cmd.allow_latest,
+            user: cmd.user,
+            password: cmd.password,
+            insecure: cmd.insecure,
+            no_cache: cmd.no_cache,
+        }
+    }
+}
+
 pub async fn handle_command(
     command: ClaimsCliCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     match command {
-        ClaimsCliCommand::Inspect(inspectcmd) => render_caps(inspectcmd).await,
+        ClaimsCliCommand::Inspect(inspectcmd) => {
+            warn!("claims inspect will be deprecated in future versions. Use inspect instead.");
+            inspect::handle_command(inspectcmd, output_kind).await
+        }
         ClaimsCliCommand::Sign(signcmd) => sign_file(signcmd, output_kind),
         ClaimsCliCommand::Token(gencmd) => generate_token(gencmd, output_kind),
     }
@@ -636,190 +648,6 @@ pub fn sign_file(cmd: SignCommand, output_kind: OutputKind) -> Result<CommandOut
     }?;
 
     Ok(output)
-}
-
-async fn get_caps(cmd: InspectCommand) -> Result<Option<Token<Actor>>> {
-    let cache_path = (!cmd.no_cache).then(|| super::cached_oci_file(&cmd.module));
-    let artifact_bytes = crate::registry::get_oci_artifact(
-        cmd.module,
-        cache_path,
-        OciPullOptions {
-            digest: cmd.digest,
-            allow_latest: cmd.allow_latest,
-            user: cmd.user,
-            password: cmd.password,
-            insecure: cmd.insecure,
-        },
-    )
-    .await?;
-
-    // Extract will return an error if it encounters an invalid hash in the claims
-    Ok(wascap::wasm::extract_claims(artifact_bytes)?)
-}
-
-async fn render_caps(cmd: InspectCommand) -> Result<CommandOutput> {
-    let module_name = cmd.module.clone();
-    let jwt_only = cmd.jwt_only;
-    let caps = get_caps(cmd).await?;
-
-    let out = match caps {
-        Some(token) => {
-            if jwt_only {
-                CommandOutput::from_key_and_text("token", token.jwt)
-            } else {
-                let validation = wascap::jwt::validate_token::<Actor>(&token.jwt)?;
-                render_actor_claims(token.claims, validation)
-            }
-        }
-        None => bail!("No capabilities discovered in : {}", module_name),
-    };
-    warn!("claims inspect will be deprecated in future versions. Use inspect instead.");
-    Ok(out)
-}
-
-/// Renders actor claims into provided output format
-pub fn render_actor_claims(claims: Claims<Actor>, validation: TokenValidation) -> CommandOutput {
-    let md = claims.metadata.clone().unwrap();
-    let name = md.name();
-    let friendly_rev = md.rev.unwrap_or(0);
-    let friendly_ver = md.ver.unwrap_or_else(|| "None".to_string());
-    let friendly = format!("{} ({})", friendly_ver, friendly_rev);
-    let provider = if md.provider {
-        "Capability Provider"
-    } else {
-        "Capabilities"
-    };
-
-    let tags = if let Some(tags) = &claims.metadata.as_ref().unwrap().tags {
-        if tags.is_empty() {
-            "None".to_string()
-        } else {
-            tags.join(",")
-        }
-    } else {
-        "None".to_string()
-    };
-
-    let friendly_caps: Vec<String> = if let Some(caps) = &claims.metadata.as_ref().unwrap().caps {
-        caps.iter().map(|c| capability_name(c)).collect()
-    } else {
-        vec![]
-    };
-
-    let call_alias = claims
-        .metadata
-        .as_ref()
-        .unwrap()
-        .call_alias
-        .clone()
-        .unwrap_or_else(|| "(Not set)".to_string());
-
-    let iss_label = token_label(&claims.issuer).to_ascii_lowercase();
-    let sub_label = token_label(&claims.subject).to_ascii_lowercase();
-    let provider_json = provider.replace(' ', "_").to_ascii_lowercase();
-
-    let mut map = HashMap::new();
-    map.insert(iss_label, json!(claims.issuer));
-    map.insert(sub_label, json!(claims.subject));
-    map.insert("expires".to_string(), json!(validation.expires_human));
-    map.insert(
-        "can_be_used".to_string(),
-        json!(validation.not_before_human),
-    );
-    map.insert("version".to_string(), json!(friendly_ver));
-    map.insert("revision".to_string(), json!(friendly_rev));
-    map.insert(provider_json, json!(friendly_caps));
-    map.insert("tags".to_string(), json!(tags));
-    map.insert("call_alias".to_string(), json!(call_alias));
-    map.insert("name".to_string(), json!(name));
-
-    let mut table = render_core(&claims, validation);
-
-    table.add_row(Row::new(vec![
-        TableCell::new("Version"),
-        TableCell::new_with_alignment(friendly, 1, Alignment::Right),
-    ]));
-
-    table.add_row(Row::new(vec![
-        TableCell::new("Call Alias"),
-        TableCell::new_with_alignment(call_alias, 1, Alignment::Right),
-    ]));
-
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        provider,
-        2,
-        Alignment::Center,
-    )]));
-
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        friendly_caps.join("\n"),
-        2,
-        Alignment::Left,
-    )]));
-
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        "Tags",
-        2,
-        Alignment::Center,
-    )]));
-
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        tags,
-        2,
-        Alignment::Left,
-    )]));
-
-    CommandOutput::new(table.render(), map)
-}
-
-// * - we don't need render impls for Operator or Account because those tokens are never embedded into a module,
-// only actors.
-
-fn token_label(pk: &str) -> String {
-    match pk.chars().next().unwrap() {
-        'A' => "Account".to_string(),
-        'M' => "Module".to_string(),
-        'O' => "Operator".to_string(),
-        'S' => "Server".to_string(),
-        'U' => "User".to_string(),
-        _ => "<Unknown>".to_string(),
-    }
-}
-
-fn render_core<T>(claims: &Claims<T>, validation: TokenValidation) -> Table
-where
-    T: serde::Serialize + DeserializeOwned + WascapEntity,
-{
-    let mut table = Table::new();
-    super::configure_table_style(&mut table);
-
-    let headline = format!("{} - {}", claims.name(), token_label(&claims.subject));
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        headline,
-        2,
-        Alignment::Center,
-    )]));
-
-    table.add_row(Row::new(vec![
-        TableCell::new(token_label(&claims.issuer)),
-        TableCell::new_with_alignment(&claims.issuer, 1, Alignment::Right),
-    ]));
-    table.add_row(Row::new(vec![
-        TableCell::new(token_label(&claims.subject)),
-        TableCell::new_with_alignment(&claims.subject, 1, Alignment::Right),
-    ]));
-
-    table.add_row(Row::new(vec![
-        TableCell::new("Expires"),
-        TableCell::new_with_alignment(validation.expires_human, 1, Alignment::Right),
-    ]));
-
-    table.add_row(Row::new(vec![
-        TableCell::new("Can Be Used"),
-        TableCell::new_with_alignment(validation.not_before_human, 1, Alignment::Right),
-    ]));
-
-    table
 }
 
 fn sanitize_alias(call_alias: Option<String>) -> Result<Option<String>> {

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -25,6 +25,7 @@ use wascap::{
     },
     wasm::{days_from_now_to_jwt_time, sign_buffer_with_claims},
 };
+use log::warn;
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum ClaimsCliCommand {
@@ -672,11 +673,12 @@ async fn render_caps(cmd: InspectCommand) -> Result<CommandOutput> {
         }
         None => bail!("No capabilities discovered in : {}", module_name),
     };
+    warn!("claims inspect will be deprecated in future versions. Use inspect instead.");
     Ok(out)
 }
 
 /// Renders actor claims into provided output format
-pub(crate) fn render_actor_claims(
+pub fn render_actor_claims(
     claims: Claims<Actor>,
     validation: TokenValidation,
 ) -> CommandOutput {

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -14,10 +14,7 @@ use nkeys::{KeyPair, KeyPairType};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use wascap::{
-    caps::capability_name,
-    jwt::{
-        Account, Actor, CapabilityProvider, Claims, Operator, Token, TokenValidation, WascapEntity,
-    },
+    jwt::{Account, Actor, CapabilityProvider, Claims, Operator},
     wasm::{days_from_now_to_jwt_time, sign_buffer_with_claims},
 };
 

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -10,6 +10,7 @@ use crate::registry::OciPullOptions;
 use super::{extract_keypair, CommandOutput, OutputKind};
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
+use log::warn;
 use nkeys::{KeyPair, KeyPairType};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
@@ -25,7 +26,6 @@ use wascap::{
     },
     wasm::{days_from_now_to_jwt_time, sign_buffer_with_claims},
 };
-use log::warn;
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum ClaimsCliCommand {
@@ -678,10 +678,7 @@ async fn render_caps(cmd: InspectCommand) -> Result<CommandOutput> {
 }
 
 /// Renders actor claims into provided output format
-pub fn render_actor_claims(
-    claims: Claims<Actor>,
-    validation: TokenValidation,
-) -> CommandOutput {
+pub fn render_actor_claims(claims: Claims<Actor>, validation: TokenValidation) -> CommandOutput {
     let md = claims.metadata.clone().unwrap();
     let name = md.name();
     let friendly_rev = md.rev.unwrap_or(0);

--- a/crates/wash-lib/src/cli/inspect.rs
+++ b/crates/wash-lib/src/cli/inspect.rs
@@ -1,14 +1,15 @@
-use crate::util::{self};
+use super::{cached_oci_file, CommandOutput, OutputKind};
+use crate::registry::{get_oci_artifact, OciPullOptions};
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use provider_archive::*;
+use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::{collections::HashMap, fs::File, io::Read, path::PathBuf};
 use term_table::{row::Row, table_cell::*, Table};
-use wascap::jwt::{Actor, Token};
-use wash_lib::{
-    cli::{cached_oci_file, claims::render_actor_claims, CommandOutput, OutputKind},
-    registry::OciPullOptions,
+use wascap::{
+    caps::capability_name,
+    jwt::{Actor, Claims, Token, TokenValidation, WascapEntity},
 };
 
 // The magic number 0061 736D is present at the beginning of all wasm files.
@@ -21,15 +22,15 @@ pub struct InspectCliCommand {
 
     /// Extract the raw JWT from the file and print to stdout
     #[clap(name = "jwt_only", long = "jwt-only")]
-    jwt_only: bool,
+    pub jwt_only: bool,
 
     /// Digest to verify artifact against (if OCI URL is provided for <module> or <archive>)
     #[clap(short = 'd', long = "digest")]
-    digest: Option<String>,
+    pub digest: Option<String>,
 
     /// Allow latest artifact tags (if OCI URL is provided for <module> or <archive>)
     #[clap(long = "allow-latest")]
-    allow_latest: bool,
+    pub allow_latest: bool,
 
     /// OCI username, if omitted anonymous authentication will be used
     #[clap(
@@ -38,7 +39,7 @@ pub struct InspectCliCommand {
         env = "WASH_REG_USER",
         hide_env_values = true
     )]
-    user: Option<String>,
+    pub user: Option<String>,
 
     /// OCI password, if omitted anonymous authentication will be used
     #[clap(
@@ -47,29 +48,30 @@ pub struct InspectCliCommand {
         env = "WASH_REG_PASSWORD",
         hide_env_values = true
     )]
-    password: Option<String>,
+    pub password: Option<String>,
 
     /// Allow insecure (HTTP) registry connections
     #[clap(long = "insecure")]
-    insecure: bool,
+    pub insecure: bool,
 
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
-    no_cache: bool,
+    pub no_cache: bool,
 }
 
 /// Attempts to inspect a provider archive or signed actor module
 pub async fn handle_command(
-    command: InspectCliCommand,
+    command: impl Into<InspectCliCommand>,
     _output_kind: OutputKind,
 ) -> Result<CommandOutput> {
+    let command = command.into();
     let mut buf = Vec::new();
     if PathBuf::from(command.target.clone()).as_path().is_dir() {
         let mut f = File::open(command.target.clone())?;
         f.read_to_end(&mut buf)?;
     } else {
         let cache_file = (!command.no_cache).then(|| cached_oci_file(&command.target.clone()));
-        buf = wash_lib::registry::get_oci_artifact(
+        buf = get_oci_artifact(
             command.target.clone(),
             cache_file,
             OciPullOptions {
@@ -118,6 +120,151 @@ async fn get_caps(cmd: InspectCliCommand, artifact_bytes: &[u8]) -> Result<Optio
     Ok(wascap::wasm::extract_claims(artifact_bytes)?)
 }
 
+/// Renders actor claims into provided output format
+pub fn render_actor_claims(claims: Claims<Actor>, validation: TokenValidation) -> CommandOutput {
+    let md = claims.metadata.clone().unwrap();
+    let name = md.name();
+    let friendly_rev = md.rev.unwrap_or(0);
+    let friendly_ver = md.ver.unwrap_or_else(|| "None".to_string());
+    let friendly = format!("{} ({})", friendly_ver, friendly_rev);
+    let provider = if md.provider {
+        "Capability Provider"
+    } else {
+        "Capabilities"
+    };
+
+    let tags = if let Some(tags) = &claims.metadata.as_ref().unwrap().tags {
+        if tags.is_empty() {
+            "None".to_string()
+        } else {
+            tags.join(",")
+        }
+    } else {
+        "None".to_string()
+    };
+
+    let friendly_caps: Vec<String> = if let Some(caps) = &claims.metadata.as_ref().unwrap().caps {
+        caps.iter().map(|c| capability_name(c)).collect()
+    } else {
+        vec![]
+    };
+
+    let call_alias = claims
+        .metadata
+        .as_ref()
+        .unwrap()
+        .call_alias
+        .clone()
+        .unwrap_or_else(|| "(Not set)".to_string());
+
+    let iss_label = token_label(&claims.issuer).to_ascii_lowercase();
+    let sub_label = token_label(&claims.subject).to_ascii_lowercase();
+    let provider_json = provider.replace(' ', "_").to_ascii_lowercase();
+
+    let mut map = HashMap::new();
+    map.insert(iss_label, json!(claims.issuer));
+    map.insert(sub_label, json!(claims.subject));
+    map.insert("expires".to_string(), json!(validation.expires_human));
+    map.insert(
+        "can_be_used".to_string(),
+        json!(validation.not_before_human),
+    );
+    map.insert("version".to_string(), json!(friendly_ver));
+    map.insert("revision".to_string(), json!(friendly_rev));
+    map.insert(provider_json, json!(friendly_caps));
+    map.insert("tags".to_string(), json!(tags));
+    map.insert("call_alias".to_string(), json!(call_alias));
+    map.insert("name".to_string(), json!(name));
+
+    let mut table = render_core(&claims, validation);
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Version"),
+        TableCell::new_with_alignment(friendly, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Call Alias"),
+        TableCell::new_with_alignment(call_alias, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        provider,
+        2,
+        Alignment::Center,
+    )]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        friendly_caps.join("\n"),
+        2,
+        Alignment::Left,
+    )]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        "Tags",
+        2,
+        Alignment::Center,
+    )]));
+
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        tags,
+        2,
+        Alignment::Left,
+    )]));
+
+    CommandOutput::new(table.render(), map)
+}
+
+// * - we don't need render impls for Operator or Account because those tokens are never embedded into a module,
+// only actors.
+
+fn token_label(pk: &str) -> String {
+    match pk.chars().next().unwrap() {
+        'A' => "Account".to_string(),
+        'M' => "Module".to_string(),
+        'O' => "Operator".to_string(),
+        'S' => "Server".to_string(),
+        'U' => "User".to_string(),
+        _ => "<Unknown>".to_string(),
+    }
+}
+
+fn render_core<T>(claims: &Claims<T>, validation: TokenValidation) -> Table
+where
+    T: serde::Serialize + DeserializeOwned + WascapEntity,
+{
+    let mut table = Table::new();
+    super::configure_table_style(&mut table);
+
+    let headline = format!("{} - {}", claims.name(), token_label(&claims.subject));
+    table.add_row(Row::new(vec![TableCell::new_with_alignment(
+        headline,
+        2,
+        Alignment::Center,
+    )]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new(token_label(&claims.issuer)),
+        TableCell::new_with_alignment(&claims.issuer, 1, Alignment::Right),
+    ]));
+    table.add_row(Row::new(vec![
+        TableCell::new(token_label(&claims.subject)),
+        TableCell::new_with_alignment(&claims.subject, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Expires"),
+        TableCell::new_with_alignment(validation.expires_human, 1, Alignment::Right),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Can Be Used"),
+        TableCell::new_with_alignment(validation.not_before_human, 1, Alignment::Right),
+    ]));
+
+    table
+}
+
 /// Inspects a provider archive
 pub(crate) async fn handle_provider_archive(
     cmd: InspectCliCommand,
@@ -150,7 +297,7 @@ pub(crate) async fn handle_provider_archive(
     map.insert("targets".to_string(), json!(artifact.targets()));
     let text_table = {
         let mut table = Table::new();
-        util::configure_table_style(&mut table);
+        super::configure_table_style(&mut table);
 
         table.add_row(Row::new(vec![TableCell::new_with_alignment(
             format!("{} - Provider Archive", name),
@@ -235,27 +382,25 @@ mod test {
             "--no-cache",
         ])
         .unwrap();
-        match inspect_long.command {
-            InspectCliCommand {
-                target,
-                jwt_only,
-                digest,
-                allow_latest,
-                user,
-                password,
-                insecure,
-                no_cache,
-            } => {
-                assert_eq!(target, LOCAL);
-                assert_eq!(digest.unwrap(), "sha256:blah");
-                assert!(!allow_latest);
-                assert!(!insecure);
-                assert_eq!(user.unwrap(), "name");
-                assert_eq!(password.unwrap(), "secret");
-                assert!(jwt_only);
-                assert!(no_cache);
-            }
-        }
+        let InspectCliCommand {
+            target,
+            jwt_only,
+            digest,
+            allow_latest,
+            user,
+            password,
+            insecure,
+            no_cache,
+        } = inspect_long.command;
+        assert_eq!(target, LOCAL);
+        assert_eq!(digest.unwrap(), "sha256:blah");
+        assert!(!allow_latest);
+        assert!(!insecure);
+        assert_eq!(user.unwrap(), "name");
+        assert_eq!(password.unwrap(), "secret");
+        assert!(jwt_only);
+        assert!(no_cache);
+
         let inspect_short: Cmd = Parser::try_parse_from([
             "inspect",
             REMOTE,
@@ -271,27 +416,24 @@ mod test {
             "--no-cache",
         ])
         .unwrap();
-        match inspect_short.command {
-            InspectCliCommand {
-                target,
-                jwt_only,
-                digest,
-                allow_latest,
-                user,
-                password,
-                insecure,
-                no_cache,
-            } => {
-                assert_eq!(target, REMOTE);
-                assert_eq!(digest.unwrap(), "sha256:blah");
-                assert!(allow_latest);
-                assert!(insecure);
-                assert_eq!(user.unwrap(), "name");
-                assert_eq!(password.unwrap(), "secret");
-                assert!(jwt_only);
-                assert!(no_cache);
-            }
-        }
+        let InspectCliCommand {
+            target,
+            jwt_only,
+            digest,
+            allow_latest,
+            user,
+            password,
+            insecure,
+            no_cache,
+        } = inspect_short.command;
+        assert_eq!(target, REMOTE);
+        assert_eq!(digest.unwrap(), "sha256:blah");
+        assert!(allow_latest);
+        assert!(insecure);
+        assert_eq!(user.unwrap(), "name");
+        assert_eq!(password.unwrap(), "secret");
+        assert!(jwt_only);
+        assert!(no_cache);
 
         let cmd: Cmd = Parser::try_parse_from([
             "inspect",
@@ -309,30 +451,27 @@ mod test {
         ])
         .unwrap();
 
-        match cmd.command {
-            InspectCliCommand {
-                target,
-                jwt_only,
-                digest,
-                allow_latest,
-                user,
-                password,
-                insecure,
-                no_cache,
-            } => {
-                assert_eq!(target, SUBSCRIBER_OCI);
-                assert_eq!(
-                    digest.unwrap(),
-                    "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
-                );
-                assert_eq!(user.unwrap(), "name");
-                assert_eq!(password.unwrap(), "opensesame");
-                assert!(allow_latest);
-                assert!(insecure);
-                assert!(jwt_only);
-                assert!(no_cache);
-            }
-        }
+        let InspectCliCommand {
+            target,
+            jwt_only,
+            digest,
+            allow_latest,
+            user,
+            password,
+            insecure,
+            no_cache,
+        } = cmd.command;
+        assert_eq!(target, SUBSCRIBER_OCI);
+        assert_eq!(
+            digest.unwrap(),
+            "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
+        );
+        assert_eq!(user.unwrap(), "name");
+        assert_eq!(password.unwrap(), "opensesame");
+        assert!(allow_latest);
+        assert!(insecure);
+        assert!(jwt_only);
+        assert!(no_cache);
 
         let short_cmd: Cmd = Parser::try_parse_from([
             "inspect",
@@ -350,29 +489,26 @@ mod test {
         ])
         .unwrap();
 
-        match short_cmd.command {
-            InspectCliCommand {
-                target,
-                jwt_only,
-                digest,
-                allow_latest,
-                user,
-                password,
-                insecure,
-                no_cache,
-            } => {
-                assert_eq!(target, SUBSCRIBER_OCI);
-                assert_eq!(
-                    digest.unwrap(),
-                    "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
-                );
-                assert_eq!(user.unwrap(), "name");
-                assert_eq!(password.unwrap(), "opensesame");
-                assert!(allow_latest);
-                assert!(insecure);
-                assert!(jwt_only);
-                assert!(no_cache);
-            }
-        }
+        let InspectCliCommand {
+            target,
+            jwt_only,
+            digest,
+            allow_latest,
+            user,
+            password,
+            insecure,
+            no_cache,
+        } = short_cmd.command;
+        assert_eq!(target, SUBSCRIBER_OCI);
+        assert_eq!(
+            digest.unwrap(),
+            "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
+        );
+        assert_eq!(user.unwrap(), "name");
+        assert_eq!(password.unwrap(), "opensesame");
+        assert!(allow_latest);
+        assert!(insecure);
+        assert!(jwt_only);
+        assert!(no_cache);
     }
 }

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -25,6 +25,7 @@ use crate::keys::{
 };
 
 pub mod claims;
+pub mod inspect;
 
 /// Used for displaying human-readable output vs JSON format
 #[derive(Debug, Copy, Clone, Eq, Serialize, Deserialize, PartialEq)]

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,391 @@
+use clap::{Parser};
+use std::{collections::HashMap, fs::{File}, io::{Read},};
+use serde_json::json;
+use anyhow::{anyhow, bail,Result};
+use provider_archive::*;
+use wash_lib::{
+    cli::{cached_oci_file, CommandOutput, OutputKind, claims::render_actor_claims},
+    registry::OciPullOptions,
+};
+use wascap::{
+    jwt::{Actor, Token,}
+};
+use term_table::{row::Row, table_cell::*, Table};
+use crate::util::{self};
+
+const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
+
+#[derive(Debug,Parser, Clone)]
+pub struct InspectCliCommand {
+    /// Path to signed actor module or provider archive or OCI URL of signed actor module or provider archive
+    pub module: String,
+
+    /// Extract the raw JWT from the file and print to stdout
+    #[clap(name = "jwt_only", long = "jwt-only")]
+    jwt_only: bool,
+
+    /// Digest to verify artifact against (if OCI URL is provided for <module> or <archive>)
+    #[clap(short = 'd', long = "digest")]
+    digest: Option<String>,
+
+    /// Allow latest artifact tags (if OCI URL is provided for <module> or <archive>)
+    #[clap(long = "allow-latest")]
+    allow_latest: bool,
+
+    /// OCI username, if omitted anonymous authentication will be used
+    #[clap(
+        short = 'u',
+        long = "user",
+        env = "WASH_REG_USER",
+        hide_env_values = true
+    )]
+    user: Option<String>,
+
+    /// OCI password, if omitted anonymous authentication will be used
+    #[clap(
+        short = 'p',
+        long = "password",
+        env = "WASH_REG_PASSWORD",
+        hide_env_values = true
+    )]
+    password: Option<String>,
+
+    /// Allow insecure (HTTP) registry connections
+    #[clap(long = "insecure")]
+    insecure: bool,
+
+    /// skip the local OCI cache
+    #[clap(long = "no-cache")]
+    no_cache: bool,
+
+}
+
+fn is_wasm(input: &[u8]) -> Result<bool> {
+    if input.len() < 4 {
+        bail!("Not enough bytes to be a valid claim file")
+    }
+    Ok(input[0..4] == WASM_MAGIC)
+}
+
+async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
+    let cache_path = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
+    let artifact_bytes = wash_lib::registry::get_oci_artifact(
+        cmd.module,
+        cache_path,
+        OciPullOptions {
+            digest: cmd.digest,
+            allow_latest: cmd.allow_latest,
+            user: cmd.user,
+            password: cmd.password,
+            insecure: cmd.insecure,
+        },
+    )
+    .await?;
+
+    // Extract will return an error if it encounters an invalid hash in the claims
+    Ok(wascap::wasm::extract_claims(artifact_bytes)?)
+}
+
+async fn handle_actor_module(cmd: InspectCliCommand) -> Result<CommandOutput> {
+    let module_name = cmd.module.clone();
+    let jwt_only = cmd.jwt_only;
+    let caps = get_caps(cmd).await?;
+
+    let out = match caps {
+        Some(token) => {
+            if jwt_only {
+                CommandOutput::from_key_and_text("token", token.jwt)
+            } else {
+                let validation = wascap::jwt::validate_token::<Actor>(&token.jwt)?;
+                render_actor_claims(token.claims, validation)
+            }
+        }
+        None => bail!("No capabilities discovered in : {}", module_name),
+    };
+    Ok(out)
+}
+
+pub(crate) async fn handle_provider_archive(cmd: InspectCliCommand) -> Result<CommandOutput> {
+    let cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
+    let artifact_bytes = wash_lib::registry::get_oci_artifact(
+        cmd.module,
+        cache_file,
+        OciPullOptions {
+            digest: cmd.digest,
+            allow_latest: cmd.allow_latest,
+            user: cmd.user,
+            password: cmd.password,
+            insecure: cmd.insecure,
+        },
+    )
+    .await?;
+    let artifact = ProviderArchive::try_load(&artifact_bytes)
+        .await
+        .map_err(|e| anyhow!("{}", e))?;
+    let claims = artifact
+        .claims()
+        .ok_or_else(|| anyhow!("No claims found in artifact"))?;
+    let metadata = claims
+        .metadata
+        .ok_or_else(|| anyhow!("No metadata found"))?;
+
+    let friendly_rev = match metadata.rev {
+        Some(rev) => format!("{}", rev),
+        None => "None".to_string(),
+    };
+    let friendly_ver = metadata.ver.unwrap_or_else(|| "None".to_string());
+    let name = metadata.name.unwrap_or_else(|| "None".to_string());
+    let mut map = HashMap::new();
+    map.insert("name".to_string(), json!(name));
+    map.insert("issuer".to_string(), json!(claims.issuer));
+    map.insert("service".to_string(), json!(claims.subject));
+    map.insert("capability_contract_id".to_string(), json!(metadata.capid));
+    map.insert("vendor".to_string(), json!(metadata.vendor));
+    map.insert("version".to_string(), json!(friendly_ver));
+    map.insert("revision".to_string(), json!(friendly_rev));
+    map.insert("targets".to_string(), json!(artifact.targets()));
+    let text_table = {
+        let mut table = Table::new();
+        util::configure_table_style(&mut table);
+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            format!("{} - Provider Archive", name),
+            2,
+            Alignment::Center,
+        )]));
+
+        table.add_row(Row::new(vec![
+            TableCell::new("Account"),
+            TableCell::new_with_alignment(claims.issuer, 1, Alignment::Right),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new("Service"),
+            TableCell::new_with_alignment(claims.subject, 1, Alignment::Right),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new("Capability Contract ID"),
+            TableCell::new_with_alignment(metadata.capid, 1, Alignment::Right),
+        ]));
+        table.add_row(Row::new(vec![
+            TableCell::new("Vendor"),
+            TableCell::new_with_alignment(metadata.vendor, 1, Alignment::Right),
+        ]));
+
+        table.add_row(Row::new(vec![
+            TableCell::new("Version"),
+            TableCell::new_with_alignment(friendly_ver, 1, Alignment::Right),
+        ]));
+
+        table.add_row(Row::new(vec![
+            TableCell::new("Revision"),
+            TableCell::new_with_alignment(friendly_rev, 1, Alignment::Right),
+        ]));
+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "Supported Architecture Targets",
+            2,
+            Alignment::Center,
+        )]));
+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            artifact.targets().join("\n"),
+            2,
+            Alignment::Left,
+        )]));
+
+        table.render()
+    };
+
+    Ok(CommandOutput::new(text_table, map))
+}
+
+pub async fn handle_command(
+    command: InspectCliCommand,
+    _output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    let mut buf = Vec::new();
+    let mut f = File::open(command.module.clone())?;
+    f.read_to_end(&mut buf)?;
+
+    let jwt_only = command.jwt_only;
+
+    if is_wasm(&buf).is_ok() || jwt_only {
+        handle_actor_module(command).await
+    }else{
+        handle_provider_archive(command).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    struct Cmd {
+        #[clap(flatten)]
+        command: InspectCliCommand,
+    }
+
+    #[test]
+    /// Check all flags and options of the 'inspect' command
+    /// so that the API does not change in between versions
+    fn test_inspect_comprehensive() {
+        const LOCAL: &str = "./coolthing.par.gz";
+        const REMOTE: &str = "wasmcloud.azurecr.io/coolthing.par.gz";
+        const SUBSCRIBER_OCI: &str = "wasmcloud.azurecr.io/subscriber:0.2.0";
+
+        let inspect_long: Cmd = Parser::try_parse_from([
+            "inspect",
+            LOCAL,
+            "--digest",
+            "sha256:blah",
+            "--password",
+            "secret",
+            "--user",
+            "name",
+            "--jwt-only",
+            "--no-cache",
+        ])
+        .unwrap();
+        match inspect_long.command {
+            InspectCliCommand{
+                module,
+                jwt_only,
+                digest,
+                allow_latest,
+                user,
+                password,
+                insecure,
+                no_cache,
+            } => {
+                assert_eq!(module, LOCAL);
+                assert_eq!(digest.unwrap(), "sha256:blah");
+                assert!(!allow_latest);
+                assert!(!insecure);
+                assert_eq!(user.unwrap(), "name");
+                assert_eq!(password.unwrap(), "secret");
+                assert!(jwt_only);
+                assert!(no_cache);
+            }
+        }
+        let inspect_short: Cmd = Parser::try_parse_from([
+            "inspect",
+            REMOTE,
+            "-d",
+            "sha256:blah",
+            "-p",
+            "secret",
+            "-u",
+            "name",
+            "--allow-latest",
+            "--insecure",
+            "--jwt-only",
+            "--no-cache",
+        ])
+        .unwrap();
+        match inspect_short.command {
+            InspectCliCommand{
+                module,
+                jwt_only,
+                digest,
+                allow_latest,
+                user,
+                password,
+                insecure,
+                no_cache,
+            } => {
+                assert_eq!(module, REMOTE);
+                assert_eq!(digest.unwrap(), "sha256:blah");
+                assert!(allow_latest);
+                assert!(insecure);
+                assert_eq!(user.unwrap(), "name");
+                assert_eq!(password.unwrap(), "secret");
+                assert!(jwt_only);
+                assert!(no_cache);
+            }
+        }
+
+        let cmd: Cmd = Parser::try_parse_from([
+            "inspect",
+            SUBSCRIBER_OCI,
+            "--digest",
+            "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8",
+            "--user",
+            "name",
+            "--password",
+            "opensesame",
+            "--allow-latest",
+            "--insecure",
+            "--jwt-only",
+            "--no-cache",
+        ])
+        .unwrap();
+
+        match cmd.command {
+            InspectCliCommand{
+                module,
+                jwt_only,
+                digest,
+                allow_latest,
+                user,
+                password,
+                insecure,
+                no_cache,
+            }=> {
+                assert_eq!(module, SUBSCRIBER_OCI);
+                assert_eq!(
+                    digest.unwrap(),
+                    "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
+                );
+                assert_eq!(user.unwrap(), "name");
+                assert_eq!(password.unwrap(), "opensesame");
+                assert!(allow_latest);
+                assert!(insecure);
+                assert!(jwt_only);
+                assert!(no_cache);
+            }
+        }
+
+        let short_cmd: Cmd = Parser::try_parse_from([
+            "inspect",
+            SUBSCRIBER_OCI,
+            "-d",
+            "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8",
+            "-u",
+            "name",
+            "-p",
+            "opensesame",
+            "--allow-latest",
+            "--insecure",
+            "--jwt-only",
+            "--no-cache",
+        ])
+        .unwrap();
+
+        match short_cmd.command {
+            InspectCliCommand{
+                module,
+                jwt_only,
+                digest,
+                allow_latest,
+                user,
+                password,
+                insecure,
+                no_cache,
+            } => {
+                assert_eq!(module, SUBSCRIBER_OCI);
+                assert_eq!(
+                    digest.unwrap(),
+                    "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
+                );
+                assert_eq!(user.unwrap(), "name");
+                assert_eq!(password.unwrap(), "opensesame");
+                assert!(allow_latest);
+                assert!(insecure);
+                assert!(jwt_only);
+                assert!(no_cache);
+            }
+        }
+    }
+}

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,5 +1,5 @@
 use crate::util::{self};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use provider_archive::*;
 use serde_json::json;
@@ -11,12 +11,13 @@ use wash_lib::{
     registry::OciPullOptions,
 };
 
+// The magic number 0061 736D is present at the beginning of all wasm files.
 const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
 
 #[derive(Debug, Parser, Clone)]
 pub struct InspectCliCommand {
-    /// Path to signed actor module or provider archive or OCI URL of signed actor module or provider archive
-    pub module: String,
+    /// Path or OCI URL to signed actor module or provider archive
+    pub target: String,
 
     /// Extract the raw JWT from the file and print to stdout
     #[clap(name = "jwt_only", long = "jwt-only")]
@@ -57,36 +58,48 @@ pub struct InspectCliCommand {
     no_cache: bool,
 }
 
-/// Attempts to inspect a provider module or signed actor module
+/// Attempts to inspect a provider archive or signed actor module
 pub async fn handle_command(
     command: InspectCliCommand,
     _output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     let mut buf = Vec::new();
-    if PathBuf::from(command.module.clone()).as_path().is_dir() {
-        let mut f = File::open(command.module.clone())?;
+    if PathBuf::from(command.target.clone()).as_path().is_dir() {
+        let mut f = File::open(command.target.clone())?;
         f.read_to_end(&mut buf)?;
     } else {
-        let cache_file =
-            (!command.no_cache.clone()).then(|| cached_oci_file(&command.module.clone()));
+        let cache_file = (!command.no_cache).then(|| cached_oci_file(&command.target.clone()));
         buf = wash_lib::registry::get_oci_artifact(
-            command.module.clone(),
+            command.target.clone(),
             cache_file,
             OciPullOptions {
                 digest: command.digest.clone(),
-                allow_latest: command.allow_latest.clone(),
+                allow_latest: command.allow_latest,
                 user: command.user.clone(),
                 password: command.password.clone(),
-                insecure: command.insecure.clone(),
+                insecure: command.insecure,
             },
         )
         .await?;
     }
 
     if is_wasm(&buf) {
-        handle_actor_module(command).await
+        // Inspect an actor module
+        let module_name = command.target.clone();
+        let jwt_only = command.jwt_only;
+        let caps = get_caps(command.clone(), &buf).await?;
+        let token =
+            caps.ok_or_else(|| anyhow!("No capabilities discovered in : {}", module_name))?;
+        if jwt_only {
+            let out = CommandOutput::from_key_and_text("token", token.jwt);
+            Ok(out)
+        } else {
+            let validation = wascap::jwt::validate_token::<Actor>(&token.jwt)?;
+            let out = render_actor_claims(token.claims, validation);
+            Ok(out)
+        }
     } else {
-        handle_provider_archive(command).await
+        handle_provider_archive(command.clone(), &buf).await
     }
 }
 
@@ -95,63 +108,23 @@ fn is_wasm(input: &[u8]) -> bool {
     if input.len() < 4 {
         return false;
     }
-    return input[0..4] == WASM_MAGIC;
+    input[0..4] == WASM_MAGIC
 }
 
 /// Extracts claims for a given OCI artifact
-async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
-    let cache_path = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
-    let artifact_bytes = wash_lib::registry::get_oci_artifact(
-        cmd.module,
-        cache_path,
-        OciPullOptions {
-            digest: cmd.digest,
-            allow_latest: cmd.allow_latest,
-            user: cmd.user,
-            password: cmd.password,
-            insecure: cmd.insecure,
-        },
-    )
-    .await?;
+async fn get_caps(cmd: InspectCliCommand, artifact_bytes: &[u8]) -> Result<Option<Token<Actor>>> {
+    let _cache_path = (!cmd.no_cache).then(|| cached_oci_file(&cmd.target));
     // Extract will return an error if it encounters an invalid hash in the claims
     Ok(wascap::wasm::extract_claims(artifact_bytes)?)
 }
 
-/// Inspects an actor module
-async fn handle_actor_module(cmd: InspectCliCommand) -> Result<CommandOutput> {
-    let module_name = cmd.module.clone();
-    let jwt_only = cmd.jwt_only;
-    let caps = get_caps(cmd).await?;
-    let out = match caps {
-        Some(token) => {
-            if jwt_only {
-                CommandOutput::from_key_and_text("token", token.jwt)
-            } else {
-                let validation = wascap::jwt::validate_token::<Actor>(&token.jwt)?;
-                render_actor_claims(token.claims, validation)
-            }
-        }
-        None => bail!("No capabilities discovered in : {}", module_name),
-    };
-    Ok(out)
-}
-
 /// Inspects a provider archive
-pub(crate) async fn handle_provider_archive(cmd: InspectCliCommand) -> Result<CommandOutput> {
-    let cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
-    let artifact_bytes = wash_lib::registry::get_oci_artifact(
-        cmd.module,
-        cache_file,
-        OciPullOptions {
-            digest: cmd.digest,
-            allow_latest: cmd.allow_latest,
-            user: cmd.user,
-            password: cmd.password,
-            insecure: cmd.insecure,
-        },
-    )
-    .await?;
-    let artifact = ProviderArchive::try_load(&artifact_bytes)
+pub(crate) async fn handle_provider_archive(
+    cmd: InspectCliCommand,
+    artifact_bytes: &[u8],
+) -> Result<CommandOutput> {
+    let _cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.target));
+    let artifact = ProviderArchive::try_load(artifact_bytes)
         .await
         .map_err(|e| anyhow!("{}", e))?;
     let claims = artifact
@@ -264,7 +237,7 @@ mod test {
         .unwrap();
         match inspect_long.command {
             InspectCliCommand {
-                module,
+                target,
                 jwt_only,
                 digest,
                 allow_latest,
@@ -273,7 +246,7 @@ mod test {
                 insecure,
                 no_cache,
             } => {
-                assert_eq!(module, LOCAL);
+                assert_eq!(target, LOCAL);
                 assert_eq!(digest.unwrap(), "sha256:blah");
                 assert!(!allow_latest);
                 assert!(!insecure);
@@ -300,7 +273,7 @@ mod test {
         .unwrap();
         match inspect_short.command {
             InspectCliCommand {
-                module,
+                target,
                 jwt_only,
                 digest,
                 allow_latest,
@@ -309,7 +282,7 @@ mod test {
                 insecure,
                 no_cache,
             } => {
-                assert_eq!(module, REMOTE);
+                assert_eq!(target, REMOTE);
                 assert_eq!(digest.unwrap(), "sha256:blah");
                 assert!(allow_latest);
                 assert!(insecure);
@@ -338,7 +311,7 @@ mod test {
 
         match cmd.command {
             InspectCliCommand {
-                module,
+                target,
                 jwt_only,
                 digest,
                 allow_latest,
@@ -347,7 +320,7 @@ mod test {
                 insecure,
                 no_cache,
             } => {
-                assert_eq!(module, SUBSCRIBER_OCI);
+                assert_eq!(target, SUBSCRIBER_OCI);
                 assert_eq!(
                     digest.unwrap(),
                     "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
@@ -379,7 +352,7 @@ mod test {
 
         match short_cmd.command {
             InspectCliCommand {
-                module,
+                target,
                 jwt_only,
                 digest,
                 allow_latest,
@@ -388,7 +361,7 @@ mod test {
                 insecure,
                 no_cache,
             } => {
-                assert_eq!(module, SUBSCRIBER_OCI);
+                assert_eq!(target, SUBSCRIBER_OCI);
                 assert_eq!(
                     digest.unwrap(),
                     "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,5 +1,5 @@
 use clap::{Parser};
-use std::{collections::HashMap, fs::{File}, io::{Read},};
+use std::{collections::HashMap, fs::{File}, io::{Read},path::{PathBuf}};
 use serde_json::json;
 use anyhow::{anyhow, bail,Result};
 use provider_archive::*;
@@ -8,7 +8,7 @@ use wash_lib::{
     registry::OciPullOptions,
 };
 use wascap::{
-    jwt::{Actor, Token,}
+    jwt::{Actor, Token}
 };
 use term_table::{row::Row, table_cell::*, Table};
 use crate::util::{self};
@@ -60,11 +60,11 @@ pub struct InspectCliCommand {
 
 }
 
-fn is_wasm(input: &[u8]) -> Result<bool> {
+fn is_wasm(input: &[u8]) -> bool {
     if input.len() < 4 {
-        bail!("Not enough bytes to be a valid claim file")
+        return false
     }
-    Ok(input[0..4] == WASM_MAGIC)
+    return input[0..4] == WASM_MAGIC
 }
 
 async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
@@ -81,7 +81,6 @@ async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
         },
     )
     .await?;
-
     // Extract will return an error if it encounters an invalid hash in the claims
     Ok(wascap::wasm::extract_claims(artifact_bytes)?)
 }
@@ -90,7 +89,6 @@ async fn handle_actor_module(cmd: InspectCliCommand) -> Result<CommandOutput> {
     let module_name = cmd.module.clone();
     let jwt_only = cmd.jwt_only;
     let caps = get_caps(cmd).await?;
-
     let out = match caps {
         Some(token) => {
             if jwt_only {
@@ -204,12 +202,27 @@ pub async fn handle_command(
     _output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     let mut buf = Vec::new();
-    let mut f = File::open(command.module.clone())?;
-    f.read_to_end(&mut buf)?;
+    if PathBuf::from(command.module.clone()).as_path().is_dir() {
+        let mut f = File::open(command.module.clone())?;
+        f.read_to_end(&mut buf)?;     
+    }else{
+        let cache_file = (!command.no_cache.clone()).then(|| cached_oci_file(&command.module.clone()));
+        buf = wash_lib::registry::get_oci_artifact(
+            command.module.clone(),
+            cache_file,
+            OciPullOptions {
+                digest: command.digest.clone(),
+                allow_latest: command.allow_latest.clone(),
+                user: command.user.clone(),
+                password: command.password.clone(),
+                insecure: command.insecure.clone(),
+            },
+        ).await?;
+    }
 
-    let jwt_only = command.jwt_only;
+    let jwt_only = command.jwt_only.clone();
 
-    if is_wasm(&buf).is_ok() || jwt_only {
+    if is_wasm(&buf) || jwt_only{
         handle_actor_module(command).await
     }else{
         handle_provider_archive(command).await

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,21 +1,19 @@
-use clap::{Parser};
-use std::{collections::HashMap, fs::{File}, io::{Read},path::{PathBuf}};
-use serde_json::json;
-use anyhow::{anyhow, bail,Result};
+use crate::util::{self};
+use anyhow::{anyhow, bail, Result};
+use clap::Parser;
 use provider_archive::*;
+use serde_json::json;
+use std::{collections::HashMap, fs::File, io::Read, path::PathBuf};
+use term_table::{row::Row, table_cell::*, Table};
+use wascap::jwt::{Actor, Token};
 use wash_lib::{
-    cli::{cached_oci_file, CommandOutput, OutputKind, claims::render_actor_claims},
+    cli::{cached_oci_file, claims::render_actor_claims, CommandOutput, OutputKind},
     registry::OciPullOptions,
 };
-use wascap::{
-    jwt::{Actor, Token}
-};
-use term_table::{row::Row, table_cell::*, Table};
-use crate::util::{self};
 
 const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
 
-#[derive(Debug,Parser, Clone)]
+#[derive(Debug, Parser, Clone)]
 pub struct InspectCliCommand {
     /// Path to signed actor module or provider archive or OCI URL of signed actor module or provider archive
     pub module: String,
@@ -57,16 +55,50 @@ pub struct InspectCliCommand {
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
     no_cache: bool,
-
 }
 
+/// Attempts to inspect a provider module or signed actor module
+pub async fn handle_command(
+    command: InspectCliCommand,
+    _output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    let mut buf = Vec::new();
+    if PathBuf::from(command.module.clone()).as_path().is_dir() {
+        let mut f = File::open(command.module.clone())?;
+        f.read_to_end(&mut buf)?;
+    } else {
+        let cache_file =
+            (!command.no_cache.clone()).then(|| cached_oci_file(&command.module.clone()));
+        buf = wash_lib::registry::get_oci_artifact(
+            command.module.clone(),
+            cache_file,
+            OciPullOptions {
+                digest: command.digest.clone(),
+                allow_latest: command.allow_latest.clone(),
+                user: command.user.clone(),
+                password: command.password.clone(),
+                insecure: command.insecure.clone(),
+            },
+        )
+        .await?;
+    }
+
+    if is_wasm(&buf) {
+        handle_actor_module(command).await
+    } else {
+        handle_provider_archive(command).await
+    }
+}
+
+/// Checks if the given file is a wasm file by searching a WASM magic number at the start of a binary
 fn is_wasm(input: &[u8]) -> bool {
     if input.len() < 4 {
-        return false
+        return false;
     }
-    return input[0..4] == WASM_MAGIC
+    return input[0..4] == WASM_MAGIC;
 }
 
+/// Extracts claims for a given OCI artifact
 async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
     let cache_path = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
     let artifact_bytes = wash_lib::registry::get_oci_artifact(
@@ -85,6 +117,7 @@ async fn get_caps(cmd: InspectCliCommand) -> Result<Option<Token<Actor>>> {
     Ok(wascap::wasm::extract_claims(artifact_bytes)?)
 }
 
+/// Inspects an actor module
 async fn handle_actor_module(cmd: InspectCliCommand) -> Result<CommandOutput> {
     let module_name = cmd.module.clone();
     let jwt_only = cmd.jwt_only;
@@ -103,6 +136,7 @@ async fn handle_actor_module(cmd: InspectCliCommand) -> Result<CommandOutput> {
     Ok(out)
 }
 
+/// Inspects a provider archive
 pub(crate) async fn handle_provider_archive(cmd: InspectCliCommand) -> Result<CommandOutput> {
     let cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.module));
     let artifact_bytes = wash_lib::registry::get_oci_artifact(
@@ -127,10 +161,9 @@ pub(crate) async fn handle_provider_archive(cmd: InspectCliCommand) -> Result<Co
         .metadata
         .ok_or_else(|| anyhow!("No metadata found"))?;
 
-    let friendly_rev = match metadata.rev {
-        Some(rev) => format!("{}", rev),
-        None => "None".to_string(),
-    };
+    let friendly_rev = metadata
+        .rev
+        .map_or("None".to_string(), |rev| rev.to_string());
     let friendly_ver = metadata.ver.unwrap_or_else(|| "None".to_string());
     let name = metadata.name.unwrap_or_else(|| "None".to_string());
     let mut map = HashMap::new();
@@ -197,38 +230,6 @@ pub(crate) async fn handle_provider_archive(cmd: InspectCliCommand) -> Result<Co
     Ok(CommandOutput::new(text_table, map))
 }
 
-pub async fn handle_command(
-    command: InspectCliCommand,
-    _output_kind: OutputKind,
-) -> Result<CommandOutput> {
-    let mut buf = Vec::new();
-    if PathBuf::from(command.module.clone()).as_path().is_dir() {
-        let mut f = File::open(command.module.clone())?;
-        f.read_to_end(&mut buf)?;     
-    }else{
-        let cache_file = (!command.no_cache.clone()).then(|| cached_oci_file(&command.module.clone()));
-        buf = wash_lib::registry::get_oci_artifact(
-            command.module.clone(),
-            cache_file,
-            OciPullOptions {
-                digest: command.digest.clone(),
-                allow_latest: command.allow_latest.clone(),
-                user: command.user.clone(),
-                password: command.password.clone(),
-                insecure: command.insecure.clone(),
-            },
-        ).await?;
-    }
-
-    let jwt_only = command.jwt_only.clone();
-
-    if is_wasm(&buf) || jwt_only{
-        handle_actor_module(command).await
-    }else{
-        handle_provider_archive(command).await
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -262,7 +263,7 @@ mod test {
         ])
         .unwrap();
         match inspect_long.command {
-            InspectCliCommand{
+            InspectCliCommand {
                 module,
                 jwt_only,
                 digest,
@@ -298,7 +299,7 @@ mod test {
         ])
         .unwrap();
         match inspect_short.command {
-            InspectCliCommand{
+            InspectCliCommand {
                 module,
                 jwt_only,
                 digest,
@@ -336,7 +337,7 @@ mod test {
         .unwrap();
 
         match cmd.command {
-            InspectCliCommand{
+            InspectCliCommand {
                 module,
                 jwt_only,
                 digest,
@@ -345,7 +346,7 @@ mod test {
                 password,
                 insecure,
                 no_cache,
-            }=> {
+            } => {
                 assert_eq!(module, SUBSCRIBER_OCI);
                 assert_eq!(
                     digest.unwrap(),
@@ -377,7 +378,7 @@ mod test {
         .unwrap();
 
         match short_cmd.command {
-            InspectCliCommand{
+            InspectCliCommand {
                 module,
                 jwt_only,
                 digest,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use ctl::CtlCliCommand;
 use ctx::CtxCommand;
 use down::DownCommand;
 use generate::NewCliCommand;
+use inspect::InspectCliCommand;
 use keys::KeysCliCommand;
 use par::ParCliCommand;
 use reg::RegCliCommand;
@@ -31,6 +32,7 @@ mod ctx;
 mod down;
 mod drain;
 mod generate;
+mod inspect;
 mod keys;
 mod par;
 mod reg;
@@ -100,6 +102,9 @@ enum CliCommand {
     /// Generate code from smithy IDL files
     #[clap(name = "gen")]
     Gen(GenerateCli),
+    /// Inspect capability provider or actor module
+    #[clap(name = "inspect")]
+    Inspect(InspectCliCommand),
     /// Utilities for generating and managing keys
     #[clap(name = "keys", subcommand)]
     Keys(KeysCliCommand),
@@ -146,6 +151,7 @@ async fn main() {
         CliCommand::Down(down_cli) => down::handle_command(down_cli, output_kind).await,
         CliCommand::Drain(drain_cli) => drain::handle_command(drain_cli),
         CliCommand::Gen(generate_cli) => smithy::handle_gen_command(generate_cli),
+        CliCommand::Inspect(inspect_cli) => inspect::handle_command(inspect_cli, output_kind).await,
         CliCommand::Keys(keys_cli) => keys::handle_command(keys_cli),
         CliCommand::Lint(lint_cli) => smithy::handle_lint_command(lint_cli).await,
         CliCommand::New(new_cli) => generate::handle_command(new_cli).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use ctl::CtlCliCommand;
 use ctx::CtxCommand;
 use down::DownCommand;
 use generate::NewCliCommand;
-use inspect::InspectCliCommand;
 use keys::KeysCliCommand;
 use par::ParCliCommand;
 use reg::RegCliCommand;
@@ -18,6 +17,7 @@ use serde_json::json;
 use smithy::{GenerateCli, LintCli, ValidateCli};
 use up::UpCommand;
 use wash_lib::cli::claims::ClaimsCliCommand;
+use wash_lib::cli::inspect::InspectCliCommand;
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::drain::Drain as DrainSelection;
 
@@ -32,7 +32,6 @@ mod ctx;
 mod down;
 mod drain;
 mod generate;
-mod inspect;
 mod keys;
 mod par;
 mod reg;
@@ -151,7 +150,9 @@ async fn main() {
         CliCommand::Down(down_cli) => down::handle_command(down_cli, output_kind).await,
         CliCommand::Drain(drain_cli) => drain::handle_command(drain_cli),
         CliCommand::Gen(generate_cli) => smithy::handle_gen_command(generate_cli),
-        CliCommand::Inspect(inspect_cli) => inspect::handle_command(inspect_cli, output_kind).await,
+        CliCommand::Inspect(inspect_cli) => {
+            wash_lib::cli::inspect::handle_command(inspect_cli, output_kind).await
+        }
         CliCommand::Keys(keys_cli) => keys::handle_command(keys_cli),
         CliCommand::Lint(lint_cli) => smithy::handle_lint_command(lint_cli).await,
         CliCommand::New(new_cli) => generate::handle_command(new_cli).await,

--- a/src/par.rs
+++ b/src/par.rs
@@ -2,21 +2,14 @@ use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
-use log::warn;
 use nkeys::KeyPairType;
 use provider_archive::ProviderArchive;
 use serde_json::json;
-use term_table::{
-    row::Row,
-    table_cell::{Alignment, TableCell},
-    Table,
-};
-use wash_lib::{
-    cli::{cached_oci_file, extract_keypair, CommandOutput, OutputKind},
-    registry::OciPullOptions,
-};
+use term_table::{row::Row, table_cell::*, Table};
+use wash_lib::cli::{extract_keypair, inspect, CommandOutput, OutputKind};
+use wash_lib::registry::OciPullOptions;
 
-use crate::util::{self, convert_error};
+use crate::util::convert_error;
 
 const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
 
@@ -190,13 +183,27 @@ pub(crate) struct InsertCommand {
     disable_keygen: bool,
 }
 
+impl From<InspectCommand> for inspect::InspectCliCommand {
+    fn from(cmd: InspectCommand) -> Self {
+        inspect::InspectCliCommand {
+            target: cmd.archive,
+            jwt_only: false,
+            digest: cmd.digest,
+            allow_latest: cmd.allow_latest,
+            user: cmd.user,
+            password: cmd.password,
+            insecure: cmd.insecure,
+            no_cache: cmd.no_cache,
+        }
+    }
+}
 pub(crate) async fn handle_command(
     command: ParCliCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     match command {
         ParCliCommand::Create(cmd) => handle_create(cmd, output_kind).await,
-        ParCliCommand::Inspect(cmd) => handle_par_inspect(cmd).await,
+        ParCliCommand::Inspect(cmd) => inspect::handle_command(cmd, output_kind).await,
         ParCliCommand::Insert(cmd) => handle_insert(cmd, output_kind).await,
     }
 }
@@ -267,102 +274,6 @@ pub(crate) async fn handle_create(
         format!("Successfully created archive {outfile}"),
         map,
     ))
-}
-
-/// Loads a provider archive and outputs the contents of the claims
-pub(crate) async fn handle_par_inspect(cmd: InspectCommand) -> Result<CommandOutput> {
-    let cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.archive));
-    let artifact_bytes = wash_lib::registry::get_oci_artifact(
-        cmd.archive,
-        cache_file,
-        OciPullOptions {
-            digest: cmd.digest,
-            allow_latest: cmd.allow_latest,
-            user: cmd.user,
-            password: cmd.password,
-            insecure: cmd.insecure,
-        },
-    )
-    .await?;
-    let artifact = ProviderArchive::try_load(&artifact_bytes)
-        .await
-        .map_err(|e| anyhow!("{}", e))?;
-    let claims = artifact
-        .claims()
-        .ok_or_else(|| anyhow!("No claims found in artifact"))?;
-    let metadata = claims
-        .metadata
-        .ok_or_else(|| anyhow!("No metadata found"))?;
-
-    let friendly_rev = match metadata.rev {
-        Some(rev) => format!("{rev}"),
-        None => "None".to_string(),
-    };
-    let friendly_ver = metadata.ver.unwrap_or_else(|| "None".to_string());
-    let name = metadata.name.unwrap_or_else(|| "None".to_string());
-    let mut map = HashMap::new();
-    map.insert("name".to_string(), json!(name));
-    map.insert("issuer".to_string(), json!(claims.issuer));
-    map.insert("service".to_string(), json!(claims.subject));
-    map.insert("capability_contract_id".to_string(), json!(metadata.capid));
-    map.insert("vendor".to_string(), json!(metadata.vendor));
-    map.insert("version".to_string(), json!(friendly_ver));
-    map.insert("revision".to_string(), json!(friendly_rev));
-    map.insert("targets".to_string(), json!(artifact.targets()));
-    let text_table = {
-        let mut table = Table::new();
-        util::configure_table_style(&mut table);
-
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            format!("{name} - Provider Archive"),
-            2,
-            Alignment::Center,
-        )]));
-
-        table.add_row(Row::new(vec![
-            TableCell::new("Account"),
-            TableCell::new_with_alignment(claims.issuer, 1, Alignment::Right),
-        ]));
-        table.add_row(Row::new(vec![
-            TableCell::new("Service"),
-            TableCell::new_with_alignment(claims.subject, 1, Alignment::Right),
-        ]));
-        table.add_row(Row::new(vec![
-            TableCell::new("Capability Contract ID"),
-            TableCell::new_with_alignment(metadata.capid, 1, Alignment::Right),
-        ]));
-        table.add_row(Row::new(vec![
-            TableCell::new("Vendor"),
-            TableCell::new_with_alignment(metadata.vendor, 1, Alignment::Right),
-        ]));
-
-        table.add_row(Row::new(vec![
-            TableCell::new("Version"),
-            TableCell::new_with_alignment(friendly_ver, 1, Alignment::Right),
-        ]));
-
-        table.add_row(Row::new(vec![
-            TableCell::new("Revision"),
-            TableCell::new_with_alignment(friendly_rev, 1, Alignment::Right),
-        ]));
-
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "Supported Architecture Targets",
-            2,
-            Alignment::Center,
-        )]));
-
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            artifact.targets().join("\n"),
-            2,
-            Alignment::Left,
-        )]));
-
-        table.render()
-    };
-    warn!("par inspect will be deprecated in future versions. Use inspect instead.");
-
-    Ok(CommandOutput::new(text_table, map))
 }
 
 /// Loads a provider archive and attempts to insert an additional provider into it

--- a/src/par.rs
+++ b/src/par.rs
@@ -1,15 +1,12 @@
 use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 
+use crate::util::convert_error;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
 use nkeys::KeyPairType;
 use provider_archive::ProviderArchive;
 use serde_json::json;
-use term_table::{row::Row, table_cell::*, Table};
 use wash_lib::cli::{extract_keypair, inspect, CommandOutput, OutputKind};
-use wash_lib::registry::OciPullOptions;
-
-use crate::util::convert_error;
 
 const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
 

--- a/src/par.rs
+++ b/src/par.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 use crate::util::convert_error;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
+use log::warn;
 use nkeys::KeyPairType;
 use provider_archive::ProviderArchive;
 use serde_json::json;
@@ -200,7 +201,10 @@ pub(crate) async fn handle_command(
 ) -> Result<CommandOutput> {
     match command {
         ParCliCommand::Create(cmd) => handle_create(cmd, output_kind).await,
-        ParCliCommand::Inspect(cmd) => inspect::handle_command(cmd, output_kind).await,
+        ParCliCommand::Inspect(cmd) => {
+            warn!("par inspect will be deprecated in future versions. Use inspect instead.");
+            inspect::handle_command(cmd, output_kind).await
+        }
         ParCliCommand::Insert(cmd) => handle_insert(cmd, output_kind).await,
     }
 }

--- a/src/par.rs
+++ b/src/par.rs
@@ -14,6 +14,7 @@ use wash_lib::{
     cli::{cached_oci_file, extract_keypair, CommandOutput, OutputKind},
     registry::OciPullOptions,
 };
+use log::warn;
 
 use crate::util::{self, convert_error};
 
@@ -195,7 +196,7 @@ pub(crate) async fn handle_command(
 ) -> Result<CommandOutput> {
     match command {
         ParCliCommand::Create(cmd) => handle_create(cmd, output_kind).await,
-        ParCliCommand::Inspect(cmd) => handle_inspect(cmd).await,
+        ParCliCommand::Inspect(cmd) => handle_par_inspect(cmd).await,
         ParCliCommand::Insert(cmd) => handle_insert(cmd, output_kind).await,
     }
 }
@@ -269,7 +270,7 @@ pub(crate) async fn handle_create(
 }
 
 /// Loads a provider archive and outputs the contents of the claims
-pub(crate) async fn handle_inspect(cmd: InspectCommand) -> Result<CommandOutput> {
+pub(crate) async fn handle_par_inspect(cmd: InspectCommand) -> Result<CommandOutput> {
     let cache_file = (!cmd.no_cache).then(|| cached_oci_file(&cmd.archive));
     let artifact_bytes = wash_lib::registry::get_oci_artifact(
         cmd.archive,
@@ -359,6 +360,7 @@ pub(crate) async fn handle_inspect(cmd: InspectCommand) -> Result<CommandOutput>
 
         table.render()
     };
+    warn!("par inspect will be deprecated in future versions. Use inspect instead.");
 
     Ok(CommandOutput::new(text_table, map))
 }

--- a/src/par.rs
+++ b/src/par.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
+use log::warn;
 use nkeys::KeyPairType;
 use provider_archive::ProviderArchive;
 use serde_json::json;
@@ -14,7 +15,6 @@ use wash_lib::{
     cli::{cached_oci_file, extract_keypair, CommandOutput, OutputKind},
     registry::OciPullOptions,
 };
-use log::warn;
 
 use crate::util::{self, convert_error};
 

--- a/tests/integration_inspect.rs
+++ b/tests/integration_inspect.rs
@@ -109,7 +109,7 @@ fn integration_inspect_provider() {
     let inspect_dir = test_dir_with_subfolder(SUBFOLDER);
     let httpclient_inspect = &format!("{}/httpclient:inspect", LOCAL_REGISTRY);
 
-    // Pull the echo module and push to local registry to test local inspect
+    // Pull the httpclient provider and push to local registry to test local inspect
     let local_http_client_path = test_dir_file(SUBFOLDER, "httpclient.wasm");
     let get_http_client = wash()
         .args([
@@ -122,7 +122,7 @@ fn integration_inspect_provider() {
         .output()
         .expect("failed to pull https server for inspect test");
     assert!(get_http_client.status.success());
-    let push_echo = wash()
+    let push_http_client = wash()
         .args([
             "reg",
             "push",
@@ -132,7 +132,7 @@ fn integration_inspect_provider() {
         ])
         .output()
         .expect("failed to push echo.wasm to local registry");
-    assert!(push_echo.status.success());
+    assert!(push_http_client.status.success());
 
     // Inspect local, local registry, and remote registry actor wasm
     // `String.contains` is used here to ensure we aren't relying on relative json field position.

--- a/tests/integration_inspect.rs
+++ b/tests/integration_inspect.rs
@@ -43,12 +43,7 @@ fn integration_inspect_actor() {
 
     // Inspect local, local registry, and remote registry actor wasm
     let local_inspect = wash()
-        .args([
-            "inspect",
-            echo.to_str().unwrap(),
-            "--output",
-            "json",
-        ])
+        .args(["inspect", echo.to_str().unwrap(), "--output", "json"])
         .output()
         .expect("failed to inspect local wasm");
     assert!(local_inspect.status.success());
@@ -162,13 +157,7 @@ fn integration_inspect_provider() {
     assert_json_include!(actual: local_inspect_output, expected: inspect_expected);
 
     let local_reg_inspect = wash()
-        .args([
-            "inspect",
-            httpclient_inspect,
-            "--insecure",
-            "-o",
-            "json",
-        ])
+        .args(["inspect", httpclient_inspect, "--insecure", "-o", "json"])
         .output()
         .expect("failed to inspect local registry wasm");
     assert!(local_reg_inspect.status.success());

--- a/tests/integration_inspect.rs
+++ b/tests/integration_inspect.rs
@@ -7,7 +7,6 @@ use std::{
     env::temp_dir,
     fs::{remove_dir_all, remove_file},
 };
-
 #[test]
 fn integration_inspect_actor() {
     const SUBFOLDER: &str = "inspect";
@@ -108,7 +107,7 @@ fn integration_inspect_actor() {
 
 #[test]
 fn integration_inspect_provider() {
-    const SUBFOLDER: &str = "inspect";
+    const SUBFOLDER: &str = "inspect_test";
     const HTTP_OCI: &str = "wasmcloud.azurecr.io/httpclient:0.3.5";
     const HTTP_ISSUER: &str = "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW";
     const HTTP_SERVICE: &str = "VCCVLH4XWGI3SGARFNYKYT2A32SUYA2KVAIV2U2Q34DQA7WWJPFRKIKM";

--- a/tests/integration_inspect.rs
+++ b/tests/integration_inspect.rs
@@ -1,0 +1,235 @@
+mod common;
+use crate::common::LOCAL_REGISTRY;
+use assert_json_diff::assert_json_include;
+use common::{get_json_output, test_dir_file, test_dir_with_subfolder, wash};
+use serde_json::json;
+use std::{
+    env::temp_dir,
+    fs::{remove_dir_all, remove_file},
+};
+
+#[test]
+fn integration_inspect_actor() {
+    const SUBFOLDER: &str = "inspect";
+    const ECHO_OCI: &str = "wasmcloud.azurecr.io/echo:0.2.1";
+    const ECHO_ACC: &str = "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW";
+    const ECHO_MOD: &str = "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5";
+    let inspect_dir = test_dir_with_subfolder(SUBFOLDER);
+    let echo_inspect = &format!("{}/echo:inspect", LOCAL_REGISTRY);
+
+    // Pull the echo module and push to local registry to test local inspect
+    let echo = test_dir_file(SUBFOLDER, "echo.wasm");
+    let get_hello_wasm = wash()
+        .args([
+            "reg",
+            "pull",
+            ECHO_OCI,
+            "--destination",
+            echo.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pull echo for claims sign test");
+    assert!(get_hello_wasm.status.success());
+    let push_echo = wash()
+        .args([
+            "reg",
+            "push",
+            echo_inspect,
+            echo.to_str().unwrap(),
+            "--insecure",
+        ])
+        .output()
+        .expect("failed to push echo.wasm to local registry");
+    assert!(push_echo.status.success());
+
+    // Inspect local, local registry, and remote registry actor wasm
+    let local_inspect = wash()
+        .args([
+            "inspect",
+            echo.to_str().unwrap(),
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("failed to inspect local wasm");
+    assert!(local_inspect.status.success());
+
+    let local_inspect_output = get_json_output(local_inspect).unwrap();
+
+    let expected_inspect_output = json!({
+            "account": ECHO_ACC,
+            "module": ECHO_MOD,
+            "can_be_used": "immediately",
+            "capabilities": ["HTTP Server"],
+            "expires": "never",
+            "tags": "None",
+            "version": "0.2.1"
+
+    });
+
+    assert_json_include!(
+        actual: local_inspect_output,
+        expected: expected_inspect_output
+    );
+
+    let local_reg_inspect = wash()
+        .args(["inspect", echo_inspect, "--insecure", "-o", "json"])
+        .output()
+        .expect("failed to inspect local registry wasm");
+    assert!(local_reg_inspect.status.success());
+    let local_reg_inspect_output = get_json_output(local_reg_inspect).unwrap();
+
+    assert_json_include!(
+        actual: local_reg_inspect_output,
+        expected: expected_inspect_output
+    );
+
+    let remote_inspect = wash()
+        .args([
+            "inspect",
+            ECHO_OCI,
+            "--digest",
+            "sha256:55689502d1bc9c48f22b278c54efeee206a839b8e8eedd4ea6b19e6861f66b3c",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("failed to inspect local registry wasm");
+    assert!(remote_inspect.status.success());
+    let remote_inspect_output = get_json_output(remote_inspect).unwrap();
+
+    assert_json_include!(
+        actual: remote_inspect_output,
+        expected: expected_inspect_output
+    );
+
+    remove_dir_all(inspect_dir).unwrap();
+}
+
+#[test]
+fn integration_inspect_provider() {
+    const SUBFOLDER: &str = "inspect";
+    const HTTP_OCI: &str = "wasmcloud.azurecr.io/httpclient:0.3.5";
+    const HTTP_ISSUER: &str = "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW";
+    const HTTP_SERVICE: &str = "VCCVLH4XWGI3SGARFNYKYT2A32SUYA2KVAIV2U2Q34DQA7WWJPFRKIKM";
+    let inspect_dir = test_dir_with_subfolder(SUBFOLDER);
+    let httpclient_inspect = &format!("{}/httpclient:inspect", LOCAL_REGISTRY);
+
+    // Pull the echo module and push to local registry to test local inspect
+    let local_http_client_path = test_dir_file(SUBFOLDER, "httpclient.wasm");
+    let get_http_client = wash()
+        .args([
+            "reg",
+            "pull",
+            HTTP_OCI,
+            "--destination",
+            local_http_client_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pull https server for inspect test");
+    assert!(get_http_client.status.success());
+    let push_echo = wash()
+        .args([
+            "reg",
+            "push",
+            httpclient_inspect,
+            local_http_client_path.to_str().unwrap(),
+            "--insecure",
+        ])
+        .output()
+        .expect("failed to push echo.wasm to local registry");
+    assert!(push_echo.status.success());
+
+    // Inspect local, local registry, and remote registry actor wasm
+    // `String.contains` is used here to ensure we aren't relying on relative json field position.
+    // This also allows tests to pass if information is _added_ but not if information is _omitted_
+    // from the command output
+    let local_inspect = wash()
+        .args([
+            "inspect",
+            local_http_client_path.to_str().unwrap(),
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("failed to inspect local http server");
+    assert!(local_inspect.status.success());
+    let local_inspect_output = get_json_output(local_inspect).unwrap();
+    let inspect_expected = json!({
+        "issuer": HTTP_ISSUER,
+        "service": HTTP_SERVICE,
+        "capability_contract_id": "wasmcloud:httpclient",
+    });
+    assert_json_include!(actual: local_inspect_output, expected: inspect_expected);
+
+    let local_reg_inspect = wash()
+        .args([
+            "inspect",
+            httpclient_inspect,
+            "--insecure",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("failed to inspect local registry wasm");
+    assert!(local_reg_inspect.status.success());
+    let local_reg_inspect_output = get_json_output(local_reg_inspect).unwrap();
+    assert_json_include!(actual: local_reg_inspect_output, expected: inspect_expected);
+
+    let remote_inspect = wash()
+        .args(["inspect", HTTP_OCI, "-o", "json"])
+        .output()
+        .expect("failed to inspect local registry wasm");
+    assert!(remote_inspect.status.success());
+    let remote_inspect_output = get_json_output(remote_inspect).unwrap();
+    assert_json_include!(actual: remote_inspect_output, expected: inspect_expected);
+
+    remove_dir_all(inspect_dir).unwrap();
+}
+
+#[test]
+fn integration_inspect_cached() {
+    const HTTP_OCI: &str = "wasmcloud.azurecr.io/httpclient:0.3.5";
+    const HTTP_FAKE_OCI: &str = "foo.bar.io/httpclient:0.3.5";
+    const HTTP_FAKE_CACHED: &str = "foo_bar_io_httpclient_0_3_5";
+    const HTTP_ISSUER: &str = "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW";
+    const HTTP_SERVICE: &str = "VCCVLH4XWGI3SGARFNYKYT2A32SUYA2KVAIV2U2Q34DQA7WWJPFRKIKM";
+
+    let mut http_client_cache_path = temp_dir().join("wasmcloud_ocicache").join(HTTP_FAKE_CACHED);
+    let _ = ::std::fs::create_dir_all(&http_client_cache_path);
+    http_client_cache_path.set_extension("bin");
+
+    let get_http_client = wash()
+        .args([
+            "reg",
+            "pull",
+            HTTP_OCI,
+            "--destination",
+            http_client_cache_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pull echo for claims sign test");
+    assert!(get_http_client.status.success());
+
+    let remote_inspect = wash()
+        .args(["inspect", HTTP_FAKE_OCI, "-o", "json"])
+        .output()
+        .expect("failed to inspect remote cached registry");
+    assert!(remote_inspect.status.success());
+    let remote_inspect_output = get_json_output(remote_inspect).unwrap();
+    let expected_output = json!({
+        "issuer": HTTP_ISSUER,
+        "service": HTTP_SERVICE,
+        "capability_contract_id": "wasmcloud:httpclient",
+    });
+    assert_json_include!(actual: remote_inspect_output, expected: expected_output);
+
+    let remote_inspect_no_cache = wash()
+        .args(["inspect", HTTP_FAKE_OCI, "-o", "json", "--no-cache"])
+        .output()
+        .expect("failed to inspect remote cached registry");
+
+    assert!(!remote_inspect_no_cache.status.success());
+
+    remove_file(http_client_cache_path).unwrap();
+}


### PR DESCRIPTION
## Feature or Problem
Created a new command named inspect that will perform the functionalities of par inspect and claims inspect.
Added deprecation warnings for par inspect and claims inspect.
Added unit and integration tests.

## Related Issues
Fixes https://github.com/wasmCloud/wash/issues/369

## Release Information
Next

## Consumer Impact
par inspect and claims inspect work for now but they will be deprecated in future releases

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [x] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [x] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Unit Test name : test_inspect_comprehensive
To test the inspect cli command

### Acceptance or Integration
Integration tests for inspect cli

### Manual Verification
Unit and integration tests
