### PR TITLE
feat(*) wadm 0.4 support in `wash app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,6 +4157,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-compression",
+ "async-nats 0.29.0",
  "cargo_toml",
  "claims",
  "clap 4.2.5",
@@ -4188,6 +4189,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tar",
  "toml 0.7.3",
+ "wadm",
  "walkdir",
  "wascap 0.10.1",
  "weld-codegen 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "any_ascii"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,41 +241,42 @@ version = "0.24.0-ALPHA.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cdefe54cd7867d937c0a507d2a3a830af410044282cd3e4002b5b7860e1892e"
 dependencies = [
- "rustls 0.21.1",
+ "rustls 0.21.0",
  "tokio",
  "webpki",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -362,7 +412,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -436,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
  "memchr",
  "serde",
@@ -455,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byteorder"
@@ -501,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -553,13 +603,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -570,26 +620,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.14"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
+checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
 dependencies = [
  "clap_builder",
- "clap_derive 4.1.14",
+ "clap_derive 4.2.0",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.1.14"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
+checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
 dependencies = [
+ "anstream",
+ "anstyle",
  "bitflags",
  "clap_lex 0.4.1",
- "is-terminal",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
@@ -598,27 +648,27 @@ version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a19591b2ab0e3c04b588a0e04ddde7b9eaa423646d1b4a8092879216bf47473"
 dependencies = [
- "clap 4.1.14",
+ "clap 4.2.5",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.14"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d7dc0031c3a59a04fc2ba395c8e2dd463cba1859275f065d225f6122221b45"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -656,7 +706,26 @@ dependencies = [
  "serde_json",
  "snafu",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.1",
+ "web-sys",
+]
+
+[[package]]
+name = "cloudevents-sdk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801713078518ab05d7c78508c14cf55173a14a1a6659421d3352c2576a6167bf"
+dependencies = [
+ "base64 0.12.3",
+ "bitflags",
+ "chrono",
+ "delegate-attr",
+ "hostname",
+ "serde",
+ "serde_json",
+ "snafu",
+ "url",
+ "uuid 1.3.1",
  "web-sys",
 ]
 
@@ -669,6 +738,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -708,7 +783,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.5.10",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -743,15 +818,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -767,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -777,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -788,22 +863,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -825,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -834,7 +909,7 @@ version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
 dependencies = [
- "nix 0.26.1",
+ "nix 0.26.2",
  "windows-sys 0.45.0",
 ]
 
@@ -853,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -865,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -875,24 +950,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -957,7 +1032,7 @@ checksum = "ee7e7ea0dba407429d816e8e38dda1a467cd74737722f2ccc8eae60429a1a3ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1002,7 +1077,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1063,15 +1138,15 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -1090,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -1102,9 +1177,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -1147,24 +1222,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1195,23 +1259,23 @@ checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1222,12 +1286,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -1345,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1355,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1366,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "globset"
@@ -1385,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1398,7 +1462,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tracing",
 ]
 
@@ -1459,6 +1523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "http-auth"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4ad8df7ddb631856ed3e5a385b781ae8d731727ae5dd7c5aa4784bfa878405"
+checksum = "5430cacd7a1f9a02fbeb350dfc81a0e5ed42d81f3398cb0ba184017f85bdcfbc"
 dependencies = [
  "memchr",
 ]
@@ -1535,9 +1605,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1565,7 +1635,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls",
 ]
@@ -1584,16 +1654,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -1641,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1673,30 +1743,31 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.36.6",
- "windows-sys 0.42.0",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1710,15 +1781,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1772,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "link-cplusplus"
@@ -1793,15 +1864,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "lock_api"
@@ -1854,18 +1919,18 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
@@ -1905,15 +1970,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.5"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1937,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1964,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1974,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -2048,9 +2122,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -2075,16 +2149,16 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tracing",
  "unicase",
 ]
 
 [[package]]
 name = "olpc-cjson"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dc75cf72208cd853671c1abccc5d5d1e43b1e378dde67340ef933219a8c13c"
+checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
 dependencies = [
  "serde",
  "serde_json",
@@ -2176,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "output_vt100"
@@ -2213,22 +2287,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "path-absolutize"
@@ -2271,9 +2345,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2293,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2303,33 +2377,33 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2352,7 +2426,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2412,7 +2486,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2476,7 +2550,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2551,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -2561,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2647,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2668,14 +2742,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2756,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2768,37 +2842,23 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
  "bitflags",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
-dependencies = [
- "bitflags",
- "errno 0.3.0",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.0",
- "windows-sys 0.45.0",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2808,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
 dependencies = [
  "log",
  "ring",
@@ -2851,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -2891,9 +2951,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -2907,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2920,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2948,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -2988,13 +3048,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3082,18 +3142,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3137,9 +3186,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -3164,9 +3213,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3195,7 +3244,7 @@ checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3276,7 +3325,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3296,9 +3345,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3314,18 +3363,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3352,7 +3389,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.3",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -3369,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3395,7 +3432,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3441,10 +3478,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3497,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3558,7 +3596,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
 ]
@@ -3605,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3620,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3701,7 +3739,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3718,7 +3756,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3738,11 +3776,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3751,13 +3788,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3817,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3865,15 +3902,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -3886,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -3897,16 +3934,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unsafe-libyaml"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"
@@ -3927,6 +3958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom",
  "serde",
@@ -3962,6 +3999,36 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wadm"
+version = "0.4.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add1c2aa376d24ab5592fd0949d09f5d04559f2a61b07a213832bc29cd8769ce"
+dependencies = [
+ "anyhow",
+ "async-nats 0.29.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "cloudevents-sdk 0.7.0",
+ "futures",
+ "indexmap",
+ "lazy_static",
+ "nkeys",
+ "rand",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.6",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "uuid 1.3.1",
+ "wasmcloud-control-interface",
+]
 
 [[package]]
 name = "walkdir"
@@ -4029,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4038,9 +4105,9 @@ dependencies = [
  "bytes",
  "cargo_atelier",
  "chrono",
- "clap 4.1.14",
+ "clap 4.2.5",
  "clap_complete",
- "cloudevents-sdk",
+ "cloudevents-sdk 0.6.0",
  "console",
  "ctrlc",
  "dirs",
@@ -4074,6 +4141,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.7.3",
+ "wadm",
  "wascap 0.10.1",
  "wash-lib",
  "wasmbus-rpc 0.13.0",
@@ -4085,13 +4153,13 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-compression",
  "cargo_toml",
  "claims",
- "clap 4.1.14",
+ "clap 4.2.5",
  "command-group",
  "config",
  "console",
@@ -4139,9 +4207,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4149,24 +4217,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4176,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4186,22 +4254,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
@@ -4244,7 +4312,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4274,11 +4342,11 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "tokio",
- "toml 0.5.10",
+ "toml 0.5.11",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uuid 1.2.2",
+ "uuid 1.3.1",
  "wascap 0.8.0",
  "wasmbus-macros",
  "weld-codegen 0.6.0",
@@ -4313,12 +4381,12 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "tokio",
- "toml 0.5.10",
+ "toml 0.5.11",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid 1.2.2",
+ "uuid 1.3.1",
  "wascap 0.8.0",
  "wasmbus-macros",
  "weld-codegen 0.7.0",
@@ -4331,7 +4399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dc1ae78202376144100b410d7d8b9d48c2845018f157cbd3a8bc817cfa2fcec"
 dependencies = [
  "async-nats 0.29.0",
- "cloudevents-sdk",
+ "cloudevents-sdk 0.6.0",
  "data-encoding",
  "futures",
  "ring",
@@ -4378,7 +4446,7 @@ dependencies = [
  "serde_json",
  "termcolor",
  "tokio",
- "toml 0.5.10",
+ "toml 0.5.11",
  "wasmbus-rpc 0.11.2",
  "wasmcloud-interface-testing",
 ]
@@ -4395,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4436,7 +4504,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if",
- "clap 3.2.23",
+ "clap 3.2.25",
  "directories",
  "downloader",
  "handlebars",
@@ -4449,7 +4517,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4466,7 +4534,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if",
- "clap 4.1.14",
+ "clap 4.2.5",
  "directories",
  "downloader",
  "handlebars",
@@ -4479,7 +4547,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4496,7 +4564,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if",
- "clap 4.1.14",
+ "clap 4.2.5",
  "directories",
  "downloader",
  "handlebars",
@@ -4553,6 +4621,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4703,9 +4780,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69af645a61644c6dd379ade8b77cc87efb5393c988707bad12d3c8e00c50f669"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -4739,21 +4816,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
- "synstructure",
+ "syn 2.0.15",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -12,7 +12,7 @@ repository = "https://github.com/wasmcloud/wash"
 rust-version = "1.60.0"
 
 [badges]
-maintenance = {status = "actively-developed"}
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
@@ -49,6 +49,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
 which = { workspace = true }
+wadm = { workspace = true }
 wash-lib = { workspace = true, features = ["cli"] }
 wascap = { workspace = true }
 weld-codegen = { workspace = true }
@@ -75,7 +76,7 @@ path = "src/main.rs"
 test = true
 
 [workspace]
-members = [ "./", "./crates/wash-lib"]
+members = ["./", "./crates/wash-lib"]
 
 [workspace.dependencies]
 anyhow = "1.0.71"
@@ -127,13 +128,14 @@ term-table = "1.3.1"
 test-case = "2.2.1"
 test_bin = "0.4.0"
 thiserror = "1.0"
-tokio = { version = "1.27.0", default-features = false, features = ["fs"] }
+tokio = { version = "1.27.0", default-features = false }
 tokio-stream = "0.1"
 tokio-tar = "0.3"
-toml = "0.7.3"
+toml = "0.7.2"
+wadm = "0.4.0-alpha.2"
 walkdir = "2.3"
 wascap = "0.10.1"
-wash-lib = { version = "0.8", path = "./crates/wash-lib" }
+wash-lib = { version = "0.9.0", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.13.0"
 wasmcloud-control-interface = "0.25"
 wasmcloud-test-util = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ term-table = "1.3.1"
 test-case = "2.2.1"
 test_bin = "0.4.0"
 thiserror = "1.0"
-tokio = { version = "1.27.0", default-features = false }
+tokio = { version = "1.27.0", default-features = false, features = ["fs"] }
 tokio-stream = "0.1"
 tokio-tar = "0.3"
 toml = "0.7.2"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -14,14 +14,16 @@ repository = "https://github.com/wasmcloud/wash"
 maintenance = {status = "actively-developed"}
 
 [features]
-default = ["start", "parser"]
+default = ["start", "parser", "nats"]
 start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
 cli = ["clap", "term-table", "console", "dialoguer", "heck", "ignore", "indicatif", "path-absolutize"]
+nats = ["async-nats", "wadm"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
+async-nats = { workspace = true, optional = true}
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 command-group = { workspace = true, features = ["with-tokio"] }
 config = { workspace = true, features = ["toml"], optional = true }
@@ -50,6 +52,7 @@ tokio = { workspace = true, features = ["process"] }
 tokio-stream = { workspace = true }
 tokio-tar = { workspace = true }
 toml = { workspace = true }
+wadm = { workspace = true, optional = true}
 walkdir = { workspace = true }
 wascap = { workspace = true }
 weld-codegen = { workspace = true }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -1,0 +1,240 @@
+//! Interact with and manage wadm applications over NATS, requires the `nats` feature
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use async_nats::{Client, Message};
+use wadm::server::{
+    DeleteModelRequest, DeleteModelResponse, DeployModelRequest, DeployModelResponse,
+    GetModelRequest, GetModelResponse, ModelSummary, PutModelResponse, UndeployModelRequest,
+    VersionResponse,
+};
+
+use crate::config::DEFAULT_LATTICE_PREFIX;
+
+/// The NATS prefix wadm's API is listening on
+const WADM_API_PREFIX: &str = "wadm.api";
+
+/// A helper enum to easily refer to wadm model operations and then use the
+/// [ToString](ToString) implementation for NATS topic formation
+pub enum ModelOperation {
+    List,
+    Get,
+    History,
+    Delete,
+    Put,
+    Deploy,
+    Undeploy,
+}
+
+impl ToString for ModelOperation {
+    fn to_string(&self) -> String {
+        match self {
+            ModelOperation::List => "list",
+            ModelOperation::Get => "get",
+            ModelOperation::History => "versions",
+            ModelOperation::Delete => "del",
+            ModelOperation::Put => "put",
+            ModelOperation::Deploy => "deploy",
+            ModelOperation::Undeploy => "undeploy",
+        }
+        .to_string()
+    }
+}
+
+/// Undeploy a model, instructing wadm to no longer manage the given application
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application is managed on, defaults to `default`
+/// * `model_name` - Model name to undeploy
+/// * `non_destructive` - Undeploy deletes managed resources by default, this can be overridden by setting this to `true`
+pub async fn undeploy_model(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model_name: &str,
+    non_destructive: bool,
+) -> Result<DeployModelResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::Undeploy,
+        lattice_prefix,
+        Some(model_name),
+        serde_json::to_vec(&UndeployModelRequest { non_destructive })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Deploy a model, instructing wadm to manage the application
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application will be managed on, defaults to `default`
+/// * `model_name` - Model name to deploy
+/// * `version` - Version to deploy, defaults to deploying the latest "put" version
+pub async fn deploy_model(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model_name: &str,
+    version: Option<String>,
+) -> Result<DeployModelResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::Deploy,
+        lattice_prefix,
+        Some(model_name),
+        serde_json::to_vec(&DeployModelRequest { version })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Put a model definition, instructing wadm to store the application manifest for later deploys
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application manifest will be stored on, defaults to `default`
+/// * `model` - The full YAML or JSON string containing the OAM wadm manifest
+pub async fn put_model(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model: &str,
+) -> Result<PutModelResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::Put,
+        lattice_prefix,
+        None,
+        model.as_bytes().to_vec(),
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Query wadm for the history of a given model name
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `model_name` - Name of the model to retrieve history for
+pub async fn get_model_history(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model_name: &str,
+) -> Result<VersionResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::History,
+        lattice_prefix,
+        Some(model_name),
+        vec![],
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Query wadm for details on a given model
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `model_name` - Name of the model to retrieve history for
+/// * `version` - Version to retrieve, defaults to retrieving the latest "put" version
+pub async fn get_model_details(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model_name: &str,
+    version: Option<String>,
+) -> Result<GetModelResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::Get,
+        lattice_prefix,
+        Some(model_name),
+        serde_json::to_vec(&GetModelRequest { version })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Delete a model version from wadm
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `model_name` - Name of the model
+/// * `version` - Version to retrieve, defaults to deleting the latest "put" version (or all if `delete_all` is specified)
+/// * `delete_all` - Whether or not to delete all versions for a given model name
+pub async fn delete_model_version(
+    client: &Client,
+    lattice_prefix: Option<String>,
+    model_name: &str,
+    version: Option<String>,
+    delete_all: bool,
+) -> Result<DeleteModelResponse> {
+    let res = model_request(
+        client,
+        ModelOperation::Delete,
+        lattice_prefix,
+        Some(model_name),
+        serde_json::to_vec(&DeleteModelRequest {
+            version: version.unwrap_or_default(),
+            delete_all,
+        })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Query wadm for all application manifests
+///
+/// # Arguments
+/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `lattice_prefix` - Optional lattice prefix that the application manifests are stored on, defaults to `default`
+pub async fn get_models(
+    client: &Client,
+    lattice_prefix: Option<String>,
+) -> Result<Vec<ModelSummary>> {
+    let res = model_request(client, ModelOperation::List, lattice_prefix, None, vec![]).await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Helper function to make a NATS request given connection options, an operation, optional name, and bytes
+/// Designed for internal use
+async fn model_request(
+    client: &Client,
+    operation: ModelOperation,
+    lattice_prefix: Option<String>,
+    object_name: Option<&str>,
+    bytes: Vec<u8>,
+) -> Result<Message> {
+    // Topic is of the form of wadm.api.<lattice>.<category>.<operation>.<OPTIONAL: object_name>
+    // We let callers of this function dictate the topic after the prefix + lattice
+    let topic = format!(
+        "{WADM_API_PREFIX}.{}.model.{}{}",
+        lattice_prefix.unwrap_or_else(|| DEFAULT_LATTICE_PREFIX.to_string()),
+        operation.to_string(),
+        object_name
+            .map(|name| format!(".{name}"))
+            .unwrap_or_default()
+    );
+
+    match tokio::time::timeout(
+        Duration::from_millis(2_000),
+        client.request(topic, bytes.into()),
+    )
+    .await
+    {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(e)) => bail!("Error making model request: {}", e),
+        Err(e) => bail!("model_request timed out:  {}", e),
+    }
+}

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -2,19 +2,31 @@
 //!
 //! The `wash` command line interface <https://github.com/wasmcloud/wash> is a great place
 //! to find examples on how to fully utilize this library.
+//!
+//! This library contains a few feature flags, most enabled by default but optional in order to
+//! allow consumers to omit some functionality. This is especially useful when considering compiling this
+//! library to restrictive targets, e.g. `wasm32-unknown-unknown` or `wasm32-wasi`. Support for `wasm` targets
+//! is a goal but has not been tested yet.
+//!
+//! | Feature Name | Default Enabled | Description |
+//! | --- | --- | --- |
+//! | start | true | Contains the [start](start) module, with utilities to start wasmCloud runtimes, NATS, and wadm |
+//! | parser | true | Contains the [parser](parser) module, with utilities to parse `wasmcloud.toml` files |
+//! | cli | false | Contains the build, cli, and generate modules with additional trait derives for usage in building CLI applications |
+//! | nats| true| Contains the [app](app) module with a dependency on `async_nats` |
 
-#[cfg(feature = "start")]
-pub mod start;
-
-#[cfg(feature = "parser")]
-pub mod parser;
-
+#[cfg(feature = "nats")]
+pub mod app;
 #[cfg(feature = "cli")]
 pub mod build;
 #[cfg(feature = "cli")]
 pub mod cli;
 #[cfg(feature = "cli")]
 pub mod generate;
+#[cfg(feature = "parser")]
+pub mod parser;
+#[cfg(feature = "start")]
+pub mod start;
 
 pub mod config;
 pub mod context;

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -110,7 +110,7 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
         Some(caps) => caps.get(2).map(|m| m.as_str().to_owned()),
         None => bail!("Invalid OCI reference URL."),
     }
-    .unwrap_or(String::from(""));
+    .unwrap_or_default();
 
     if !options.allow_latest {
         if input_tag == "latest" {

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -149,6 +149,7 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
         None => None,
     };
 
+    println!("digest: {:?}", image_data.digest);
     match (digest, image_data.digest) {
         (Some(digest), Some(image_digest)) if digest != image_digest => {
             return Err(anyhow!(

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -149,7 +149,6 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
         None => None,
     };
 
-    println!("digest: {:?}", image_data.digest);
     match (digest, image_data.digest) {
         (Some(digest), Some(image_digest)) if digest != image_digest => {
             return Err(anyhow!(

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -1,0 +1,92 @@
+//! Reusable code for downloading tarballs from GitHub releases
+
+use anyhow::{anyhow, Result};
+use async_compression::tokio::bufread::GzipDecoder;
+#[cfg(target_family = "unix")]
+use std::os::unix::prelude::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::{ffi::OsStr, io::Cursor};
+use tokio::fs::{create_dir_all, metadata, File};
+use tokio_stream::StreamExt;
+use tokio_tar::Archive;
+
+/// Downloads the specified GitHub release version of nats-server from <https://github.com/nats-io/nats-server/releases/>
+/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the NATS executable.
+/// # Arguments
+///
+/// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
+/// * `arch` - Specifies the architecture of the binary to download, e.g. `amd64`
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `dir` - Where to download the `nats-server` binary to
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use wash_lib::start::download_nats_server_for_os_arch_pair;
+/// let os = std::env::consts::OS;
+/// let arch = std::env::consts::ARCH;
+/// let res = download_nats_server_for_os_arch_pair(os, arch, "v2.8.4", "/tmp/").await;
+/// assert!(res.is_ok());
+/// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
+/// # }
+/// ```
+pub async fn download_binary_from_github<P>(url: &str, dir: P, bin_name: &str) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    let bin_path = dir.as_ref().join(bin_name);
+    // Download NATS tarball
+    let body = match reqwest::get(url).await {
+        Ok(resp) => resp.bytes().await?,
+        Err(e) => return Err(anyhow!("Failed to request NATS release: {:?}", e)),
+    };
+    let cursor = Cursor::new(body);
+    let mut bin_tarball = Archive::new(Box::new(GzipDecoder::new(cursor)));
+
+    // Look for binary within tarball and only extract that
+    let mut entries = bin_tarball.entries()?;
+    while let Some(res) = entries.next().await {
+        let mut entry = res.map_err(|e| {
+            anyhow!(
+                "Failed to retrieve file from archive, ensure {bin_name} exists. Original error: {e}",
+            )
+        })?;
+        if let Ok(tar_path) = entry.path() {
+            match tar_path.file_name() {
+                Some(name) if name == OsStr::new(bin_name) => {
+                    // Ensure target directory exists
+                    create_dir_all(&dir).await?;
+                    let mut bin_file = File::create(&bin_path).await?;
+                    // Make binary executable
+                    #[cfg(target_family = "unix")]
+                    {
+                        let mut permissions = bin_file.metadata().await?.permissions();
+                        // Read/write/execute for owner and read/execute for others. This is what `cargo install` does
+                        permissions.set_mode(0o755);
+                        bin_file.set_permissions(permissions).await?;
+                    }
+
+                    tokio::io::copy(&mut entry, &mut bin_file).await?;
+                    return Ok(bin_path);
+                }
+                // Ignore other files LICENSE and README in the tarball
+                _ => (),
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "{bin_name} binary could not be installed, please see logs"
+    ))
+}
+
+/// Helper function to determine if the provided binary is present in a directory
+pub async fn is_bin_installed<P>(dir: P, bin_name: P) -> bool
+where
+    P: AsRef<Path>,
+{
+    metadata(dir.as_ref().join(bin_name))
+        .await
+        .map_or(false, |m| m.is_file())
+}

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -79,7 +79,8 @@ where
 }
 
 /// Helper function to determine if the provided binary is present in a directory
