### PR TITLE
fix: bump tinygo to 0.27.0

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -46,10 +46,10 @@ jobs:
       - uses: actions/checkout@v3
       # Cache Rust builds between runs
       - uses: Swatinem/rust-cache@v2
-      - name: Setup tinygo
-        run: |
-          wget https://github.com/tinygo-org/tinygo/releases/download/v0.23.0/tinygo_0.23.0_amd64.deb
-          sudo dpkg -i tinygo_0.23.0_amd64.deb
+      - uses: acifani/setup-tinygo@v1
+        with:
+          tinygo-version: '0.27.0'
+          install-binaryen: 'false'
       - name: Add wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
       - name: Launch integration test services


### PR DESCRIPTION
Uses a github action that's not official but after a review,
appears to be well supported. If/When we get an official
GitHub action from tinygo folks, then we should change to that.
We aren't using the binaryen feature of the action
because we aren't building for the web.

Fixes #514

Signed-off-by: Bailey Hayes <behayes2@gmail.com>