### PR TITLE
refactor: use make from ci

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Rust check + clippy
         run: make rust-check
+
   unit_tests:
     name: Unit Tests
     strategy:
@@ -29,7 +30,8 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run all wash & wash-lib unit tests
-        run: cargo nextest run --profile ci --workspace --bin wash
+        run: make test-wash-ci
+
   integration_tests:
     name: Integration Tests
     runs-on: ubuntu-22.04
@@ -48,4 +50,4 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run integration tests
-        run: cargo nextest run --profile ci --workspace -E 'kind(test)'
+        run: make test-integration-ci

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ build-watch: ## Continuously build the project
 CARGO_TEST_TARGET ?= ""
 
 test: ## Run unit test suite
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
-	@$(CARGO) nextest $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
 
 test-watch: ## Run unit tests continously, can optionally specify a target test filter.
 	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
@@ -47,7 +47,7 @@ test-integration-watch: ## Run integration test suite continuously
 	@$(CARGO) watch -- $(MAKE) test-integration
 
 test-unit: ## Run one or more unit tests
-	@$(CARGO) nextest $(CARGO_TEST_TARGET)
+	@$(CARGO) nextest run $(CARGO_TEST_TARGET)
 
 test-unit-watch: ## Run tests continuously
 	@$(CARGO) watch -- $(MAKE) test-unit

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,19 @@ test: ## Run unit test suite
 	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast --bin wash
 	@$(CARGO) nextest run $(CARGO_TEST_TARGET) --no-fail-fast -p wash-lib
 
+test-wash-ci:
+	@$(CARGO) nextest run --profile ci --workspace --bin wash
+
 test-watch: ## Run unit tests continously, can optionally specify a target test filter.
 	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)
 
-test-integration: ## Run the entire integration test suite
+test-integration: ## Run the entire integration test suite (with docker compose)
 	@$(DOCKER) compose -f ./tools/docker-compose.yml up --detach
 	@$(CARGO) nextest run --profile integration -E 'kind(test)'
 	@$(DOCKER) compose -f ./tools/docker-compose.yml down
+
+test-integration-ci: ## Run the entire integration test suite only
+	@$(CARGO) nextest run --profile ci -E 'kind(test)'
 
 test-integration-watch: ## Run integration test suite continuously
 	@$(CARGO) watch -- $(MAKE) test-integration


### PR DESCRIPTION
## Feature or Problem

Use `make` targets from CI (to ensure any breakage in Makefile is reflected in CI)

## Related Issues

Avoids the bug I introduced (`nextest` command was missing `run` in the Makefile) that [@aish-where-ya fixed for everyone](https://github.com/wasmCloud/wash/commit/0b2f0d3c1d56d1a7d2f8fed0f389a82846817051)

## Release Information

`next`

## Consumer Impact

Makefiles are less likely to break independent of CI

## Testing

CI will test this (should pass)

Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

N/A

### Acceptance or Integration

CI tests must pass

### Manual Verification

N/A (CI must pass)