-pub async fn is_bin_installed<P>(dir: P, bin_name: &str) -> bool
+#[allow(unused)]
+pub(crate) async fn is_bin_installed<P>(dir: P, bin_name: &str) -> bool
 where
     P: AsRef<Path>,
 {

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -10,25 +10,22 @@ use tokio::fs::{create_dir_all, metadata, File};
 use tokio_stream::StreamExt;
 use tokio_tar::Archive;
 
-/// Downloads the specified GitHub release version of nats-server from <https://github.com/nats-io/nats-server/releases/>
-/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the NATS executable.
+/// Reusable function to download a release tarball from GitHub and extract an embedded binary to a specified directory
+///
 /// # Arguments
 ///
-/// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
-/// * `arch` - Specifies the architecture of the binary to download, e.g. `amd64`
-/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
-/// * `dir` - Where to download the `nats-server` binary to
+/// * `url` - URL of the GitHub release artifact tarball (Usually in the form of https://github.com/<owner>/<repo>/releases/download/<tag>/<artifact>.tar.gz)
+/// * `dir` - Directory on disk to install the binary into. This will be created if it doesn't exist
+/// * `bin_name` - Name of the binary inside of the tarball, e.g. `nats-server` or `wadm`
 /// # Examples
 ///
 /// ```no_run
 /// # #[tokio::main]
 /// # async fn main() {
-/// use wash_lib::start::download_nats_server_for_os_arch_pair;
-/// let os = std::env::consts::OS;
-/// let arch = std::env::consts::ARCH;
-/// let res = download_nats_server_for_os_arch_pair(os, arch, "v2.8.4", "/tmp/").await;
+/// let url = "https://github.com/wasmCloud/wadm/releases/download/v0.4.0-alpha.1/wadm-v0.4.0-alpha.1-linux-amd64.tar.gz";
+/// let res = download_binary_from_github(url, "/tmp/", "wadm").await;
 /// assert!(res.is_ok());
-/// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
+/// assert!(res.unwrap().to_string_lossy() == "/tmp/wadm");
 /// # }
 /// ```
 pub async fn download_binary_from_github<P>(url: &str, dir: P, bin_name: &str) -> Result<PathBuf>
@@ -36,10 +33,10 @@ where
     P: AsRef<Path>,
 {
     let bin_path = dir.as_ref().join(bin_name);
-    // Download NATS tarball
+    // Download release tarball
     let body = match reqwest::get(url).await {
         Ok(resp) => resp.bytes().await?,
-        Err(e) => return Err(anyhow!("Failed to request NATS release: {:?}", e)),
+        Err(e) => return Err(anyhow!("Failed to request release tarball: {:?}", e)),
     };
     let cursor = Cursor::new(body);
     let mut bin_tarball = Archive::new(Box::new(GzipDecoder::new(cursor)));
@@ -70,7 +67,7 @@ where
                     tokio::io::copy(&mut entry, &mut bin_file).await?;
                     return Ok(bin_path);
                 }
-                // Ignore other files LICENSE and README in the tarball
+                // Ignore all other files in the tarball
                 _ => (),
             }
         }
@@ -82,7 +79,7 @@ where
 }
 
 /// Helper function to determine if the provided binary is present in a directory
-pub async fn is_bin_installed<P>(dir: P, bin_name: P) -> bool
+pub async fn is_bin_installed<P>(dir: P, bin_name: &str) -> bool
 where
     P: AsRef<Path>,
 {

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -72,7 +72,12 @@ pub async fn wait_for_server(url: &str, service: &str) -> Result<()> {
     }
     Ok(())
 }
+
+mod github;
+pub(crate) use github::*;
 mod nats;
 pub use nats::*;
+mod wadm;
+pub use wadm::*;
 mod wasmcloud;
 pub use wasmcloud::*;

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -78,6 +78,6 @@ pub(crate) use github::*;
 mod nats;
 pub use nats::*;
 mod wadm;
-pub use wadm::*;
+pub use self::wadm::*;
 mod wasmcloud;
 pub use wasmcloud::*;

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -1,15 +1,11 @@
 use crate::start::wait_for_server;
 use anyhow::{anyhow, Result};
-use async_compression::tokio::bufread::GzipDecoder;
-#[cfg(target_family = "unix")]
-use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::{ffi::OsStr, io::Cursor};
-use tokio::fs::{create_dir_all, metadata, write, File};
+use tokio::fs::{metadata, write};
 use tokio::process::{Child, Command};
-use tokio_stream::StreamExt;
-use tokio_tar::Archive;
+
+use super::download_binary_from_github;
 
 const NATS_GITHUB_RELEASE_URL: &str = "https://github.com/nats-io/nats-server/releases/download";
 pub const NATS_SERVER_CONF: &str = "nats.conf";
@@ -19,8 +15,7 @@ pub const NATS_SERVER_BINARY: &str = "nats-server";
 #[cfg(target_family = "windows")]
 pub const NATS_SERVER_BINARY: &str = "nats-server.exe";
 
-/// A wrapper around the [ensure_nats_server_for_os_arch_pair] function that uses the
-/// architecture and operating system of the current host machine.
+/// Downloads the NATS binary for the architecture and operating system of the current host machine.
 ///
 /// # Arguments
 ///
@@ -82,11 +77,10 @@ where
         return Ok(nats_bin_path);
     }
     // Download NATS tarball
-    download_nats_server_for_os_arch_pair(os, arch, version, dir).await
+    download_binary_from_github(&nats_url(os, arch, version), dir, NATS_SERVER_BINARY).await
 }
 
-/// A wrapper around the [download_nats_server_for_os_arch_pair] function that uses the
-/// architecture and operating system of the current host machine.
+/// Downloads the NATS binary for the architecture and operating system of the current host machine.
 ///
 /// # Arguments
 ///
