### PR TITLE
fix(*): Bumps wash-lib version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -134,7 +134,7 @@ tokio-tar = "0.3"
 toml = "0.5"
 walkdir = "2.3"
 wascap = "0.10.1"
-wash-lib = { version = "0.7.0", path = "./crates/wash-lib" }
+wash-lib = { version = "0.8", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.11.2"
 wasmcloud-control-interface = "0.23"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
This was missed and so cargo installing from main causes issues. Also bumps 0.17 so that it can pick up the new version from crates. Once this is published we should yank 0.17.0
