### PR TITLE
bump versions to same commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -135,7 +135,7 @@ tokio-tar = "0.3"
 toml = "0.5"
 walkdir = "2.3"
 wascap = "0.9.2"
-wash-lib = { version = "0.6.1", path = "./crates/wash-lib" }
+wash-lib = { version = "0.7.0", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.11.2"
 wasmcloud-control-interface = "0.23"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
## Feature or Problem
Somehow `wash-lib` and `wash` were published using different code, so `wash` fails to install with cargo

## Release Information
Bumping wash-lib to v0.7.0 to reflect a feature change (consolidating `inspect`) and wash to v0.16.1

## Consumer Impact
Users should be able to install wash via cargo again after this

## Testing

### Manual Verification
Manually built wash off this branch