@@ -107,91 +101,12 @@ pub async fn download_nats_server<P>(version: &str, dir: P) -> Result<PathBuf>
 where
     P: AsRef<Path>,
 {
-    download_nats_server_for_os_arch_pair(
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-        version,
+    download_binary_from_github(
+        &nats_url(std::env::consts::OS, std::env::consts::ARCH, version),
         dir,
+        NATS_SERVER_BINARY,
     )
     .await
-}
-
-/// Downloads the specified GitHub release version of nats-server from <https://github.com/nats-io/nats-server/releases/>
-/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the NATS executable.
-/// # Arguments
-///
-/// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
-/// * `arch` - Specifies the architecture of the binary to download, e.g. `amd64`
-/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
-/// * `dir` - Where to download the `nats-server` binary to
-/// # Examples
-///
-/// ```no_run
-/// # #[tokio::main]
-/// # async fn main() {
-/// use wash_lib::start::download_nats_server_for_os_arch_pair;
-/// let os = std::env::consts::OS;
-/// let arch = std::env::consts::ARCH;
-/// let res = download_nats_server_for_os_arch_pair(os, arch, "v2.8.4", "/tmp/").await;
-/// assert!(res.is_ok());
-/// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
-/// # }
-/// ```
-pub async fn download_nats_server_for_os_arch_pair<P>(
-    os: &str,
-    arch: &str,
-    version: &str,
-    dir: P,
-) -> Result<PathBuf>
-where
-    P: AsRef<Path>,
-{
-    let nats_bin_path = dir.as_ref().join(NATS_SERVER_BINARY);
-    // Download NATS tarball
-    let url = nats_url(os, arch, version);
-    let body = match reqwest::get(url).await {
-        Ok(resp) => resp.bytes().await?,
-        Err(e) => return Err(anyhow!("Failed to request NATS release: {:?}", e)),
-    };
-    let cursor = Cursor::new(body);
-    let mut nats_server = Archive::new(Box::new(GzipDecoder::new(cursor)));
-
-    // Look for nats-server binary and only extract that
-    let mut entries = nats_server.entries()?;
-    while let Some(res) = entries.next().await {
-        let mut entry = res.map_err(|e| {
-            anyhow!(
-                "Failed to retrieve file from archive, ensure NATS server {} exists. Original error: {}",
-                version, e
-            )
-        })?;
-        if let Ok(tar_path) = entry.path() {
-            match tar_path.file_name() {
-                Some(name) if name == OsStr::new(NATS_SERVER_BINARY) => {
-                    // Ensure target directory exists
-                    create_dir_all(&dir).await?;
-                    let mut nats_server = File::create(&nats_bin_path).await?;
-                    // Make nats-server executable
-                    #[cfg(target_family = "unix")]
-                    {
-                        let mut permissions = nats_server.metadata().await?.permissions();
-                        // Read/write/execute for owner and read/execute for others. This is what `cargo install` does
-                        permissions.set_mode(0o755);
-                        nats_server.set_permissions(permissions).await?;
-                    }
-
-                    tokio::io::copy(&mut entry, &mut nats_server).await?;
-                    return Ok(nats_bin_path);
-                }
-                // Ignore LICENSE and README in the NATS tarball
-                _ => (),
-            }
-        }
-    }
-
-    Err(anyhow!(
-        "NATS Server binary could not be installed, please see logs"
-    ))
 }
 
 /// Configuration for a NATS server that supports running either in "standalone" or "leaf" mode.
@@ -353,17 +268,6 @@ where
         .map(|_| child)
 }
 
