### PR TITLE
bump to v0.61.0 of wasmcloud host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -460,7 +460,7 @@ mod test {
     }
 
     const NATS_SERVER_VERSION: &str = "v2.8.4";
-    const WASMCLOUD_HOST_VERSION: &str = "v0.60.0";
+    const WASMCLOUD_HOST_VERSION: &str = "v0.61.0";
 
     #[tokio::test]
     async fn can_download_and_start_wasmcloud() -> anyhow::Result<()> {

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -9,7 +9,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.60.0";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.61.0";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";


### PR DESCRIPTION
## Feature or Problem
Bumpity bump!

## Related Issues
N/A

## Release Information
v0.16.2

## Consumer Impact
Users get v0.61.0 yayyyy

## Testing

### Manual Verification
Tested with `wash up` locally, and everything seems to be working