### PR TITLE
Wash up waits for washboard to be up

### DIFF
--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -52,6 +52,26 @@
 //!     Ok(())
 //! }
 //! ```
+
+use anyhow::Result;
+pub async fn wait_for_server(url: &str, service: &str) -> Result<()> {
+    let mut wait_count = 1;
+    loop {
+        // Magic number: 10 + 1, since we are starting at 1 for humans
+        if wait_count >= 11 {
+            anyhow::bail!("Ran out of retries waiting for host to start");
+        }
+        match tokio::net::TcpStream::connect(url).await {
+            Ok(_) => break,
+            Err(e) => {
+                log::debug!("Waiting for {service} at {url} to come up, attempt {wait_count}. Will retry in 1 second. Got error {:?}", e);
+                wait_count += 1;
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Ok(())
+}
 mod nats;
 pub use nats::*;
 mod wasmcloud;

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -347,7 +347,9 @@ where
             "Could not write config to disk, couldn't find download directory"
         ))
     }?;
-    wait_for_server(&host_addr).await.map(|_| child)
+    wait_for_server(&host_addr, "NATS server")
+        .await
+        .map(|_| child)
 }
 
 /// Helper function to indicate if the NATS server binary is successfully
@@ -361,7 +363,7 @@ where
         .map_or(false, |m| m.is_file())
 }
 