-/// Helper function to indicate if the NATS server binary is successfully
-/// installed in a directory
-pub async fn is_nats_installed<P>(dir: P) -> bool
-where
-    P: AsRef<Path>,
-{
-    metadata(dir.as_ref().join(NATS_SERVER_BINARY))
-        .await
-        .map_or(false, |m| m.is_file())
-}
-
 /// Helper function to determine the NATS server release path given an os/arch and version
 fn nats_url(os: &str, arch: &str, version: &str) -> String {
     // Replace "macos" with "darwin" to match NATS release scheme
@@ -380,7 +284,7 @@ fn nats_url(os: &str, arch: &str, version: &str) -> String {
 #[cfg(test)]
 mod test {
     use crate::start::{
-        ensure_nats_server, is_nats_installed, start_nats_server, NatsConfig, NATS_SERVER_BINARY,
+        ensure_nats_server, is_bin_installed, start_nats_server, NatsConfig, NATS_SERVER_BINARY,
     };
     use anyhow::Result;
     use std::env::temp_dir;
@@ -396,7 +300,9 @@ mod test {
         let install_dir = temp_dir().join("can_handle_missing_nats_version");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(!is_nats_installed(&install_dir).await);
+        assert!(
+            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
+        );
 
         let res = ensure_nats_server("v300.22.1111223", &install_dir).await;
         assert!(res.is_err());
@@ -410,7 +316,9 @@ mod test {
         let install_dir = temp_dir().join("can_download_and_start_nats");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(!is_nats_installed(&install_dir).await);
+        assert!(
+            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
+        );
 
         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
         assert!(res.is_ok());
@@ -450,7 +358,9 @@ mod test {
         let install_dir = temp_dir().join("can_gracefully_fail_running_nats");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(!is_nats_installed(&install_dir).await);
+        assert!(
+            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
+        );
 
         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
         assert!(res.is_ok());
@@ -483,7 +393,7 @@ mod test {
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
         assert!(
-            !is_nats_installed(&install_dir).await,
+            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await,
             "NATS should not be installed"
         );
 

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -300,9 +300,7 @@ mod test {
         let install_dir = temp_dir().join("can_handle_missing_nats_version");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(
-            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
-        );
+        assert!(!is_bin_installed(&install_dir, NATS_SERVER_BINARY).await);
 
         let res = ensure_nats_server("v300.22.1111223", &install_dir).await;
         assert!(res.is_err());
@@ -316,9 +314,7 @@ mod test {
         let install_dir = temp_dir().join("can_download_and_start_nats");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(
-            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
-        );
+        assert!(!is_bin_installed(&install_dir, NATS_SERVER_BINARY).await);
 
         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
         assert!(res.is_ok());
@@ -358,9 +354,7 @@ mod test {
         let install_dir = temp_dir().join("can_gracefully_fail_running_nats");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        assert!(
-            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
-        );
+        assert!(!is_bin_installed(&install_dir, NATS_SERVER_BINARY).await);
 
         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
         assert!(res.is_ok());
@@ -393,7 +387,7 @@ mod test {
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
         assert!(
-            !is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await,
+            !is_bin_installed(&install_dir, NATS_SERVER_BINARY).await,
             "NATS should not be installed"
         );
 

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::fs::metadata;
@@ -71,16 +71,12 @@ where
     let wadm_bin_path = dir.as_ref().join(WADM_BINARY);
     if let Ok(_md) = metadata(&wadm_bin_path).await {
         // Check version to see if we need to download new one
-        match Command::new(&wadm_bin_path).arg("--version").output().await {
-            Ok(output) => {
-                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                if stdout.replace("wadm", "").trim() == version.trim_start_matches("v") {
-                    // wadm already exists, return early
-                    return Ok(wadm_bin_path);
-                }
+        if let Ok(output) = Command::new(&wadm_bin_path).arg("--version").output().await {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            if stdout.replace("wadm", "").trim() == version.trim_start_matches('v') {
+                // wadm already exists, return early
+                return Ok(wadm_bin_path);
             }
-            // If we couldn't find out the version, it's probably not the wadm binary. Ignore and download
-            Err(_) => (),
         }
     }
     // Download wadm tarball
@@ -129,7 +125,9 @@ pub struct WadmConfig {
     pub nats_credsfile: Option<PathBuf>,
 }
 
-/// Helper function to execute a wadm binary with optional arguments
+/// Helper function to execute a wadm binary with optional arguments. This function does not check to see if a
+/// wadm instance is already running or managing a lattice as wadm does not need to be a singleton.
+///
 /// # Arguments
 ///
 /// * `bin_path` - Path to the wadm binary to execute
@@ -141,16 +139,6 @@ where
     T: Into<Stdio>,
 {
     let pid_file = bin_path.as_ref().parent().map(|p| p.join(WADM_PID));
-    match pid_file.as_ref() {
-        Some(path) => {
-            if let Ok(previous_pid) = tokio::fs::read_to_string(&path).await {
-                //TODO: bad? What if file just isn't cleared out?
-                // probably should find another way, validate with app API
-                bail!("wadm is already running with pid {previous_pid}, aborting")
-            }
-        }
-        None => (),
-    }
 
     let mut cmd = Command::new(bin_path.as_ref());
     cmd.stderr(stderr).stdin(Stdio::null());
@@ -174,13 +162,10 @@ where
     let child = cmd.spawn().map_err(anyhow::Error::from);
 
     let pid = child.as_ref().map(|c| c.id());
-    match (pid, pid_file) {
-        (Ok(Some(wadm_pid)), Some(pid_path)) => {
-            if let Err(e) = tokio::fs::write(pid_path, wadm_pid.to_string()).await {
-                log::warn!("Couldn't write wadm pidfile: {e}");
-            }
+    if let (Ok(Some(wadm_pid)), Some(pid_path)) = (pid, pid_file) {
+        if let Err(e) = tokio::fs::write(pid_path, wadm_pid.to_string()).await {
+            log::warn!("Couldn't write wadm pidfile: {e}");
         }
-        _ => (),
     }
     child
 }

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -235,36 +235,4 @@ mod test {
         let _ = remove_dir_all(install_dir).await;
         Ok(())
     }
-
-    //     #[tokio::test]
-    //     async fn can_gracefully_fail_running_nats() -> Result<()> {
-    //         let install_dir = temp_dir().join("can_gracefully_fail_running_nats");
-    //         let _ = remove_dir_all(&install_dir).await;
-    //         create_dir_all(&install_dir).await?;
-    //         assert!(!is_nats_installed(&install_dir).await);
-
-    //         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
-    //         assert!(res.is_ok());
-
-    //         let config = NatsConfig::new_standalone("127.0.0.1", 10003, Some("extender".to_string()));
-    //         let nats_one = start_nats_server(
-    //             &install_dir.join(NATS_SERVER_BINARY),
-    //             std::process::Stdio::null(),
-    //             config.clone(),
-    //         )
-    //         .await;
-    //         assert!(nats_one.is_ok());
-
-    //         // Give NATS a few seconds to start up and listen
-    //         tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
-    //         let log_path = install_dir.join("nats.log");
-    //         let log = std::fs::File::create(&log_path)?;
-    //         let nats_two = start_nats_server(&install_dir.join(NATS_SERVER_BINARY), log, config).await;
-    //         assert!(nats_two.is_err());
-
-    //         nats_one.unwrap().kill().await?;
-    //         let _ = remove_dir_all(install_dir).await;
-
-    //         Ok(())
-    //     }
 }

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -70,8 +70,18 @@ where
 {
     let wadm_bin_path = dir.as_ref().join(WADM_BINARY);
     if let Ok(_md) = metadata(&wadm_bin_path).await {
-        // wadm already exists, return early
-        return Ok(wadm_bin_path);
+        // Check version to see if we need to download new one
+        match Command::new(&wadm_bin_path).arg("--version").output().await {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                if stdout.replace("wadm", "").trim() == version.trim_start_matches("v") {
+                    // wadm already exists, return early
+                    return Ok(wadm_bin_path);
+                }
+            }
+            // If we couldn't find out the version, it's probably not the wadm binary. Ignore and download
+            Err(_) => (),
+        }
     }
     // Download wadm tarball
     download_binary_from_github(&wadm_url(os, arch, version), dir, WADM_BINARY).await

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -1,23 +1,19 @@
-use crate::start::wait_for_server;
-use anyhow::{anyhow, Result};
-use async_compression::tokio::bufread::GzipDecoder;
+use anyhow::{bail, Result};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::{ffi::OsStr, io::Cursor};
-use tokio::fs::{create_dir_all, metadata, write, File};
+use tokio::fs::metadata;
 use tokio::process::{Child, Command};
-use tokio_stream::StreamExt;
-use tokio_tar::Archive;
 
 use super::download_binary_from_github;
 
 const WADM_GITHUB_RELEASE_URL: &str = "https://github.com/wasmcloud/wadm/releases/download";
+pub const WADM_PID: &str = "wadm.pid";
 #[cfg(target_family = "unix")]
 pub const WADM_BINARY: &str = "wadm";
 #[cfg(target_family = "windows")]
 pub const WADM_BINARY: &str = "wadm.exe";
 
-/// Downloads the Wadm binary for the architecture and operating system of the current host machine.
+/// Downloads the wadm binary for the architecture and operating system of the current host machine.
 ///
 /// # Arguments
 ///
@@ -43,7 +39,7 @@ where
 
 /// Ensures the `wadm` binary is installed, returning the path to the executable early if it exists or
 /// downloading the specified GitHub release version of wadm from <https://github.com/wasmcloud/wadm/releases/>
-/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the Wadm executable.
+/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the wadm executable.
 /// # Arguments
 ///
 /// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
@@ -74,14 +70,14 @@ where
 {
     let wadm_bin_path = dir.as_ref().join(WADM_BINARY);
     if let Ok(_md) = metadata(&wadm_bin_path).await {
-        // Wadm already exists, return early
+        // wadm already exists, return early
         return Ok(wadm_bin_path);
     }
-    // Download Wadm tarball
+    // Download wadm tarball
     download_binary_from_github(&wadm_url(os, arch, version), dir, WADM_BINARY).await
 }
 
-/// Downloads the Wadm binary for the architecture and operating system of the current host machine.
+/// Downloads the wadm binary for the architecture and operating system of the current host machine.
 ///
 /// # Arguments
 ///
@@ -93,7 +89,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::download_wadm;
-/// let res = download_wadm("v2.8.4", "/tmp/").await;
+/// let res = download_wadm("v0.4.0-alpha.1", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/wadm");
 /// # }
@@ -110,179 +106,78 @@ where
     .await
 }
 
-/// Configuration for a NATS server that supports running either in "standalone" or "leaf" mode.
-/// See the respective [NatsConfig::new_standalone] and [NatsConfig::new_leaf] implementations below for more information.
-// #[derive(Clone)]
-// pub struct NatsConfig {
-//     pub host: String,
-//     pub port: u16,
-//     pub js_domain: Option<String>,
-//     pub remote_url: Option<String>,
-//     pub credentials: Option<PathBuf>,
-// }
+/// Configuration for wadm
+#[derive(Clone)]
+pub struct WadmConfig {
+    /// Whether or not to use structured log output (as JSON)
+    pub structured_logging: bool,
+    /// The NATS JetStream domain to connect to [env: WADM_JETSTREAM_DOMAIN=]
+    pub js_domain: Option<String>,
+    /// The URL of the nats server you want to connect to
+    pub nats_server_url: String,
+    // (Optional) NATS credential file to use when authenticating [env: WADM_NATS_CREDS_FILE=]
+    pub nats_credsfile: Option<PathBuf>,
+}
 
-// /// Returns a standalone NATS config with the following values:
-// /// * `host`: `127.0.0.1`
-// /// * `port`: `4222`
-// /// * `js_domain`: `Some("core")`
-// /// * `remote_url`: `None`
-// /// * `credentials`: `None`
-// impl Default for NatsConfig {
-//     fn default() -> Self {
-//         NatsConfig {
-//             host: "127.0.0.1".to_string(),
-//             port: 4222,
-//             js_domain: Some("core".to_string()),
-//             remote_url: None,
-//             credentials: None,
-//         }
-//     }
-// }
+/// Helper function to execute a wadm binary with optional arguments
+/// # Arguments
+///
+/// * `bin_path` - Path to the wadm binary to execute
+/// * `stderr` - Specify where wadm stderr logs should be written to. If logs aren't important, use std::process::Stdio::null()
+/// * `config` - Optional configuration for wadm
+pub async fn start_wadm<P, T>(bin_path: P, stderr: T, config: Option<WadmConfig>) -> Result<Child>
+where
+    P: AsRef<Path>,
+    T: Into<Stdio>,
+{
+    let pid_file = bin_path.as_ref().parent().map(|p| p.join(WADM_PID));
+    match pid_file.as_ref() {
+        Some(path) => {
+            if let Ok(previous_pid) = tokio::fs::read_to_string(&path).await {
+                //TODO: bad? What if file just isn't cleared out?
+                // probably should find another way, validate with app API
+                bail!("wadm is already running with pid {previous_pid}, aborting")
+            }
+        }
+        None => (),
+    }
 
-// impl NatsConfig {
-//     /// Instantiates config for a NATS leaf node. Leaf nodes are meant to extend
-//     /// an existing NATS infrastructure like [Synadia's NGS](https://synadia.com/ngs), but can
-//     /// also be used to extend your own NATS infrastructure. For more information,
-//     /// our [Working with Leaf Nodes](https://wasmcloud.dev/reference/lattice/leaf-nodes/) docs
-//     ///
-//     /// # Arguments
-//     /// * `host`: NATS host to listen on, e.g. `127.0.0.1`
-//     /// * `port`: NATS port to listen on, e.g. `4222`
-//     /// * `js_domain`: Jetstream domain to use, defaults to `core`. See [Configuring Jetstream](https://wasmcloud.dev/reference/lattice/jetstream/) for more information
-//     /// * `remote_url`: URL of NATS cluster to extend
-//     /// * `credentials`: Credentials to authenticate to the existing NATS cluster
-//     pub fn new_leaf(
-//         host: &str,
-//         port: u16,
-//         js_domain: Option<String>,
-//         remote_url: String,
-//         credentials: PathBuf,
-//     ) -> Self {
-//         NatsConfig {
-//             host: host.to_owned(),
-//             port,
-//             js_domain,
-//             remote_url: Some(remote_url),
-//             credentials: Some(credentials),
-//         }
-//     }
-//     /// Instantiates config for a standalone NATS server. Unless you're looking to extend
-//     /// existing NATS infrastructure, this is the preferred NATS server mode.
-//     ///
-//     /// # Arguments
-//     /// * `host`: NATS host to listen on, e.g. `127.0.0.1`
-//     /// * `port`: NATS port to listen on, e.g. `4222`
-//     /// * `js_domain`: Jetstream domain to use, defaults to `core`. See [Configuring Jetstream](https://wasmcloud.dev/reference/lattice/jetstream/) for more information
-//     pub fn new_standalone(host: &str, port: u16, js_domain: Option<String>) -> Self {
-//         if host == "0.0.0.0" {
-//             log::warn!("Listening on 0.0.0.0 is unsupported on some platforms, use 127.0.0.1 for best results")
-//         }
-//         NatsConfig {
-//             host: host.to_owned(),
-//             port,
-//             js_domain,
-//             ..Default::default()
-//         }
-//     }
+    let mut cmd = Command::new(bin_path.as_ref());
+    cmd.stderr(stderr).stdin(Stdio::null());
 
-//     async fn write_to_path<P>(self, path: P) -> Result<()>
-//     where
-//         P: AsRef<Path>,
-//     {
-//         let leafnode_section = match (self.remote_url, self.credentials) {
-//             (Some(url), Some(creds)) => format!(
-//                 r#"
-// leafnodes {{
-//     remotes = [
-//         {{
-//             url: "{}"
-//             credentials: {:?}
-//         }}
-//     ]
-// }}
-//                 "#,
-//                 url,
-//                 creds.to_string_lossy()
-//             ),
-//             _ => "".to_owned(),
-//         };
-//         let config = format!(
-//             r#"
-// jetstream {{
-//     domain={}
-// }}
-// {}
-// "#,
-//             self.js_domain.unwrap_or_else(|| "core".to_string()),
-//             leafnode_section
-//         );
-//         write(path, config).await.map_err(anyhow::Error::from)
-//     }
-// }
+    if let Some(wadm_config) = config {
+        cmd.arg("--nats-server");
+        cmd.arg(wadm_config.nats_server_url);
+        if wadm_config.structured_logging {
+            cmd.arg("--structured-logging");
+        }
+        if let Some(domain) = wadm_config.js_domain.as_ref() {
+            cmd.arg("-d");
+            cmd.arg(domain);
+        }
+        if let Some(credsfile) = wadm_config.nats_credsfile.as_ref() {
+            cmd.arg("--nats-creds-file");
+            cmd.arg(credsfile);
+        }
+    }
 
-// /// Helper function to execute a NATS server binary with required wasmCloud arguments, e.g. JetStream
-// /// # Arguments
-// ///
-// /// * `bin_path` - Path to the nats-server binary to execute
-// /// * `stderr` - Specify where NATS stderr logs should be written to. If logs aren't important, use std::process::Stdio::null()
-// /// * `config` - Configuration for the NATS server, see [NatsConfig] for options. This config file is written alongside the nats-server binary as `nats.conf`
-// pub async fn start_nats_server<P, T>(bin_path: P, stderr: T, config: NatsConfig) -> Result<Child>
-// where
-//     P: AsRef<Path>,
-//     T: Into<Stdio>,
-// {
-//     let host_addr = format!("{}:{}", config.host, config.port);
-//     // If we can connect to the local port, NATS won't be able to listen on that port
-//     if tokio::net::TcpStream::connect(&host_addr).await.is_ok() {
-//         return Err(anyhow!(
-//             "Could not start NATS server, a process is already listening on {}:{}",
-//             config.host,
-//             config.port
-//         ));
-//     }
-//     let child = if let Some(parent_path) = bin_path.as_ref().parent() {
-//         let config_path = parent_path.join(NATS_SERVER_CONF);
-//         let host = config.host.to_owned();
-//         let port = config.port;
-//         config.write_to_path(&config_path).await?;
-//         Command::new(bin_path.as_ref())
-//             .stderr(stderr)
-//             .stdin(Stdio::null())
-//             .arg("-js")
-//             .arg("--config")
-//             .arg(config_path)
-//             .arg("--addr")
-//             .arg(host)
-//             .arg("--port")
-//             .arg(port.to_string())
-//             .arg("--pid")
-//             .arg(parent_path.join(NATS_SERVER_PID))
-//             .spawn()
-//             .map_err(anyhow::Error::from)
-//     } else {
-//         Err(anyhow!(
-//             "Could not write config to disk, couldn't find download directory"
-//         ))
-//     }?;
-//     wait_for_server(&host_addr, "NATS server")
-//         .await
-//         .map(|_| child)
-// }
+    let child = cmd.spawn().map_err(anyhow::Error::from);
 
-// /// Helper function to indicate if the NATS server binary is successfully
-// /// installed in a directory
-// pub async fn is_nats_installed<P>(dir: P) -> bool
-// where
-//     P: AsRef<Path>,
-// {
-//     metadata(dir.as_ref().join(NATS_SERVER_BINARY))
-//         .await
-//         .map_or(false, |m| m.is_file())
-// }
+    let pid = child.as_ref().map(|c| c.id());
+    match (pid, pid_file) {
+        (Ok(Some(wadm_pid)), Some(pid_path)) => {
+            if let Err(e) = tokio::fs::write(pid_path, wadm_pid.to_string()).await {
+                log::warn!("Couldn't write wadm pidfile: {e}");
+            }
+        }
+        _ => (),
+    }
+    child
+}
 
-/// Helper function to determine the Wadm release path given an os/arch and version
+/// Helper function to determine the wadm release path given an os/arch and version
 fn wadm_url(os: &str, arch: &str, version: &str) -> String {
-    // Replace architecture to match Wadm release naming scheme
+    // Replace architecture to match wadm release naming scheme
     let arch = match arch {
         "x86_64" => "amd64",
         _ => arch,
@@ -292,64 +187,57 @@ fn wadm_url(os: &str, arch: &str, version: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use crate::start::is_bin_installed;
+
     use super::*;
     use anyhow::Result;
     use std::env::temp_dir;
-    use tokio::{
-        fs::{create_dir_all, remove_dir_all},
-        io::AsyncReadExt,
-    };
+    use tokio::fs::{create_dir_all, remove_dir_all};
 
     const WADM_VERSION: &str = "v0.4.0-alpha.1";
 
-    //     #[tokio::test]
-    //     async fn can_handle_missing_nats_version() -> Result<()> {
-    //         let install_dir = temp_dir().join("can_handle_missing_nats_version");
-    //         let _ = remove_dir_all(&install_dir).await;
-    //         create_dir_all(&install_dir).await?;
-    //         assert!(!is_nats_installed(&install_dir).await);
+    #[tokio::test]
+    async fn can_handle_missing_wadm_version() -> Result<()> {
+        let install_dir = temp_dir().join("can_handle_missing_wadm_version");
+        let _ = remove_dir_all(&install_dir).await;
+        create_dir_all(&install_dir).await?;
+        assert!(!is_bin_installed(&install_dir, WADM_BINARY).await);
 
-    //         let res = ensure_nats_server("v300.22.1111223", &install_dir).await;
-    //         assert!(res.is_err());
+        let major: u8 = 123;
+        let minor: u8 = 52;
+        let patch: u8 = 222;
 
-    //         let _ = remove_dir_all(install_dir).await;
-    //         Ok(())
-    //     }
+        let res = ensure_wadm(&format!("v{major}.{minor}.{patch}"), &install_dir).await;
+        assert!(res.is_err());
+
+        let _ = remove_dir_all(install_dir).await;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn can_download_and_start_wadm() -> Result<()> {
         let install_dir = temp_dir().join("can_download_and_start_wadm");
         let _ = remove_dir_all(&install_dir).await;
         create_dir_all(&install_dir).await?;
-        // assert!(!is_nats_installed(&install_dir).await);
+        assert!(!is_bin_installed(&install_dir, WADM_BINARY).await);
 
         let res = ensure_wadm(WADM_VERSION, &install_dir).await;
         assert!(res.is_ok());
-        println!("res: {:?}", res);
 
-        // let child_res =
-        //     start_nats_server(&install_dir.join(NATS_SERVER_BINARY), log_file, config).await;
-        // assert!(child_res.is_ok());
+        let log_path = install_dir.join("wadm.log");
+        let log_file = tokio::fs::File::create(&log_path).await?.into_std().await;
 
-        // // Give NATS max 5 seconds to start up
-        // for _ in 0..4 {
-        //     let log_contents = tokio::fs::read_to_string(&log_path).await?;
-        //     if log_contents.is_empty() {
-        //         println!("NATS server hasn't started up yet, waiting 1 second");
-        //         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-        //     } else {
-        //         // Give just a little bit of time for the startup logs to flow in
-        //         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        let child_res = start_wadm(&install_dir.join(WADM_BINARY), log_file, None).await;
+        assert!(child_res.is_ok());
 
-        //         assert!(log_contents.contains("Starting nats-server"));
-        //         assert!(log_contents.contains("Starting JetStream"));
-        //         assert!(log_contents.contains("Server is ready"));
-        //         break;
-        //     }
-        // }
+        // Wait for process to exit since NATS couldn't connect
+        assert!(child_res.unwrap().wait().await.is_ok());
+        let log_contents = tokio::fs::read_to_string(&log_path).await?;
+        // wadm couldn't connect to NATS but that's okay
+        assert!(log_contents.contains("Connection refused (os error 61)"));
 
         // child_res.unwrap().kill().await?;
-        // let _ = remove_dir_all(install_dir).await;
+        let _ = remove_dir_all(install_dir).await;
         Ok(())
     }
 
@@ -382,43 +270,6 @@ mod test {
     //         nats_one.unwrap().kill().await?;
     //         let _ = remove_dir_all(install_dir).await;
 
-    //         Ok(())
-    //     }
-
-    //     #[tokio::test]
-    //     async fn can_write_properly_formed_credsfile() -> Result<()> {
-    //         let install_dir = temp_dir().join("can_write_properly_formed_credsfile");
-    //         let _ = remove_dir_all(&install_dir).await;
-    //         create_dir_all(&install_dir).await?;
-    //         assert!(
-    //             !is_nats_installed(&install_dir).await,
-    //             "NATS should not be installed"
-    //         );
-
-    //         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
-    //         assert!(res.is_ok(), "NATS should be able to start");
-
-    //         let creds = dirs::home_dir().unwrap().join("nats.creds");
-    //         let config: NatsConfig = NatsConfig::new_leaf(
-    //             "127.0.0.1",
-    //             4243,
-    //             None,
-    //             "connect.ngs.global".to_string(),
-    //             creds.clone(),
-    //         );
-
-    //         config.write_to_path(creds.clone()).await?;
-
-    //         let mut credsfile = tokio::fs::File::open(creds.clone()).await?;
-    //         let mut contents = String::new();
-    //         credsfile.read_to_string(&mut contents).await?;
-
-    //         assert_eq!(contents, format!("\njetstream {{\n    domain={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", "connect.ngs.global", creds.to_string_lossy()));
-    //         // A simple check to ensure we are properly escaping quotes, this is unescaped and checks for "\\"
-    //         #[cfg(target_family = "windows")]
-    //         assert!(creds.to_string_lossy().contains("\\"));
-
-    //         let _ = remove_dir_all(install_dir).await;
     //         Ok(())
     //     }
 }

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -1,0 +1,424 @@
+use crate::start::wait_for_server;
+use anyhow::{anyhow, Result};
+use async_compression::tokio::bufread::GzipDecoder;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::{ffi::OsStr, io::Cursor};
+use tokio::fs::{create_dir_all, metadata, write, File};
+use tokio::process::{Child, Command};
+use tokio_stream::StreamExt;
+use tokio_tar::Archive;
+
+use super::download_binary_from_github;
+
+const WADM_GITHUB_RELEASE_URL: &str = "https://github.com/wasmcloud/wadm/releases/download";
+#[cfg(target_family = "unix")]
+pub const WADM_BINARY: &str = "wadm";
+#[cfg(target_family = "windows")]
+pub const WADM_BINARY: &str = "wadm.exe";
+
+/// Downloads the Wadm binary for the architecture and operating system of the current host machine.
+///
+/// # Arguments
+///
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `dir` - Where to download the `wadm` binary to
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use wash_lib::start::ensure_wadm;
+/// let res = ensure_wadm("v0.4.0-alpha.1", "/tmp/").await;
+/// assert!(res.is_ok());
+/// assert!(res.unwrap().to_string_lossy() == "/tmp/wadm");
+/// # }
+/// ```
+pub async fn ensure_wadm<P>(version: &str, dir: P) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    ensure_wadm_for_os_arch_pair(std::env::consts::OS, std::env::consts::ARCH, version, dir).await
+}
+
+/// Ensures the `wadm` binary is installed, returning the path to the executable early if it exists or
+/// downloading the specified GitHub release version of wadm from <https://github.com/wasmcloud/wadm/releases/>
+/// and unpacking the binary for a specified OS/ARCH pair to a directory. Returns the path to the Wadm executable.
+/// # Arguments
+///
+/// * `os` - Specifies the operating system of the binary to download, e.g. `linux`
+/// * `arch` - Specifies the architecture of the binary to download, e.g. `amd64`
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `dir` - Where to download the `wadm` binary to
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use wash_lib::start::ensure_wadm_for_os_arch_pair;
+/// let os = std::env::consts::OS;
+/// let arch = std::env::consts::ARCH;
+/// let res = ensure_wadm_for_os_arch_pair(os, arch, "v0.4.0-alpha.1", "/tmp/").await;
+/// assert!(res.is_ok());
+/// assert!(res.unwrap().to_string_lossy() == "/tmp/wadm");
+/// # }
+/// ```
+pub async fn ensure_wadm_for_os_arch_pair<P>(
+    os: &str,
+    arch: &str,
+    version: &str,
+    dir: P,
+) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    let wadm_bin_path = dir.as_ref().join(WADM_BINARY);
+    if let Ok(_md) = metadata(&wadm_bin_path).await {
+        // Wadm already exists, return early
+        return Ok(wadm_bin_path);
+    }
+    // Download Wadm tarball
+    download_binary_from_github(&wadm_url(os, arch, version), dir, WADM_BINARY).await
+}
+
+/// Downloads the Wadm binary for the architecture and operating system of the current host machine.
+///
+/// # Arguments
+///
+/// * `version` - Specifies the version of the binary to download in the form of `vX.Y.Z`
+/// * `dir` - Where to download the `wadm` binary to
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use wash_lib::start::download_wadm;
+/// let res = download_wadm("v2.8.4", "/tmp/").await;
+/// assert!(res.is_ok());
+/// assert!(res.unwrap().to_string_lossy() == "/tmp/wadm");
+/// # }
+/// ```
+pub async fn download_wadm<P>(version: &str, dir: P) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    download_binary_from_github(
+        &wadm_url(std::env::consts::OS, std::env::consts::ARCH, version),
+        dir,
+        WADM_BINARY,
+    )
+    .await
+}
+
+/// Configuration for a NATS server that supports running either in "standalone" or "leaf" mode.
+/// See the respective [NatsConfig::new_standalone] and [NatsConfig::new_leaf] implementations below for more information.
+// #[derive(Clone)]
+// pub struct NatsConfig {
+//     pub host: String,
+//     pub port: u16,
+//     pub js_domain: Option<String>,
+//     pub remote_url: Option<String>,
+//     pub credentials: Option<PathBuf>,
+// }
+
+// /// Returns a standalone NATS config with the following values:
+// /// * `host`: `127.0.0.1`
+// /// * `port`: `4222`
+// /// * `js_domain`: `Some("core")`
+// /// * `remote_url`: `None`
+// /// * `credentials`: `None`
+// impl Default for NatsConfig {
+//     fn default() -> Self {
+//         NatsConfig {
+//             host: "127.0.0.1".to_string(),
+//             port: 4222,
+//             js_domain: Some("core".to_string()),
+//             remote_url: None,
+//             credentials: None,
+//         }
+//     }
+// }
+
+// impl NatsConfig {
+//     /// Instantiates config for a NATS leaf node. Leaf nodes are meant to extend
+//     /// an existing NATS infrastructure like [Synadia's NGS](https://synadia.com/ngs), but can
+//     /// also be used to extend your own NATS infrastructure. For more information,
+//     /// our [Working with Leaf Nodes](https://wasmcloud.dev/reference/lattice/leaf-nodes/) docs
+//     ///
+//     /// # Arguments
+//     /// * `host`: NATS host to listen on, e.g. `127.0.0.1`
+//     /// * `port`: NATS port to listen on, e.g. `4222`
+//     /// * `js_domain`: Jetstream domain to use, defaults to `core`. See [Configuring Jetstream](https://wasmcloud.dev/reference/lattice/jetstream/) for more information
+//     /// * `remote_url`: URL of NATS cluster to extend
+//     /// * `credentials`: Credentials to authenticate to the existing NATS cluster
+//     pub fn new_leaf(
+//         host: &str,
+//         port: u16,
+//         js_domain: Option<String>,
+//         remote_url: String,
+//         credentials: PathBuf,
+//     ) -> Self {
+//         NatsConfig {
+//             host: host.to_owned(),
+//             port,
+//             js_domain,
+//             remote_url: Some(remote_url),
+//             credentials: Some(credentials),
+//         }
+//     }
+//     /// Instantiates config for a standalone NATS server. Unless you're looking to extend
+//     /// existing NATS infrastructure, this is the preferred NATS server mode.
+//     ///
+//     /// # Arguments
+//     /// * `host`: NATS host to listen on, e.g. `127.0.0.1`
+//     /// * `port`: NATS port to listen on, e.g. `4222`
+//     /// * `js_domain`: Jetstream domain to use, defaults to `core`. See [Configuring Jetstream](https://wasmcloud.dev/reference/lattice/jetstream/) for more information
+//     pub fn new_standalone(host: &str, port: u16, js_domain: Option<String>) -> Self {
+//         if host == "0.0.0.0" {
+//             log::warn!("Listening on 0.0.0.0 is unsupported on some platforms, use 127.0.0.1 for best results")
+//         }
+//         NatsConfig {
+//             host: host.to_owned(),
+//             port,
+//             js_domain,
+//             ..Default::default()
+//         }
+//     }
+
+//     async fn write_to_path<P>(self, path: P) -> Result<()>
+//     where
+//         P: AsRef<Path>,
+//     {
+//         let leafnode_section = match (self.remote_url, self.credentials) {
+//             (Some(url), Some(creds)) => format!(
+//                 r#"
+// leafnodes {{
+//     remotes = [
+//         {{
+//             url: "{}"
+//             credentials: {:?}
+//         }}
+//     ]
+// }}
+//                 "#,
+//                 url,
+//                 creds.to_string_lossy()
+//             ),
+//             _ => "".to_owned(),
+//         };
+//         let config = format!(
+//             r#"
+// jetstream {{
+//     domain={}
+// }}
+// {}
+// "#,
+//             self.js_domain.unwrap_or_else(|| "core".to_string()),
+//             leafnode_section
+//         );
+//         write(path, config).await.map_err(anyhow::Error::from)
+//     }
+// }
+
+// /// Helper function to execute a NATS server binary with required wasmCloud arguments, e.g. JetStream
+// /// # Arguments
+// ///
+// /// * `bin_path` - Path to the nats-server binary to execute
+// /// * `stderr` - Specify where NATS stderr logs should be written to. If logs aren't important, use std::process::Stdio::null()
+// /// * `config` - Configuration for the NATS server, see [NatsConfig] for options. This config file is written alongside the nats-server binary as `nats.conf`
+// pub async fn start_nats_server<P, T>(bin_path: P, stderr: T, config: NatsConfig) -> Result<Child>
+// where
+//     P: AsRef<Path>,
+//     T: Into<Stdio>,
+// {
+//     let host_addr = format!("{}:{}", config.host, config.port);
+//     // If we can connect to the local port, NATS won't be able to listen on that port
+//     if tokio::net::TcpStream::connect(&host_addr).await.is_ok() {
+//         return Err(anyhow!(
+//             "Could not start NATS server, a process is already listening on {}:{}",
+//             config.host,
+//             config.port
+//         ));
+//     }
+//     let child = if let Some(parent_path) = bin_path.as_ref().parent() {
+//         let config_path = parent_path.join(NATS_SERVER_CONF);
+//         let host = config.host.to_owned();
+//         let port = config.port;
+//         config.write_to_path(&config_path).await?;
+//         Command::new(bin_path.as_ref())
+//             .stderr(stderr)
+//             .stdin(Stdio::null())
+//             .arg("-js")
+//             .arg("--config")
+//             .arg(config_path)
+//             .arg("--addr")
+//             .arg(host)
+//             .arg("--port")
+//             .arg(port.to_string())
+//             .arg("--pid")
+//             .arg(parent_path.join(NATS_SERVER_PID))
+//             .spawn()
+//             .map_err(anyhow::Error::from)
+//     } else {
+//         Err(anyhow!(
+//             "Could not write config to disk, couldn't find download directory"
+//         ))
+//     }?;
+//     wait_for_server(&host_addr, "NATS server")
+//         .await
+//         .map(|_| child)
+// }
+
+// /// Helper function to indicate if the NATS server binary is successfully
+// /// installed in a directory
+// pub async fn is_nats_installed<P>(dir: P) -> bool
+// where
+//     P: AsRef<Path>,
+// {
+//     metadata(dir.as_ref().join(NATS_SERVER_BINARY))
+//         .await
+//         .map_or(false, |m| m.is_file())
+// }
+
+/// Helper function to determine the Wadm release path given an os/arch and version
+fn wadm_url(os: &str, arch: &str, version: &str) -> String {
+    // Replace architecture to match Wadm release naming scheme
+    let arch = match arch {
+        "x86_64" => "amd64",
+        _ => arch,
+    };
+    format!("{WADM_GITHUB_RELEASE_URL}/{version}/wadm-{version}-{os}-{arch}.tar.gz")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+    use std::env::temp_dir;
+    use tokio::{
+        fs::{create_dir_all, remove_dir_all},
+        io::AsyncReadExt,
+    };
+
+    const WADM_VERSION: &str = "v0.4.0-alpha.1";
+
+    //     #[tokio::test]
+    //     async fn can_handle_missing_nats_version() -> Result<()> {
+    //         let install_dir = temp_dir().join("can_handle_missing_nats_version");
+    //         let _ = remove_dir_all(&install_dir).await;
+    //         create_dir_all(&install_dir).await?;
+    //         assert!(!is_nats_installed(&install_dir).await);
+
+    //         let res = ensure_nats_server("v300.22.1111223", &install_dir).await;
+    //         assert!(res.is_err());
+
+    //         let _ = remove_dir_all(install_dir).await;
+    //         Ok(())
+    //     }
+
+    #[tokio::test]
+    async fn can_download_and_start_wadm() -> Result<()> {
+        let install_dir = temp_dir().join("can_download_and_start_wadm");
+        let _ = remove_dir_all(&install_dir).await;
+        create_dir_all(&install_dir).await?;
+        // assert!(!is_nats_installed(&install_dir).await);
+
+        let res = ensure_wadm(WADM_VERSION, &install_dir).await;
+        assert!(res.is_ok());
+        println!("res: {:?}", res);
+
+        // let child_res =
+        //     start_nats_server(&install_dir.join(NATS_SERVER_BINARY), log_file, config).await;
+        // assert!(child_res.is_ok());
+
+        // // Give NATS max 5 seconds to start up
+        // for _ in 0..4 {
+        //     let log_contents = tokio::fs::read_to_string(&log_path).await?;
+        //     if log_contents.is_empty() {
+        //         println!("NATS server hasn't started up yet, waiting 1 second");
+        //         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        //     } else {
+        //         // Give just a little bit of time for the startup logs to flow in
+        //         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+
+        //         assert!(log_contents.contains("Starting nats-server"));
+        //         assert!(log_contents.contains("Starting JetStream"));
+        //         assert!(log_contents.contains("Server is ready"));
+        //         break;
+        //     }
+        // }
+
+        // child_res.unwrap().kill().await?;
+        // let _ = remove_dir_all(install_dir).await;
+        Ok(())
+    }
+
+    //     #[tokio::test]
+    //     async fn can_gracefully_fail_running_nats() -> Result<()> {
+    //         let install_dir = temp_dir().join("can_gracefully_fail_running_nats");
+    //         let _ = remove_dir_all(&install_dir).await;
+    //         create_dir_all(&install_dir).await?;
+    //         assert!(!is_nats_installed(&install_dir).await);
+
+    //         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
+    //         assert!(res.is_ok());
+
+    //         let config = NatsConfig::new_standalone("127.0.0.1", 10003, Some("extender".to_string()));
+    //         let nats_one = start_nats_server(
+    //             &install_dir.join(NATS_SERVER_BINARY),
+    //             std::process::Stdio::null(),
+    //             config.clone(),
+    //         )
+    //         .await;
+    //         assert!(nats_one.is_ok());
+
+    //         // Give NATS a few seconds to start up and listen
+    //         tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+    //         let log_path = install_dir.join("nats.log");
+    //         let log = std::fs::File::create(&log_path)?;
+    //         let nats_two = start_nats_server(&install_dir.join(NATS_SERVER_BINARY), log, config).await;
+    //         assert!(nats_two.is_err());
+
+    //         nats_one.unwrap().kill().await?;
+    //         let _ = remove_dir_all(install_dir).await;
+
+    //         Ok(())
+    //     }
+
+    //     #[tokio::test]
+    //     async fn can_write_properly_formed_credsfile() -> Result<()> {
+    //         let install_dir = temp_dir().join("can_write_properly_formed_credsfile");
+    //         let _ = remove_dir_all(&install_dir).await;
+    //         create_dir_all(&install_dir).await?;
+    //         assert!(
+    //             !is_nats_installed(&install_dir).await,
+    //             "NATS should not be installed"
+    //         );
+
+    //         let res = ensure_nats_server(NATS_SERVER_VERSION, &install_dir).await;
+    //         assert!(res.is_ok(), "NATS should be able to start");
+
+    //         let creds = dirs::home_dir().unwrap().join("nats.creds");
+    //         let config: NatsConfig = NatsConfig::new_leaf(
+    //             "127.0.0.1",
+    //             4243,
+    //             None,
+    //             "connect.ngs.global".to_string(),
+    //             creds.clone(),
+    //         );
+
+    //         config.write_to_path(creds.clone()).await?;
+
+    //         let mut credsfile = tokio::fs::File::open(creds.clone()).await?;
+    //         let mut contents = String::new();
+    //         credsfile.read_to_string(&mut contents).await?;
+
+    //         assert_eq!(contents, format!("\njetstream {{\n    domain={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", "connect.ngs.global", creds.to_string_lossy()));
+    //         // A simple check to ensure we are properly escaping quotes, this is unescaped and checks for "\\"
+    //         #[cfg(target_family = "windows")]
+    //         assert!(creds.to_string_lossy().contains("\\"));
+
+    //         let _ = remove_dir_all(install_dir).await;
+    //         Ok(())
+    //     }
+}

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -483,9 +483,7 @@ mod test {
         assert!(ensure_nats_server(NATS_SERVER_VERSION, &install_dir)
             .await
             .is_ok());
-        assert!(
-            is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
-        );
+        assert!(is_bin_installed(&install_dir, NATS_SERVER_BINARY).await);
         let config = NatsConfig::new_standalone("127.0.0.1", nats_port, None);
         let mut nats_child = start_nats_server(
             install_dir.join(NATS_SERVER_BINARY),

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -340,7 +340,7 @@ mod test {
     use super::{check_version, ensure_wasmcloud, wasmcloud_url};
     use crate::start::{
         ensure_nats_server, ensure_wasmcloud_for_os_arch_pair, find_wasmcloud_binary,
-        is_nats_installed, start_nats_server, start_wasmcloud_host, NatsConfig, NATS_SERVER_BINARY,
+        is_bin_installed, start_nats_server, start_wasmcloud_host, NatsConfig, NATS_SERVER_BINARY,
     };
     use reqwest::StatusCode;
     use std::{collections::HashMap, env::temp_dir};
@@ -483,7 +483,9 @@ mod test {
         assert!(ensure_nats_server(NATS_SERVER_VERSION, &install_dir)
             .await
             .is_ok());
-        assert!(is_nats_installed(&install_dir).await);
+        assert!(
+            is_bin_installed(&install_dir, &std::path::PathBuf::from(NATS_SERVER_BINARY)).await
+        );
         let config = NatsConfig::new_standalone("127.0.0.1", nats_port, None);
         let mut nats_child = start_nats_server(
             install_dir.join(NATS_SERVER_BINARY),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -108,10 +108,6 @@ pub(crate) struct DeployCommand {
     #[clap(name = "version")]
     version: Option<String>,
 
-    /// Force deployment of this manifest, overwriting the existing version if present
-    #[clap(short = 'f', long = "force")]
-    force: bool,
-
     #[clap(flatten)]
     opts: ConnectionOpts,
 }
@@ -240,25 +236,6 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
 
         match put_res.result {
             PutResult::Created | PutResult::NewVersion => put_res.name,
-            // TODO: Might be better to have a `PutVersion::AlreadyExists` variant
-            PutResult::Error if cmd.force => {
-                // TODO: Care about this
-                let delete_res = delete_model_version(DeleteCommand {
-                    //TODO: Name and version here are empty, need that info
-                    model_name: put_res.name.to_owned(),
-                    version: Some(put_res.current_version.to_owned()),
-                    delete_all: false,
-                    opts: cmd.opts.to_owned(),
-                })
-                .await?;
-                let put_res = put_model(PutCommand {
-                    source: PathBuf::from(&cmd.model_name),
-                    opts: cmd.opts.to_owned(),
-                })
-                .await?;
-
-                put_res.name
-            }
             _ => bail!("Could not put manifest to deploy {}", put_res.message),
         }
     } else {
@@ -369,7 +346,6 @@ fn show_del_results(results: DeleteModelResponse) -> CommandOutput {
 fn show_deploy_results(results: DeployModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("acknowledged".to_string(), json!(results));
-    // TODO: more info here, wadm just returns "Deployed model"
     CommandOutput::new(results.message, map)
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,16 +1,15 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Result};
-use async_nats::{Client, Message};
+use async_nats::Client;
 use clap::{Args, Subcommand};
 use serde_json::json;
 use wadm::server::{
-    DeleteModelRequest, DeleteModelResponse, DeployModelRequest, DeployModelResponse,
-    GetModelRequest, GetModelResponse, GetResult, ModelSummary, PutModelResponse, PutResult,
-    UndeployModelRequest, VersionResponse,
+    DeleteModelResponse, DeployModelResponse, GetModelResponse, GetResult, ModelSummary,
+    PutModelResponse, PutResult, VersionResponse,
 };
 use wash_lib::cli::{CommandOutput, OutputKind};
-use wash_lib::config::{DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
+use wash_lib::config::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use wash_lib::context::{
     fs::{load_context, ContextDir},
     ContextManager,
@@ -22,36 +21,7 @@ use crate::{
     ctx::{context_dir, ensure_host_config_context},
 };
 
-const WADM_API_PREFIX: &str = "wadm.api";
-
 mod output;
-
-/// A helper enum to easily refer to model operations and then use the
-/// [ToString](ToString) implementation for NATS topic formation
-pub(crate) enum ModelOperation {
-    List,
-    Get,
-    History,
-    Delete,
-    Put,
-    Deploy,
-    Undeploy,
-}
-
-impl ToString for ModelOperation {
-    fn to_string(&self) -> String {
-        match self {
-            ModelOperation::List => "list",
-            ModelOperation::Get => "get",
-            ModelOperation::History => "versions",
-            ModelOperation::Delete => "del",
-            ModelOperation::Put => "put",
-            ModelOperation::Deploy => "deploy",
-            ModelOperation::Undeploy => "undeploy",
-        }
-        .to_string()
-    }
-}
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum AppCliCommand {
@@ -212,26 +182,29 @@ pub(crate) async fn handle_command(
 }
 
 async fn undeploy_model(cmd: UndeployCommand) -> Result<DeployModelResponse> {
-    let res = model_request(
-        cmd.opts,
-        ModelOperation::Undeploy,
-        Some(&cmd.model_name),
-        serde_json::to_vec(&UndeployModelRequest {
-            non_destructive: cmd.non_destructive,
-        })?,
-    )
-    .await?;
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
 
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::undeploy_model(
+        &client,
+        lattice_prefix,
+        &cmd.model_name,
+        cmd.non_destructive,
+    )
+    .await
 }
 
 async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
+
     // If the model name is a file on disk, apply it and then deploy
-    let name = if tokio::fs::metadata(&cmd.model_name).await.is_ok() {
-        let put_res = put_model(PutCommand {
-            source: PathBuf::from(&cmd.model_name),
-            opts: cmd.opts.to_owned(),
-        })
+    let model_name = if tokio::fs::metadata(&cmd.model_name).await.is_ok() {
+        let put_res = wash_lib::app::put_model(
+            &client,
+            lattice_prefix.clone(),
+            &tokio::fs::read_to_string(&cmd.model_name).await?,
+        )
         .await?;
 
         match put_res.result {
@@ -242,70 +215,54 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
         cmd.model_name
     };
 
-    let res = model_request(
-        cmd.opts,
-        ModelOperation::Deploy,
-        Some(&name),
-        serde_json::to_vec(&DeployModelRequest {
-            version: cmd.version,
-        })?,
-    )
-    .await?;
-
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::deploy_model(&client, lattice_prefix, &model_name, cmd.version).await
 }
 
 async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
-    let raw = std::fs::read_to_string(&cmd.source)?;
-    let res = model_request(cmd.opts, ModelOperation::Put, None, raw.as_bytes().to_vec()).await?;
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
+
+    wash_lib::app::put_model(
+        &client,
+        lattice_prefix,
+        &tokio::fs::read_to_string(&cmd.source).await?,
+    )
+    .await
 }
 
 async fn get_model_history(cmd: HistoryCommand) -> Result<VersionResponse> {
-    let res = model_request(
-        cmd.opts,
-        ModelOperation::History,
-        Some(&cmd.model_name),
-        vec![],
-    )
-    .await?;
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
 
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::get_model_history(&client, lattice_prefix, &cmd.model_name).await
 }
 
 async fn get_model_details(cmd: GetCommand) -> Result<GetModelResponse> {
-    let res = model_request(
-        cmd.opts,
-        ModelOperation::Get,
-        Some(&cmd.model_name),
-        serde_json::to_vec(&GetModelRequest {
-            version: cmd.version,
-        })?,
-    )
-    .await?;
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
 
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::get_model_details(&client, lattice_prefix, &cmd.model_name, cmd.version).await
 }
 
 async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse> {
-    let res = model_request(
-        cmd.opts,
-        ModelOperation::Delete,
-        Some(&cmd.model_name),
-        serde_json::to_vec(&DeleteModelRequest {
-            version: cmd.version.unwrap_or_default(),
-            delete_all: cmd.delete_all,
-        })?,
-    )
-    .await?;
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
 
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::delete_model_version(
+        &client,
+        lattice_prefix,
+        &cmd.model_name,
+        cmd.version,
+        cmd.delete_all,
+    )
+    .await
 }
 
 async fn get_models(cmd: ListCommand) -> Result<Vec<ModelSummary>> {
-    let res = model_request(cmd.opts, ModelOperation::List, None, vec![]).await?;
+    let lattice_prefix = cmd.opts.lattice_prefix.clone();
+    let (client, _timeout) = nats_client_from_opts(cmd.opts).await?;
 
-    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+    wash_lib::app::get_models(&client, lattice_prefix).await
 }
 
 fn list_models_output(results: Vec<ModelSummary>) -> CommandOutput {
@@ -406,32 +363,4 @@ async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Client, Duration
     let timeout = Duration::from_millis(opts.timeout_ms);
 
     Ok((nc, timeout))
-}
-
-/// Helper function to make a NATS request given connection options, an operation, optional name, and bytes
-async fn model_request(
-    opts: ConnectionOpts,
-    operation: ModelOperation,
-    object_name: Option<&str>,
-    bytes: Vec<u8>,
-) -> Result<Message> {
-    let (nc, timeout) = nats_client_from_opts(opts.clone()).await?;
-
-    // Topic is of the form of wadm.api.<lattice>.<category>.<operation>.<OPTIONAL: object_name>
-    // We let callers of this function dictate the topic after the prefix + lattice
-    let topic = format!(
-        "{WADM_API_PREFIX}.{}.model.{}{}",
-        opts.lattice_prefix
-            .unwrap_or_else(|| DEFAULT_LATTICE_PREFIX.to_string()),
-        operation.to_string(),
-        object_name
-            .map(|name| format!(".{name}"))
-            .unwrap_or_default()
-    );
-
-    match tokio::time::timeout(timeout, nc.request(topic, bytes.into())).await {
-        Ok(Ok(res)) => Ok(res),
-        Ok(Err(e)) => bail!("Error making model request: {}", e),
-        Err(e) => bail!("model_request timed out:  {}", e),
-    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,12 +1,16 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Result};
-use async_nats::Client;
+use async_nats::{Client, Message};
 use clap::{Args, Subcommand};
-use serde::{Deserialize, Serialize};
 use serde_json::json;
+use wadm::server::{
+    DeleteModelRequest, DeleteModelResponse, DeployModelRequest, DeployModelResponse,
+    GetModelRequest, GetModelResponse, GetResult, ModelSummary, PutModelResponse, PutResult,
+    UndeployModelRequest, VersionResponse,
+};
 use wash_lib::cli::{CommandOutput, OutputKind};
-use wash_lib::config::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
+use wash_lib::config::{DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use wash_lib::context::{
     fs::{load_context, ContextDir},
     ContextManager,
@@ -18,7 +22,36 @@ use crate::{
     ctx::{context_dir, ensure_host_config_context},
 };
 
+const WADM_API_PREFIX: &str = "wadm.api";
+
 mod output;
+
+/// A helper enum to easily refer to model operations and then use the
+/// [ToString](ToString) implementation for NATS topic formation
+pub(crate) enum ModelOperation {
+    List,
+    Get,
+    History,
+    Delete,
+    Put,
+    Deploy,
+    Undeploy,
+}
+
+impl ToString for ModelOperation {
+    fn to_string(&self) -> String {
+        match self {
+            ModelOperation::List => "list",
+            ModelOperation::Get => "get",
+            ModelOperation::History => "versions",
+            ModelOperation::Delete => "del",
+            ModelOperation::Put => "put",
+            ModelOperation::Deploy => "deploy",
+            ModelOperation::Undeploy => "undeploy",
+        }
+        .to_string()
+    }
+}
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum AppCliCommand {
@@ -50,11 +83,16 @@ pub(crate) struct ListCommand {
     #[clap(flatten)]
     opts: ConnectionOpts,
 }
+
 #[derive(Args, Debug, Clone)]
 pub(crate) struct UndeployCommand {
     /// Name of the app specification to undeploy
     #[clap(name = "name")]
     model_name: String,
+
+    /// Whether or not to delete resources that are undeployed. Defaults to remove managed resources
+    #[clap(long = "non-destructive")]
+    non_destructive: bool,
 
     #[clap(flatten)]
     opts: ConnectionOpts,
@@ -66,9 +104,13 @@ pub(crate) struct DeployCommand {
     #[clap(name = "name")]
     model_name: String,
 
-    /// Version of the app specification to deploy
+    /// Version of the app specification to deploy, defaults to the latest created version
     #[clap(name = "version")]
-    version: String,
+    version: Option<String>,
+
+    /// Force deployment of this manifest, overwriting the existing version if present
+    #[clap(short = 'f', long = "force")]
+    force: bool,
 
     #[clap(flatten)]
     opts: ConnectionOpts,
@@ -83,6 +125,10 @@ pub(crate) struct DeleteCommand {
     /// Version of the app specification to delete
     #[clap(name = "version")]
     version: String,
+
+    #[clap(long = "delete-all")]
+    /// Whether or not to delete all app versions, defaults to `false`
+    delete_all: bool,
 
     #[clap(flatten)]
     opts: ConnectionOpts,
@@ -103,9 +149,9 @@ pub(crate) struct GetCommand {
     #[clap(name = "name")]
     model_name: String,
 
-    /// The version of the app spec to retrieve
+    /// The version of the app spec to retrieve. If left empty, retrieves the latest version
     #[clap(name = "version")]
-    version: String,
+    version: Option<String>,
 
     #[clap(flatten)]
     opts: ConnectionOpts,
@@ -136,8 +182,7 @@ pub(crate) async fn handle_command(
         Get(cmd) => {
             sp.update_spinner_message("Querying app spec details ... ".to_string());
             let results = get_model_details(cmd).await?;
-            let (raw, vetted) = write_model(results.clone())?;
-            show_model_output(raw, vetted, results)
+            show_model_output(results)
         }
         History(cmd) => {
             sp.update_spinner_message("Querying app revision history ... ".to_string());
@@ -170,93 +215,122 @@ pub(crate) async fn handle_command(
     Ok(out)
 }
 
-async fn undeploy_model(cmd: UndeployCommand) -> Result<bool> {
-    let res = json_request(cmd.opts, &["undeploy", &cmd.model_name], json!({})).await?;
-
-    Ok(res.is_some())
-}
-
-async fn deploy_model(cmd: DeployCommand) -> Result<bool> {
-    let res = json_request(
+async fn undeploy_model(cmd: UndeployCommand) -> Result<DeployModelResponse> {
+    let res = model_request(
         cmd.opts,
-        &["deploy", &cmd.model_name],
-        json!({
-            "version": cmd.version
-        }),
+        ModelOperation::Undeploy,
+        Some(&cmd.model_name),
+        serde_json::to_vec(&UndeployModelRequest {
+            non_destructive: cmd.non_destructive,
+        })?,
     )
     .await?;
 
-    if let Some(v) = res {
-        Ok(v["acknowledged"].as_bool().unwrap_or(false))
-    } else {
-        bail!("Failed to deploy application")
-    }
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
 }
 
-async fn put_model(cmd: PutCommand) -> Result<PutReply> {
+async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
+    // If the model name is a file on disk, apply it and then deploy
+    let name = if tokio::fs::metadata(&cmd.model_name).await.is_ok() {
+        let put_res = put_model(PutCommand {
+            source: PathBuf::from(&cmd.model_name),
+            opts: cmd.opts.to_owned(),
+        })
+        .await?;
+
+        println!("res: {:?}", put_res);
+
+        match put_res.result {
+            PutResult::Created | PutResult::NewVersion => put_res.name,
+            // TODO: Might be better to have a `PutVersion::AlreadyExists` variant
+            PutResult::Error if cmd.force => {
+                // TODO: Care about this
+                let delete_res = delete_model_version(DeleteCommand {
+                    //TODO: Name and version here are empty, need that info
+                    model_name: put_res.name.to_owned(),
+                    version: put_res.current_version.to_owned(),
+                    delete_all: false,
+                    opts: cmd.opts.to_owned(),
+                })
+                .await?;
+                let put_res = put_model(PutCommand {
+                    source: PathBuf::from(&cmd.model_name),
+                    opts: cmd.opts.to_owned(),
+                })
+                .await?;
+
+                put_res.name
+            }
+            _ => bail!("Could not put manifest to deploy {}", put_res.message),
+        }
+    } else {
+        cmd.model_name
+    };
+
+    let res = model_request(
+        cmd.opts,
+        ModelOperation::Deploy,
+        Some(&name),
+        serde_json::to_vec(&DeployModelRequest {
+            version: cmd.version,
+        })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
     let raw = std::fs::read_to_string(&cmd.source)?;
-    let res = raw_request(cmd.opts, &["put"], raw.as_bytes()).await?;
-    if let Some(v) = res {
-        let r: PutReply = serde_json::from_value(v)?;
-        Ok(r)
-    } else {
-        bail!("Failed to put app specification");
-    }
+    let res = model_request(cmd.opts, ModelOperation::Put, None, raw.as_bytes().to_vec()).await?;
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
 }
 
-async fn get_model_history(cmd: HistoryCommand) -> Result<Vec<ModelRevision>> {
-    let res = json_request(cmd.opts, &["versions", &cmd.model_name], json!({})).await?;
-    if let Some(v) = res {
-        let revs: Vec<ModelRevision> = serde_json::from_value(v)?;
-        Ok(revs)
-    } else {
-        bail!("Failed to get model history");
-    }
-}
-
-async fn get_model_details(cmd: GetCommand) -> Result<ModelDetails> {
-    let res = json_request(
+async fn get_model_history(cmd: HistoryCommand) -> Result<VersionResponse> {
+    let res = model_request(
         cmd.opts,
-        &["get", &cmd.model_name],
-        json!({
-            "version": cmd.version
-        }),
-    )
-    .await?;
-    if let Some(v) = res {
-        let md: ModelDetails = serde_json::from_value(v)?;
-        Ok(md)
-    } else {
-        bail!("Failed to obtain reply from wadm");
-    }
-}
-
-async fn delete_model_version(cmd: DeleteCommand) -> Result<bool> {
-    let res = json_request(
-        cmd.opts,
-        &["del", &cmd.model_name],
-        json!({
-            "version": cmd.version
-        }),
+        ModelOperation::History,
+        Some(&cmd.model_name),
+        vec![],
     )
     .await?;
 
-    if res.is_none() {
-        Ok(false)
-    } else {
-        Ok(true)
-    }
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+async fn get_model_details(cmd: GetCommand) -> Result<GetModelResponse> {
+    let res = model_request(
+        cmd.opts,
+        ModelOperation::Get,
+        Some(&cmd.model_name),
+        serde_json::to_vec(&GetModelRequest {
+            version: cmd.version,
+        })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
+}
+
+async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse> {
+    let res = model_request(
+        cmd.opts,
+        ModelOperation::Delete,
+        Some(&cmd.model_name),
+        serde_json::to_vec(&DeleteModelRequest {
+            version: cmd.version,
+            delete_all: cmd.delete_all,
+        })?,
+    )
+    .await?;
+
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
 }
 
 async fn get_models(cmd: ListCommand) -> Result<Vec<ModelSummary>> {
-    let res = json_request(cmd.opts, &["list"], json!({})).await?;
+    let res = model_request(cmd.opts, ModelOperation::List, None, vec![]).await?;
 
-    if let Some(v) = res {
-        let v: Vec<ModelSummary> = serde_json::from_value(v)?;
-        Ok(v)
-    } else {
-        bail!("Failed to obtain reply from wadm");
-    }
+    serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
 }
 
 fn list_models_output(results: Vec<ModelSummary>) -> CommandOutput {
@@ -265,81 +339,46 @@ fn list_models_output(results: Vec<ModelSummary>) -> CommandOutput {
     CommandOutput::new(output::list_models_table(results), map)
 }
 
-fn show_model_output(raw: PathBuf, vetted: PathBuf, md: ModelDetails) -> CommandOutput {
+fn show_model_output(md: GetModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("model".to_string(), json!(md));
-    CommandOutput::new(output::show_model_details(raw, vetted), map)
+    if md.result == GetResult::Success {
+        let yaml = serde_yaml::to_string(&md.manifest).unwrap();
+        CommandOutput::new(yaml, map)
+    } else {
+        CommandOutput::new(md.message, map)
+    }
 }
 
-fn show_put_results(results: PutReply) -> CommandOutput {
+fn show_put_results(results: PutModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("results".to_string(), json!(results));
-    CommandOutput::new(
-        format!(
-            "App specification {} v{} stored",
-            results.name, results.current_version
-        ),
-        map,
-    )
+    CommandOutput::new(results.message, map)
 }
 
-fn show_undeploy_results(results: bool) -> CommandOutput {
+fn show_undeploy_results(results: DeployModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("results".to_string(), json!(results));
-    CommandOutput::new(
-        if results {
-            "Undeploy request acknowledged"
-        } else {
-            "Undeploy request not acknowledged"
-        },
-        map,
-    )
+    CommandOutput::new(results.message, map)
 }
 
-fn show_del_results(results: bool) -> CommandOutput {
+fn show_del_results(results: DeleteModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("deleted".to_string(), json!(results));
-    CommandOutput::new(
-        if results {
-            "Model version deleted"
-        } else {
-            "Model version was not deleted"
-        },
-        map,
-    )
+    CommandOutput::new(results.message, map)
 }
 
-fn show_deploy_results(results: bool) -> CommandOutput {
+fn show_deploy_results(results: DeployModelResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("acknowledged".to_string(), json!(results));
-    CommandOutput::new(
-        if results {
-            "App deployment request acknowledged".to_string()
-        } else {
-            "App deployment request failed".to_string()
-        },
-        map,
-    )
+    // TODO: more info here, wadm just returns "Deployed model"
+    CommandOutput::new(results.message, map)
 }
 
-fn show_model_history(results: Vec<ModelRevision>) -> CommandOutput {
+fn show_model_history(results: VersionResponse) -> CommandOutput {
     let mut map = HashMap::new();
     map.insert("revisions".to_string(), json!(results));
-    CommandOutput::new(output::list_revisions_table(results), map)
-}
-
-fn write_model(model: ModelDetails) -> Result<(PathBuf, PathBuf)> {
-    let name = model.vetted["name"].as_str().unwrap_or("");
-    let version = model.vetted["version"].as_str().unwrap_or("");
-    let json_filename = format!("{name}_v{version}.json");
-    let raw_filename = format!("{name}_v{version}.txt");
-
-    let json_buf = PathBuf::from(json_filename);
-    let raw_buf = PathBuf::from(raw_filename);
-    let _ = std::fs::write(&json_buf, serde_json::to_vec(&model.vetted).unwrap());
-    let _ = std::fs::write(&raw_buf, model.raw);
-
-    Ok((raw_buf, json_buf))
+    CommandOutput::new(output::list_revisions_table(results.versions), map)
 }
 
 async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Client, Duration)> {
@@ -395,72 +434,30 @@ async fn nats_client_from_opts(opts: ConnectionOpts) -> Result<(Client, Duration
     Ok((nc, timeout))
 }
 
-fn generate_topic(prefix: Option<String>, elements: &[&str]) -> String {
-    let prefix = prefix.unwrap_or_else(|| "default".to_string());
-    format!("wadm.api.{}.model.{}", prefix, elements.join("."))
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct ModelSummary {
-    pub name: String,
-    pub version: String,
-    pub description: String,
-    pub deployment_status: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct ModelRevision {
-    pub version: String,
-    pub created: String,
-    pub deployed: bool,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct WadmEnvelope {
-    pub result: String,
-    pub message: Option<String>,
-    pub data: Option<serde_json::Value>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct ModelDetails {
-    pub raw: String,
-    pub vetted: serde_json::Value,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct PutReply {
-    pub current_version: String,
-    pub name: String,
-}
-
-async fn raw_request(
+/// Helper function to make a NATS request given connection options, an operation, optional name, and bytes
+async fn model_request(
     opts: ConnectionOpts,
-    elements: &[&str],
-    req: &[u8],
-) -> Result<Option<serde_json::Value>> {
+    operation: ModelOperation,
+    object_name: Option<&str>,
+    bytes: Vec<u8>,
+) -> Result<Message> {
     let (nc, timeout) = nats_client_from_opts(opts.clone()).await?;
-    let topic = generate_topic(opts.lattice_prefix, elements);
 
-    match tokio::time::timeout(timeout, nc.request(topic, req.to_vec().into())).await {
-        Ok(Ok(res)) => {
-            let env: WadmEnvelope = serde_json::from_slice(&res.payload)?;
-            if env.result == "success" {
-                Ok(env.data)
-            } else {
-                bail!("{}", env.message.unwrap_or_default())
-            }
-        }
-        Ok(Err(e)) => bail!("Error making message request: {}", e),
-        Err(e) => bail!("Request timed out:  {}", e),
+    // Topic is of the form of wadm.api.<lattice>.<category>.<operation>.<OPTIONAL: object_name>
+    // We let callers of this function dictate the topic after the prefix + lattice
+    let topic = format!(
+        "{WADM_API_PREFIX}.{}.model.{}{}",
+        opts.lattice_prefix
+            .unwrap_or_else(|| DEFAULT_LATTICE_PREFIX.to_string()),
+        operation.to_string(),
+        object_name
+            .map(|name| format!(".{name}"))
+            .unwrap_or_default()
+    );
+
+    match tokio::time::timeout(timeout, nc.request(topic, bytes.into())).await {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(e)) => bail!("Error making model request: {}", e),
+        Err(e) => bail!("model_request timed out:  {}", e),
     }
-}
-
-async fn json_request(
-    opts: ConnectionOpts,
-    elements: &[&str],
-    req: serde_json::Value,
-) -> Result<Option<serde_json::Value>> {
-    let msg = serde_json::to_vec(&req)?;
-    raw_request(opts, elements, &msg).await
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -122,13 +122,13 @@ pub(crate) struct DeleteCommand {
     #[clap(name = "name")]
     model_name: String,
 
-    /// Version of the app specification to delete
-    #[clap(name = "version")]
-    version: String,
-
     #[clap(long = "delete-all")]
     /// Whether or not to delete all app versions, defaults to `false`
     delete_all: bool,
+
+    /// Version of the app specification to delete. Not required if --delete-all is supplied
+    #[clap(name = "version", required_unless_present("delete_all"))]
+    version: Option<String>,
 
     #[clap(flatten)]
     opts: ConnectionOpts,
@@ -238,8 +238,6 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
         })
         .await?;
 
-        println!("res: {:?}", put_res);
-
         match put_res.result {
             PutResult::Created | PutResult::NewVersion => put_res.name,
             // TODO: Might be better to have a `PutVersion::AlreadyExists` variant
@@ -248,7 +246,7 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
                 let delete_res = delete_model_version(DeleteCommand {
                     //TODO: Name and version here are empty, need that info
                     model_name: put_res.name.to_owned(),
-                    version: put_res.current_version.to_owned(),
+                    version: Some(put_res.current_version.to_owned()),
                     delete_all: false,
                     opts: cmd.opts.to_owned(),
                 })
@@ -318,7 +316,7 @@ async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse>
         ModelOperation::Delete,
         Some(&cmd.model_name),
         serde_json::to_vec(&DeleteModelRequest {
-            version: cmd.version,
+            version: cmd.version.unwrap_or_default(),
             delete_all: cmd.delete_all,
         })?,
     )

--- a/src/app/output.rs
+++ b/src/app/output.rs
@@ -41,7 +41,7 @@ pub(crate) fn list_models_table(models: Vec<ModelSummary>) -> String {
             TableCell::new_with_alignment(m.name.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(m.version.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(
-                m.description.clone().unwrap_or("N/A".to_string()),
+                m.description.clone().unwrap_or_else(|| "N/A".to_string()),
                 1,
                 Alignment::Left,
             ),

--- a/src/app/output.rs
+++ b/src/app/output.rs
@@ -1,33 +1,24 @@
-use std::path::PathBuf;
-
 use term_table::{
     row::Row,
     table_cell::{Alignment, TableCell},
     Table,
 };
+use wadm::server::VersionInfo;
 
-use super::{ModelRevision, ModelSummary};
+use super::ModelSummary;
 
-pub(crate) fn show_model_details(raw: PathBuf, vetted: PathBuf) -> String {
-    // TODO: in a forthcoming release, do something more meaningful than just
-    // dump the file paths
-    format!("Wrote model details to files:\nRaw: {raw:?}\nJSON: {vetted:?}")
-}
-
-pub(crate) fn list_revisions_table(revisions: Vec<ModelRevision>) -> String {
+pub(crate) fn list_revisions_table(revisions: Vec<VersionInfo>) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Version", 1, Alignment::Left),
-        TableCell::new_with_alignment("Created", 1, Alignment::Left),
         TableCell::new_with_alignment("Deployed?", 1, Alignment::Left),
     ]));
 
     revisions.iter().for_each(|r| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(r.version.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(r.created.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(r.deployed, 1, Alignment::Left),
         ]));
     });
@@ -49,8 +40,12 @@ pub(crate) fn list_models_table(models: Vec<ModelSummary>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(m.name.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(m.version.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(m.description.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(m.deployment_status.clone(), 1, Alignment::Right),
+            TableCell::new_with_alignment(
+                m.description.clone().unwrap_or("N/A".to_string()),
+                1,
+                Alignment::Left,
+            ),
+            TableCell::new_with_alignment(format!("{:?}", m.status), 1, Alignment::Right),
         ]))
     });
 

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -9,7 +9,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.1";
+pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.2";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
 pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -8,6 +8,8 @@ pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
+// wadm configuration values
+pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
 pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -30,6 +30,7 @@ use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::down::stop_nats;
 use crate::down::stop_wasmcloud;
+use crate::util::nats_client_from_opts;
 
 mod config;
 mod credsfile;
@@ -310,7 +311,11 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             })?
     };
 
-    let wadm_process = if !cmd.wadm_opts.disable_wadm {
+    let wadm_process = if !cmd.wadm_opts.disable_wadm
+        && !is_wadm_running(&nats_opts, &cmd.wasmcloud_opts.lattice_prefix)
+            .await
+            .unwrap_or(false)
+    {
         spinner.update_spinner_message(" Starting wadm ...".to_string());
         let config = WadmConfig {
             structured_logging: cmd.wasmcloud_opts.enable_structured_logging,
@@ -390,11 +395,8 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             if !cmd.nats_opts.connect_only {
                 stop_nats(install_dir).await?;
             }
-            match (wadm_process, cmd.wadm_opts.disable_wadm) {
-                (Some(mut child), true) => {
-                    child.kill().await?;
-                }
-                _ => (),
+            if let Some(mut child) = wadm_process {
+                child.kill().await?;
             }
             return Err(e);
         }
@@ -539,6 +541,23 @@ async fn run_wasmcloud_interactive(
         handle.abort()
     };
     Ok(())
+}
+
+async fn is_wadm_running(nats_opts: &NatsOpts, lattice_prefix: &str) -> Result<bool> {
+    let client = nats_client_from_opts(
+        &nats_opts.nats_host,
+        &nats_opts.nats_port.to_string(),
+        None,
+        None,
+        nats_opts.nats_credsfile.clone(),
+    )
+    .await?;
+
+    Ok(
+        wash_lib::app::get_models(&client, Some(lattice_prefix.to_string()))
+            .await
+            .is_ok(),
+    )
 }
 
 #[cfg(test)]

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -18,6 +18,9 @@ use tokio::{
     process::Child,
 };
 use wash_lib::cli::{CommandOutput, OutputKind};
+use wash_lib::start::ensure_wadm;
+use wash_lib::start::start_wadm;
+use wash_lib::start::WadmConfig;
 use wash_lib::start::{
     ensure_nats_server, ensure_wasmcloud, start_nats_server, start_wasmcloud_host, wait_for_server,
     NatsConfig,
@@ -45,6 +48,9 @@ pub(crate) struct UpCommand {
 
     #[clap(flatten)]
     pub(crate) wasmcloud_opts: WasmcloudOpts,
+
+    #[clap(flatten)]
+    pub(crate) wadm_opts: WadmOpts,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -253,6 +259,16 @@ pub(crate) struct WasmcloudOpts {
     pub(crate) start_only: bool,
 }
 
+#[derive(Parser, Debug, Clone)]
+pub(crate) struct WadmOpts {
+    /// wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
+    #[clap(long = "wadm-version", default_value = WADM_VERSION, env = "WADM_VERSION")]
+    pub(crate) wadm_version: String,
+
+    #[clap(long = "disable-wadm")]
+    pub(crate) disable_wadm: bool,
+}
+
 pub(crate) async fn handle_command(
     command: UpCommand,
     output_kind: OutputKind,
@@ -292,6 +308,41 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
                     nats_listen_address
                 )
             })?
+    };
+
+    let wadm_process = if !cmd.wadm_opts.disable_wadm {
+        spinner.update_spinner_message(" Starting wadm ...".to_string());
+        let config = WadmConfig {
+            structured_logging: cmd.wasmcloud_opts.enable_structured_logging,
+            js_domain: cmd.nats_opts.nats_js_domain.clone(),
+            nats_server_url: format!("{}:{}", cmd.nats_opts.nats_host, cmd.nats_opts.nats_port),
+            nats_credsfile: cmd.nats_opts.nats_credsfile,
+        };
+        // Start wadm, redirecting output to a log file
+        let wadm_log_path = install_dir.join("wadm.log");
+        let wadm_log_file = tokio::fs::File::create(&wadm_log_path)
+            .await?
+            .into_std()
+            .await;
+
+        let wadm_path = ensure_wadm(&cmd.wadm_opts.wadm_version, &install_dir).await;
+        match wadm_path {
+            Ok(path) => {
+                let wadm_child = start_wadm(&path, wadm_log_file, Some(config)).await;
+                if let Err(e) = &wadm_child {
+                    println!("🟨 Couldn't start wadm: {e}");
+                    None
+                } else {
+                    Some(wadm_child.unwrap())
+                }
+            }
+            Err(e) => {
+                println!("🟨 Couldn't download wadm {WADM_VERSION}: {e}");
+                None
+            }
+        }
+    } else {
+        None
     };
 
     // Download wasmCloud if not already installed
@@ -335,9 +386,15 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     {
         Ok(child) => child,
         Err(e) => {
-            // Ensure we clean up the NATS server if we can't start wasmCloud
+            // Ensure we clean up the NATS server and wadm if we can't start wasmCloud
             if !cmd.nats_opts.connect_only {
                 stop_nats(install_dir).await?;
+            }
+            match (wadm_process, cmd.wadm_opts.disable_wadm) {
+                (Some(mut child), true) => {
+                    child.kill().await?;
+                }
+                _ => (),
             }
             return Err(e);
         }
@@ -357,7 +414,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
 
         let spinner = Spinner::new(&output_kind)?;
         spinner.update_spinner_message(
-            "CTRL+c received, gracefully stopping wasmCloud and NATS...".to_string(),
+            "CTRL+c received, gracefully stopping wasmCloud, wadm, and NATS...".to_string(),
         );
 
         // Terminate wasmCloud and NATS processes
@@ -368,6 +425,9 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         if !cmd.nats_opts.connect_only {
             stop_nats(&install_dir).await?;
         }
+
+        // remove wadm pidfile, the process is stopped automatically by CTRL+c
+        tokio::fs::remove_file(&install_dir.join("wadm.pid")).await?;
 
         spinner.finish_and_clear();
     }
@@ -397,7 +457,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
             "\n🌐 The wasmCloud dashboard is running at {}\n📜 Logs for the host are being written to {}",
             url, wasmcloud_log_path.to_string_lossy()
         );
-        let _ = write!(out_text, "\n\n🛑 To stop wasmCloud, run \"wash down\"");
+        let _ = write!(out_text, "\n\n⬇️  To stop wasmCloud, run \"wash down\"");
     }
 
     Ok(CommandOutput::new(out_text, out_json))

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -17,8 +17,19 @@ fn integration_up_can_start_wasmcloud_and_actor() {
     let path = dir.join("washup.log");
     let stdout = std::fs::File::create(&path).expect("could not create log file for wash up test");
 
+    let host_seed = nkeys::KeyPair::new_server();
+
     let mut up_cmd = wash()
-        .args(["up", "--nats-port", "5893", "-o", "json", "--detached"])
+        .args([
+            "up",
+            "--nats-port",
+            "5893",
+            "-o",
+            "json",
+            "--detached",
+            "--host-seed",
+            &host_seed.seed().expect("Should have a seed for the host"),
+        ])
         .stdout(stdout)
         .spawn()
         .expect("Could not spawn wash up process");
@@ -28,20 +39,26 @@ fn integration_up_can_start_wasmcloud_and_actor() {
     assert!(status.success());
     let out = read_to_string(&path).expect("could not read output of wash up");
 
-    let (kill_cmd, wasmcloud_log) = match serde_json::from_str::<serde_json::Value>(&out) {
+    let (kill_cmd, _wasmcloud_log) = match serde_json::from_str::<serde_json::Value>(&out) {
         Ok(v) => (v["kill_cmd"].to_owned(), v["wasmcloud_log"].to_owned()),
         Err(_e) => panic!("Unable to parse kill cmd from wash up output"),
     };
 
-    // Wait until the host starts
+    // Wait until the host starts, measured by trying to retrieve host inventory over NATS
+    // Once this returns something other than a no responders, we know the host is ready for a ctl command
     let mut tries = 30;
-    while !read_to_string(wasmcloud_log.to_string().trim_matches('"'))
-        .expect("could not read output")
-        .contains("Started wasmCloud OTP Host Runtime")
-    {
-        tries -= 1;
-        assert!(tries >= 0);
-        std::thread::sleep(std::time::Duration::from_secs(1));
+    while tries >= 0 {
+        let output = wash()
+            .args(["ctl", "get", "inventory", &host_seed.public_key()])
+            .output()
+            .expect("expected command to finish");
+        if output.stdout.is_empty() {
+            tries -= 1;
+            assert!(tries >= 0);
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        } else {
+            break;
+        }
     }
 
     let start_echo = wash()

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -115,6 +115,9 @@ fn can_stop_detached_host() {
         .output()
         .expect("Could not spawn wash down process");
 
+    // After `wash down` exits, sometimes Erlang things stick around for a few seconds
+    std::thread::sleep(std::time::Duration::from_millis(5000));
+
     // Check to see if process was removed
     let mut info = sysinfo::System::new_with_specifics(
         sysinfo::RefreshKind::new().with_processes(sysinfo::ProcessRefreshKind::new()),


### PR DESCRIPTION
## Feature or Problem
After the many changes going into `wadm` 0.4, there were a few changes to the app subcommand in order to make it compatible with the new types. Additionally, this PR adds in `wadm` as a binary to download as a part of running `up` so that we can immediately interact with `wadm`.

You should consider reviewing this PR as two big sections: the `wash up` wadm support, and the changes to the `app` module.

This PR
- [x] Adds `wadm` as another binary that can be downloaded + started with `wash up`
- [x] Updates the `app` subcommand to match the Wadm NATS API
- [x] Updates async_nats, tokio, and a few other dependencies after figuring out the issue with the OCI downloads in #382 

## Related Issues
(pr) https://github.com/wasmCloud/wadm/pull/89
Fixes #382

## Release Information
v0.18.0

## Consumer Impact
Consumers of the Elixir implementation of wadm will see breaking changes here, as expected, so with the v0.18.0 release notes we should note that the latest version of wadm should be used.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Manual tested with https://github.com/wasmCloud/wadm/pull/89