### PR TITLE
test: allow targeting one test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ build-watch: ## Continuously build the project
 CARGO_TEST_TARGET ?= ""
 
 test: ## Run unit test suite
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
 
 test-watch: ## Run unit tests continously, can optionally specify a target test filter.
 	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
@@ -47,7 +47,7 @@ test-integration-watch: ## Run integration test suite continuously
 	@$(CARGO) watch -- $(MAKE) test-integration
 
 test-unit: ## Run one or more unit tests
-	@$(CARGO) nextest $(CARGO_TEST_TARGET)
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET)
 
 test-unit-watch: ## Run tests continuously
 	@$(CARGO) watch -- $(MAKE) test-unit


### PR DESCRIPTION
## Feature or Problem

I forgot to add `run` when changing a `nextest` command

## Related Issues


## Release Information

`next`

## Consumer Impact

`make test` will work properly

## Testing

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

`make test`

### Acceptance or Integration

N/A

### Manual Verification

Tested locally