-async fn wait_for_server(url: &str) -> Result<()> {
+pub async fn wait_for_server(url: &str, service: &str) -> Result<()> {
     let mut wait_count = 1;
     loop {
         // Magic number: 10 + 1, since we are starting at 1 for humans
@@ -371,7 +373,7 @@ async fn wait_for_server(url: &str) -> Result<()> {
         match tokio::net::TcpStream::connect(url).await {
             Ok(_) => break,
             Err(e) => {
-                log::debug!("Waiting for NATS server {} to come up, attempt {}. Will retry in 1 second. Got error {:?}", url, wait_count, e);
+                log::debug!("Waiting for {} {} to come up, attempt {}. Will retry in 1 second. Got error {:?}",service, url, wait_count, e);
                 wait_count += 1;
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -1,3 +1,4 @@
+use crate::start::wait_for_server;
 use anyhow::{anyhow, Result};
 use async_compression::tokio::bufread::GzipDecoder;
 #[cfg(target_family = "unix")]
@@ -361,25 +362,6 @@ where
     metadata(dir.as_ref().join(NATS_SERVER_BINARY))
         .await
         .map_or(false, |m| m.is_file())
-}
-
-pub async fn wait_for_server(url: &str, service: &str) -> Result<()> {
-    let mut wait_count = 1;
-    loop {
-        // Magic number: 10 + 1, since we are starting at 1 for humans
-        if wait_count >= 11 {
-            anyhow::bail!("Ran out of retries waiting for host to start");
-        }
-        match tokio::net::TcpStream::connect(url).await {
-            Ok(_) => break,
-            Err(e) => {
-                log::debug!("Waiting for {} {} to come up, attempt {}. Will retry in 1 second. Got error {:?}",service, url, wait_count, e);
-                wait_count += 1;
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Helper function to determine the NATS server release path given an os/arch and version

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -10,6 +10,7 @@ pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.61.0";
+pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "4000";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -19,7 +19,8 @@ use tokio::{
 };
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::start::{
-    ensure_nats_server, ensure_wasmcloud, start_nats_server, start_wasmcloud_host, NatsConfig,
+    ensure_nats_server, ensure_wasmcloud, start_nats_server, start_wasmcloud_host, wait_for_server,
+    NatsConfig,
 };
 
 use crate::appearance::spinner::Spinner;
@@ -369,6 +370,11 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             out_text,
             "\n🕸  NATS is running in the background at http://{nats_listen_address}"
         );
+
+        if let Ok(log) = wait_for_server(url, "Washboard").await {
+            println!("{:?}", log)
+        }
+
         let _ = write!(
             out_text,
             "\n🌐 The wasmCloud dashboard is running at {}\n📜 Logs for the host are being written to {}",
@@ -431,6 +437,11 @@ async fn run_wasmcloud_interactive(
         }
     })
     .expect("Error setting Ctrl-C handler, please file a bug issue https://github.com/wasmCloud/wash/issues/new/choose");
+
+    let url = "http://localhost:4000";
+    if let Ok(log) = wait_for_server(url, "Washboard").await {
+        println!("{:?}", log)
+    }
 
     if output_kind != OutputKind::Json {
         println!("🏃 Running in interactive mode, your host is running at http://localhost:4000",);

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -368,7 +368,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     if cmd.detached {
         // Write the pid file with the selected version
         tokio::fs::write(install_dir.join(config::WASMCLOUD_PID_FILE), version).await?;
-        let url = format!("{}:{}", "http://localhost:", WASMCLOUD_DASHBOARD_PORT);
+        let url = format!("{}:{}", "http://localhost", WASMCLOUD_DASHBOARD_PORT);
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
         out_json.insert("kill_cmd".to_string(), json!("wash down"));

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -331,7 +331,12 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     };
 
     let url = format!("{}:{}", "127.0.0.1", WASMCLOUD_DASHBOARD_PORT);
-    wait_for_server(&url, "Washboard").await?;
+    if wait_for_server(&url, "Washboard").await.is_err() {
+        if nats_bin.is_some() {
+            stop_nats(install_dir).await?;
+        }
+        return Err(anyhow!("wasmCloud host did not start. Failed to connect to washboard. Check host-logs at {:?}.", wasmcloud_log_path));
+    }
 
     spinner.finish_and_clear();
     if !cmd.detached {

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -330,6 +330,11 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         }
     };
 
+    let url = format!("{}:{}", "http://localhost:", WASMCLOUD_DASHBOARD_PORT);
+    if let Ok(log) = wait_for_server(&url, "Washboard").await {
+        println!("{:?}", log)
+    }
+
     spinner.finish_and_clear();
     if !cmd.detached {
         run_wasmcloud_interactive(wasmcloud_child, output_kind).await?;
@@ -360,7 +365,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     if cmd.detached {
         // Write the pid file with the selected version
         tokio::fs::write(install_dir.join(config::WASMCLOUD_PID_FILE), version).await?;
-        let url = "http://localhost:4000";
+        let url = format!("{}:{}", "http://localhost:", WASMCLOUD_DASHBOARD_PORT);
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
         out_json.insert("kill_cmd".to_string(), json!("wash down"));
@@ -370,10 +375,6 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             out_text,
             "\n🕸  NATS is running in the background at http://{nats_listen_address}"
         );
-
-        if let Ok(log) = wait_for_server(url, "Washboard").await {
-            println!("{:?}", log)
-        }
 
         let _ = write!(
             out_text,
@@ -437,11 +438,6 @@ async fn run_wasmcloud_interactive(
         }
     })
     .expect("Error setting Ctrl-C handler, please file a bug issue https://github.com/wasmCloud/wash/issues/new/choose");
-
-    let url = "http://localhost:4000";
-    if let Ok(log) = wait_for_server(url, "Washboard").await {
-        println!("{:?}", log)
-    }
 
     if output_kind != OutputKind::Json {
         println!("🏃 Running in interactive mode, your host is running at http://localhost:4000",);

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -330,10 +330,8 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         }
     };
 
-    let url = format!("{}:{}", "http://localhost:", WASMCLOUD_DASHBOARD_PORT);
-    if let Ok(log) = wait_for_server(&url, "Washboard").await {
-        println!("{:?}", log)
-    }
+    let url = format!("{}:{}", "127.0.0.1", WASMCLOUD_DASHBOARD_PORT);
+    wait_for_server(&url, "Washboard").await?;
 
     spinner.finish_and_clear();
     if !cmd.detached {


### PR DESCRIPTION
## Feature or Problem
Feature: Wash up waits for washboard to be run on port 4000

## Related Issues
#430 

## Release Information
next

## Consumer Impact
NA

## Testing
Tested using `make test-all` for flakes

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
Tested for flakes by continuously running `make test-all`
