### PR TITLE
Fixed issue with wash connecting to host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -232,7 +232,7 @@ where
 {
     // If we can connect to the local port, a wasmCloud host won't be able to listen on that port
     let port = env_vars
-        .get("PORT")
+        .get("WASMCLOUD_DASHBOARD_PORT")
         .cloned()
         .unwrap_or_else(|| "4000".to_string());
     if tokio::net::TcpStream::connect(format!("localhost:{port}"))
@@ -568,7 +568,7 @@ mod test {
         // Windows is unable to properly check running erlang nodes with `pid`
         {
             let mut host_env = HashMap::new();
-            host_env.insert("PORT".to_string(), "4002".to_string());
+            host_env.insert("WASMCLOUD_DASHBOARD_PORT".to_string(), "4002".to_string());
             host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
             host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
             host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -10,7 +10,8 @@ pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
-pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "4000";
+pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";
+pub(crate) const DEFAULT_DASHBOARD_PORT: &str = "4000";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";
@@ -196,6 +197,14 @@ pub(crate) async fn configure_host_env(
     host_config.insert(
         WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
         wasmcloud_opts.provider_delay.to_string(),
+    );
+
+    host_config.insert(
+        WASMCLOUD_DASHBOARD_PORT.to_string(),
+        wasmcloud_opts
+            .dashboard_port
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| DEFAULT_DASHBOARD_PORT.to_string()),
     );
 
     // Extras configuration


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where you can supply a wasmCloud dashboard port, but the `wash up` check only used the default port to test connectivity.

Additionally, modified `wash-lib` to properly take WASMCLOUD_DASHBOARD_PORT instead of the `PORT` environment variable. This is technically a breaking change but it's been using an outdated (and unused) variable for a while now, so I am putting it as a patch.

## Related Issues
N/A

## Release Information
wash-lib 0.8.1
wash-cli 0.17.2

## Consumer Impact


## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Manually verified this fixed issues we were having in wadm acceptance tests
