### PR TITLE
Feat/allow file upload

### DIFF
--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -32,8 +32,9 @@ type ParamMap = std::collections::BTreeMap<String, serde_json::Value>;
 const PROJECT_NAME_REGEX: &str = r"^([a-zA-Z][a-zA-Z0-9_-]+)$";
 
 /// Type of project to be generated
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum ProjectKind {
+    #[default]
     Actor,
     Interface,
     Provider,
@@ -50,12 +51,6 @@ impl fmt::Display for ProjectKind {
                 ProjectKind::Provider => "provider",
             }
         )
-    }
-}
-
-impl Default for ProjectKind {
-    fn default() -> Self {
-        ProjectKind::Actor
     }
 }
 

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -53,6 +53,8 @@ pub(crate) const WASMCLOUD_ENABLE_IPV6: &str = "WASMCLOUD_ENABLE_IPV6";
 pub(crate) const WASMCLOUD_STRUCTURED_LOGGING_ENABLED: &str =
     "WASMCLOUD_STRUCTURED_LOGGING_ENABLED";
 pub(crate) const WASMCLOUD_CONFIG_SERVICE: &str = "WASMCLOUD_CONFIG_SERVICE";
+pub(crate) const WASMCLOUD_ALLOW_FILE_LOAD: &str = "WASMCLOUD_ALLOW_FILE_LOAD";
+pub(crate) const DEFAULT_ALLOW_FILE_LOAD: &str = "true";
 
 /// Helper function to convert WasmcloudOpts to the host environment map.
 /// Takes NatsOpts as well to provide reasonable defaults
@@ -199,6 +201,9 @@ pub(crate) async fn configure_host_env(
     // Extras configuration
     if wasmcloud_opts.config_service_enabled {
         host_config.insert(WASMCLOUD_CONFIG_SERVICE.to_string(), "1".to_string());
+    }
+    if wasmcloud_opts.allow_file_load.unwrap_or_default() {
+        host_config.insert(WASMCLOUD_ALLOW_FILE_LOAD.to_string(), "1".to_string());
     }
     if wasmcloud_opts.enable_structured_logging {
         host_config.insert(

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -225,6 +225,10 @@ pub(crate) struct WasmcloudOpts {
     #[clap(long = "config-service-enabled", env = WASMCLOUD_CONFIG_SERVICE)]
     pub(crate) config_service_enabled: bool,
 
+    /// Denotes if a wasmCloud host should allow starting actors from the file system
+    #[clap(long = "allow-file-load", default_value = DEFAULT_ALLOW_FILE_LOAD, env = WASMCLOUD_ALLOW_FILE_LOAD)]
+    pub(crate) allow_file_load: Option<bool>,
+
     /// Enable JSON structured logging from the wasmCloud host
     #[clap(
         long = "enable-structured-logging",


### PR DESCRIPTION
## Feature or Problem
Resolves https://github.com/wasmCloud/wash/issues/509 by setting `WASMCLOUD_ALLOW_FILE_LOAD` to true for hosts started via `wash up`

Also fixed a clippy issue

I made the `allow-file-load` flag take an explicit value to account for the default being true. The alternative is to invert the logic in wash and make the flag something like `--disallow-file-load`. If preferred, I can swap that easily

## Related Issues
https://github.com/wasmCloud/wash/issues/509

## Release Information
Next (v0.17.0, since this is a new feature)

## Consumer Impact
After this change, users will be able to `wash up` and then `wash ctl start actor file://foo`

## Testing

### Manual Verification

Started a host with `wash up` and confirmed `WASMCLOUD_ALLOW_FILE_LOAD` was set and `wash ctl start actor file://foo` returned `:enoent`

Started a host with `wash up --allow-file-load true` and confirmed the same behavior

Started a host with `wash up --allow-file-load false` and confirmed the env var was not set and the ctl command returned `actor file loading is disabled`