### PR TITLE
Bumped wascap to v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4cb21a92b02469a7586135a2f52753815ff8599992744de5a9e7db54873b3"
+checksum = "f3a85c9ab66dd6a39400cc7235b803c8819c3b76405bce83f8e6c540a8abf89a"
 dependencies = [
  "base64 0.13.1",
  "data-encoding",
@@ -3963,7 +3963,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.5.10",
- "wascap 0.10.0",
+ "wascap 0.10.1",
  "wash-lib",
  "wasmbus-rpc",
  "wasmcloud-control-interface",
@@ -4010,7 +4010,7 @@ dependencies = [
  "tokio-tar",
  "toml 0.5.10",
  "walkdir",
- "wascap 0.10.0",
+ "wascap 0.10.1",
  "weld-codegen 0.6.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ tokio-stream = "0.1"
 tokio-tar = "0.3"
 toml = "0.5"
 walkdir = "2.3"
-wascap = "0.10"
+wascap = "0.10.1"
 wash-lib = { version = "0.7.0", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.11.2"
 wasmcloud-control-interface = "0.23"


### PR DESCRIPTION
## Feature or Problem
This PR bumps wascap to `0.10.1` to bring in a bug fix for modules signed with v0.9.0. This should be released alongside wasmCloud v0.62.0 to ensure compatibility of signed modules

## Related Issues
https://github.com/wasmCloud/wascap/issues/45

## Release Information
v0.17.0, or whenever we release the version of `wash up` with `v0.62.0`

## Consumer Impact
Folks using this version of `wash` will have to use wasmCloud v0.62.0 or greater, so this might be released as a minor bump.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Nothing modified

### Acceptance or Integration
Nothing modified

### Manual Verification
I am testing and ensuring this works with the v0.62.0 release candidate
