### PR TITLE
Feat: Resurrect multiple wasmcloud hosts

### DIFF
--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -377,6 +377,48 @@ fn nats_url(os: &str, arch: &str, version: &str) -> String {
     format!("{NATS_GITHUB_RELEASE_URL}/{version}/nats-server-{version}-{os}-{arch}.tar.gz")
 }
 
+/// Helper function to get the path to the NATS server pid file
+pub fn nats_pid_path<P>(install_dir: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    install_dir.as_ref().join(NATS_SERVER_PID)
+}
+
+/// Function to check whethere a NATS server is running along with the corrects PID file
+/// Returns true when the running NATS server has the correctly generated PID file in existence
+/// Returns false when the server is not running or has a dangling PID file
+/// Returns an error when a process is running on the given address without a PID file
+pub async fn is_nats_running(nats_listen_address: String, install_dir: &Path) -> Result<bool> {
+    let is_nats_listening = tokio::net::TcpStream::connect(&nats_listen_address)
+        .await
+        .is_ok();
+    let pid_file_path = nats_pid_path(install_dir);
+    let pid_file_exists = pid_file_path.is_file();
+
+    match (is_nats_listening, pid_file_exists) {
+        (true, true) => {
+            // Nats server is running and PID file exists: it's our wasm NATS server
+            Ok(true)
+        }
+        (true, false) => {
+            // NATS is running, PID file doesn't exist: someone else is running NATS
+            Err(anyhow!(
+                "Cannot start NATS server. An unknown process is listening on {nats_listen_address}. Kill it and try again"
+            ))
+        }
+        (false, true) => {
+            // NATS isn't running but PID file exists: clean PID file and start server
+            let _ = tokio::fs::remove_file(&pid_file_path).await;
+            Ok(false)
+        }
+        (false, false) => {
+            // NATS server isn't running PID file doesn't exist: start a new NATS server
+            Ok(false)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::start::{

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -212,6 +212,26 @@ where
         )),
     }
 }
+
+pub async fn is_wasmcloud_running<P>(bin_path: P, host_id: String) -> Result<bool>
+where
+    P: AsRef<Path>,
+{
+    if let Ok(output) = Command::new(bin_path.as_ref())
+        .arg("pid")
+        .env("RELEASE_NODE", host_id)
+        .output()
+        .await
+    {
+        // Stderr will include :nodedown if no other host is running, otherwise
+        // stdout will contain the PID
+        if String::from_utf8_lossy(&output.stderr).contains(":nodedown") {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// Helper function to start a wasmCloud host given the path to the elixir release script
 /// /// # Arguments
 ///
@@ -231,10 +251,10 @@ where
     S: Into<Stdio>,
 {
     // If we can connect to the local port, a wasmCloud host won't be able to listen on that port
-    let port = env_vars
-        .get("WASMCLOUD_DASHBOARD_PORT")
-        .cloned()
-        .unwrap_or_else(|| "4000".to_string());
+    let port = match env_vars.get("WASMCLOUD_DASHBOARD_PORT").cloned() {
+        Some(port) => port,
+        None => return Err(anyhow!("wasmCloud host port is not set")),
+    };
     if tokio::net::TcpStream::connect(format!("localhost:{port}"))
         .await
         .is_ok()

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -253,7 +253,7 @@ where
     // If we can connect to the local port, a wasmCloud host won't be able to listen on that port
     let port = match env_vars.get("WASMCLOUD_DASHBOARD_PORT").cloned() {
         Some(port) => port,
-        None => return Err(anyhow!("wasmCloud host port is not set")),
+        None => "4000".to_string(),
     };
     if tokio::net::TcpStream::connect(format!("localhost:{port}"))
         .await

--- a/src/appearance/spinner.rs
+++ b/src/appearance/spinner.rs
@@ -52,4 +52,11 @@ impl Spinner {
             None => {}
         }
     }
+
+    pub fn println<I: AsRef<str>>(&self, msg: I) {
+        match &self.spinner {
+            Some(progress_bar) => progress_bar.println(msg),
+            None => {}
+        }
+    }
 }

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 use serde_json::json;
 use tokio::process::Command;
@@ -13,9 +13,16 @@ use wash_lib::start::{find_wasmcloud_binary, NATS_SERVER_BINARY, NATS_SERVER_PID
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::up::{DOWNLOADS_DIR, WASMCLOUD_PID_FILE};
+use crate::util::get_wasmcloud_hosts;
 
 #[derive(Parser, Debug, Clone)]
-pub(crate) struct DownCommand {}
+pub(crate) struct DownCommand {
+    #[clap(long = "host-id")]
+    pub host_id: Option<String>,
+
+    #[clap(long = "all")]
+    pub all: bool,
+}
 
 pub(crate) async fn handle_command(
     command: DownCommand,
@@ -41,36 +48,110 @@ pub(crate) async fn handle_down(
     let host_bin = find_wasmcloud_binary(&install_dir, &version)
         .await
         .ok_or_else(|| anyhow::anyhow!("Couldn't find path to wasmCloud binary. Is it running?"))?;
-    if host_bin.is_file() {
-        sp.update_spinner_message(" Stopping host ...".to_string());
-        if let Ok(output) = stop_wasmcloud(host_bin).await {
+
+    let mut stopped_hosts = 0;
+    let hosts = get_wasmcloud_hosts(host_bin.clone()).await?;
+
+    if hosts.is_empty() {
+        sp.println("No local wasmCloud hosts detected.");
+    } else if let Some(host_id) = _cmd.host_id {
+        let host = match hosts.iter().find(|h| h.id == host_id) {
+            Some(host) => host,
+            None => bail!("Host {} is not running", host_id),
+        };
+        sp.update_spinner_message(format!("Stopping host {}...", host.id));
+        if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
             if output.stderr.is_empty() && output.stdout.is_empty() {
                 // if there was a host running, 'stop' has no output.
                 // Give it time to stop before stopping nats
                 tokio::time::sleep(Duration::from_secs(6)).await;
-                out_json.insert("host_stopped".to_string(), json!(true));
-                out_text.push_str("✅ wasmCloud host stopped successfully\n");
+                stopped_hosts += 1;
+                out_json.insert("host_stopped".to_string(), json!(host.id));
+                out_text.push_str(&format!(
+                    "✅ wasmCloud host {} stopped successfully\n",
+                    host_id,
+                ));
             } else {
-                out_json.insert("host_stopped".to_string(), json!(true));
-                out_text.push_str(
-                    "🤔 Host did not appear to be running, assuming it's already stopped\n",
-                );
+                out_json.insert("host_stopped".to_string(), json!(host.id));
+                out_text.push_str(&format!(
+                    "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
+                    host_id
+                ));
+            }
+        };
+    } else if hosts.len() == 1 {
+        let host = hosts.first().unwrap();
+        sp.update_spinner_message(format!("Stopping host {}...", host.id));
+        if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
+            if output.stderr.is_empty() && output.stdout.is_empty() {
+                // if there was a host running, 'stop' has no output.
+                // Give it time to stop before stopping nats
+                tokio::time::sleep(Duration::from_secs(6)).await;
+                stopped_hosts += 1;
+                out_json.insert("host_stopped".to_string(), json!(host.id));
+                out_text.push_str(&format!(
+                    "✅ wasmCloud host {} stopped successfully\n",
+                    host.id,
+                ));
+            } else {
+                out_json.insert("host_stopped".to_string(), json!(host.id));
+                out_text.push_str(&format!(
+                    "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
+                    host.id
+                ));
             }
         }
+    } else if _cmd.all {
+        for (i, host) in hosts.iter().enumerate() {
+            sp.update_spinner_message(format!(
+                "Stopping host {} ({}/{})...",
+                host.id,
+                i + 1,
+                hosts.len()
+            ));
+            if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
+                if output.stderr.is_empty() && output.stdout.is_empty() {
+                    // if there was a host running, 'stop' has no output.
+                    // Give it time to stop before stopping nats
+                    tokio::time::sleep(Duration::from_secs(6)).await;
+                    stopped_hosts += 1;
+                    out_json.insert("host_stopped".to_string(), json!(host.id));
+                    out_text.push_str(&format!(
+                        "✅ wasmCloud host {} stopped successfully\n",
+                        host.id,
+                    ));
+                } else {
+                    out_json.insert("host_stopped".to_string(), json!(host.id));
+                    out_text.push_str(&format!(
+                        "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
+                        host.id
+                    ));
+                }
+            }
+        }
+    } else {
+        bail!(
+            "Detected multiple wasmCloud hosts. Specify a host with --host-id [hostID], or use --all\nTo see your hosts, run wash ctl get hosts."
+        )
     }
 
-    let nats_bin = install_dir.join(NATS_SERVER_BINARY);
-    if nats_bin.is_file() {
-        sp.update_spinner_message(" Stopping NATS server ...".to_string());
-        if let Err(e) = stop_nats(install_dir).await {
-            out_json.insert("nats_stopped".to_string(), json!(false));
-            out_text.push_str(&format!(
-                "❌ NATS server did not stop successfully: {e:?}\n"
-            ));
-        } else {
-            out_json.insert("nats_stopped".to_string(), json!(true));
-            out_text.push_str("✅ NATS server stopped successfully\n");
+    if stopped_hosts == hosts.len() {
+        let nats_bin = install_dir.join(NATS_SERVER_BINARY);
+        if nats_bin.is_file() {
+            sp.update_spinner_message(" Stopping NATS server ...".to_string());
+            if let Err(e) = stop_nats(install_dir).await {
+                out_json.insert("nats_stopped".to_string(), json!(false));
+                out_text.push_str(&format!(
+                    "❌ NATS server did not stop successfully: {e:?}\n"
+                ));
+            } else {
+                out_json.insert("nats_stopped".to_string(), json!(true));
+                out_text.push_str("✅ NATS server stopped successfully\n");
+            }
         }
+    } else {
+        out_json.insert("nats_stopped".to_string(), json!(false));
+        out_text.push_str("NATS server is still running\n");
     }
 
     out_json.insert("success".to_string(), json!(true));
@@ -81,13 +162,14 @@ pub(crate) async fn handle_down(
 }
 
 /// Helper function to send wasmCloud the `stop` command and wait for it to clean up
-pub(crate) async fn stop_wasmcloud<P>(bin_path: P) -> Result<Output>
+pub(crate) async fn stop_wasmcloud<P>(bin_path: P, host_id: Option<String>) -> Result<Output>
 where
     P: AsRef<Path>,
 {
     Command::new(bin_path.as_ref())
         .stdout(Stdio::piped())
         .arg("stop")
+        .env("RELEASE_NODE", host_id.unwrap_or("".to_string()))
         .output()
         .await
         .map_err(anyhow::Error::from)

--- a/src/down/mod.rs
+++ b/src/down/mod.rs
@@ -8,15 +8,49 @@ use clap::Parser;
 use serde_json::json;
 use tokio::process::Command;
 use wash_lib::cli::{CommandOutput, OutputKind};
-use wash_lib::start::{find_wasmcloud_binary, NATS_SERVER_BINARY, NATS_SERVER_PID};
+use wash_lib::config::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
+use wash_lib::start::{find_wasmcloud_binary, nats_pid_path, NATS_SERVER_BINARY};
 
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
-use crate::up::{DOWNLOADS_DIR, WASMCLOUD_PID_FILE};
-use crate::util::get_wasmcloud_hosts;
+use crate::up::{
+    DEFAULT_LATTICE_PREFIX, DOWNLOADS_DIR, RELEASE_NODE, WASMCLOUD_CTL_CREDSFILE,
+    WASMCLOUD_CTL_HOST, WASMCLOUD_CTL_JWT, WASMCLOUD_CTL_PORT, WASMCLOUD_CTL_SEED,
+    WASMCLOUD_LATTICE_PREFIX, WASMCLOUD_PID_FILE,
+};
+use crate::util::{get_wasmcloud_hosts, nats_client_from_opts};
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct DownCommand {
+    /// A lattice prefix is a unique identifier for a lattice, and is frequently used within NATS topics to isolate messages from different lattices
+    #[clap(
+        short = 'x',
+        long = "lattice-prefix",
+        default_value = DEFAULT_LATTICE_PREFIX,
+        env = WASMCLOUD_LATTICE_PREFIX,
+    )]
+    pub(crate) lattice_prefix: String,
+
+    /// An IP address or DNS name to use to connect to NATS for Control Interface (CTL) messages, defaults to the value supplied to --nats-host if not supplied
+    #[clap(long = "ctl-host", env = WASMCLOUD_CTL_HOST)]
+    pub(crate) ctl_host: Option<String>,
+
+    /// A port to use to connect to NATS for CTL messages, defaults to the value supplied to --nats-port if not supplied
+    #[clap(long = "ctl-port", env = WASMCLOUD_CTL_PORT)]
+    pub(crate) ctl_port: Option<u16>,
+
+    /// Convenience flag for CTL authentication, internally this parses the JWT and seed from the credsfile
+    #[clap(long = "ctl-credsfile", env = WASMCLOUD_CTL_CREDSFILE)]
+    pub(crate) ctl_credsfile: Option<PathBuf>,
+
+    /// A seed nkey to use to authenticate to NATS for CTL messages
+    #[clap(long = "ctl-seed", env = WASMCLOUD_CTL_SEED, requires = "ctl_jwt")]
+    pub(crate) ctl_seed: Option<String>,
+
+    /// A user JWT to use to authenticate to NATS for CTL messages
+    #[clap(long = "ctl-jwt", env = WASMCLOUD_CTL_JWT, requires = "ctl_seed")]
+    pub(crate) ctl_jwt: Option<String>,
+
     #[clap(long = "host-id")]
     pub host_id: Option<String>,
 
@@ -32,7 +66,7 @@ pub(crate) async fn handle_command(
 }
 
 pub(crate) async fn handle_down(
-    _cmd: DownCommand,
+    cmd: DownCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     let install_dir = cfg_dir()?.join(DOWNLOADS_DIR);
@@ -50,58 +84,46 @@ pub(crate) async fn handle_down(
         .ok_or_else(|| anyhow::anyhow!("Couldn't find path to wasmCloud binary. Is it running?"))?;
 
     let mut stopped_hosts = 0;
-    let hosts = get_wasmcloud_hosts(host_bin.clone()).await?;
+    let nats_client = nats_client_from_opts(
+        &cmd.ctl_host.unwrap_or(DEFAULT_NATS_HOST.to_string()),
+        &cmd.ctl_port
+            .map(|port| port.to_string())
+            .unwrap_or(DEFAULT_NATS_PORT.to_string()),
+        cmd.ctl_jwt,
+        cmd.ctl_seed,
+        cmd.ctl_credsfile,
+    )
+    .await?;
+    let hosts = get_wasmcloud_hosts(host_bin.clone(), nats_client).await?;
 
     if hosts.is_empty() {
-        sp.println("No local wasmCloud hosts detected.");
-    } else if let Some(host_id) = _cmd.host_id {
+        bail!("No local wasmCloud hosts detected.");
+    } else if let Some(host_id) = cmd.host_id {
         let host = match hosts.iter().find(|h| h.id == host_id) {
             Some(host) => host,
             None => bail!("Host {} is not running", host_id),
         };
-        sp.update_spinner_message(format!("Stopping host {}...", host.id));
-        if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
-            if output.stderr.is_empty() && output.stdout.is_empty() {
-                // if there was a host running, 'stop' has no output.
-                // Give it time to stop before stopping nats
-                tokio::time::sleep(Duration::from_secs(6)).await;
-                stopped_hosts += 1;
-                out_json.insert("host_stopped".to_string(), json!(host.id));
-                out_text.push_str(&format!(
-                    "✅ wasmCloud host {} stopped successfully\n",
-                    host_id,
-                ));
-            } else {
-                out_json.insert("host_stopped".to_string(), json!(host.id));
-                out_text.push_str(&format!(
-                    "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
-                    host_id
-                ));
-            }
-        };
+        sp.update_spinner_message(format!("Stopping host {} ...", host.id));
+        (out_json, out_text, stopped_hosts) = stop_host(
+            &host_bin,
+            host.id.clone(),
+            out_json,
+            out_text,
+            stopped_hosts,
+        )
+        .await;
     } else if hosts.len() == 1 {
         let host = hosts.first().unwrap();
-        sp.update_spinner_message(format!("Stopping host {}...", host.id));
-        if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
-            if output.stderr.is_empty() && output.stdout.is_empty() {
-                // if there was a host running, 'stop' has no output.
-                // Give it time to stop before stopping nats
-                tokio::time::sleep(Duration::from_secs(6)).await;
-                stopped_hosts += 1;
-                out_json.insert("host_stopped".to_string(), json!(host.id));
-                out_text.push_str(&format!(
-                    "✅ wasmCloud host {} stopped successfully\n",
-                    host.id,
-                ));
-            } else {
-                out_json.insert("host_stopped".to_string(), json!(host.id));
-                out_text.push_str(&format!(
-                    "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
-                    host.id
-                ));
-            }
-        }
-    } else if _cmd.all {
+        sp.update_spinner_message(format!("Stopping host {} ...", host.id));
+        (out_json, out_text, stopped_hosts) = stop_host(
+            &host_bin,
+            host.id.clone(),
+            out_json,
+            out_text,
+            stopped_hosts,
+        )
+        .await;
+    } else if cmd.all {
         for (i, host) in hosts.iter().enumerate() {
             sp.update_spinner_message(format!(
                 "Stopping host {} ({}/{})...",
@@ -109,31 +131,24 @@ pub(crate) async fn handle_down(
                 i + 1,
                 hosts.len()
             ));
-            if let Ok(output) = stop_wasmcloud(&host_bin, Some(host.id.to_string())).await {
-                if output.stderr.is_empty() && output.stdout.is_empty() {
-                    // if there was a host running, 'stop' has no output.
-                    // Give it time to stop before stopping nats
-                    tokio::time::sleep(Duration::from_secs(6)).await;
-                    stopped_hosts += 1;
-                    out_json.insert("host_stopped".to_string(), json!(host.id));
-                    out_text.push_str(&format!(
-                        "✅ wasmCloud host {} stopped successfully\n",
-                        host.id,
-                    ));
-                } else {
-                    out_json.insert("host_stopped".to_string(), json!(host.id));
-                    out_text.push_str(&format!(
-                        "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
-                        host.id
-                    ));
-                }
-            }
+            (out_json, out_text, stopped_hosts) = stop_host(
+                &host_bin,
+                host.id.clone(),
+                out_json,
+                out_text,
+                stopped_hosts,
+            )
+            .await;
         }
     } else {
         bail!(
             "Detected multiple wasmCloud hosts. Specify a host with --host-id [hostID], or use --all\nTo see your hosts, run wash ctl get hosts."
         )
     }
+
+    // if there was a host running, 'stop' has no output.
+    // Give it time to stop before stopping nats
+    tokio::time::sleep(Duration::from_secs(6)).await;
 
     if stopped_hosts == hosts.len() {
         let nats_bin = install_dir.join(NATS_SERVER_BINARY);
@@ -161,6 +176,32 @@ pub(crate) async fn handle_down(
     Ok(CommandOutput::new(out_text, out_json))
 }
 
+pub(crate) async fn stop_host(
+    host_bin: &PathBuf,
+    host_id: String,
+    mut out_json: HashMap<String, serde_json::Value>,
+    mut out_text: String,
+    mut stopped_hosts: usize,
+) -> (HashMap<String, serde_json::Value>, String, usize) {
+    if let Ok(output) = stop_wasmcloud(&host_bin, Some(host_id.to_string())).await {
+        if output.stderr.is_empty() && output.stdout.is_empty() {
+            stopped_hosts += 1;
+            out_json.insert("host_stopped".to_string(), json!(host_id));
+            out_text.push_str(&format!(
+                "✅ wasmCloud host {} stopped successfully\n",
+                host_id,
+            ));
+        } else {
+            out_json.insert("host_stopped".to_string(), json!(host_id));
+            out_text.push_str(&format!(
+                "🤔 Host {} did not appear to be running, assuming it's already stopped\n",
+                host_id
+            ));
+        }
+    }
+    (out_json, out_text, stopped_hosts)
+}
+
 /// Helper function to send wasmCloud the `stop` command and wait for it to clean up
 pub(crate) async fn stop_wasmcloud<P>(bin_path: P, host_id: Option<String>) -> Result<Output>
 where
@@ -169,7 +210,7 @@ where
     Command::new(bin_path.as_ref())
         .stdout(Stdio::piped())
         .arg("stop")
-        .env("RELEASE_NODE", host_id.unwrap_or("".to_string()))
+        .env(RELEASE_NODE, host_id.unwrap_or("".to_string()))
         .output()
         .await
         .map_err(anyhow::Error::from)
@@ -200,12 +241,4 @@ where
         let _ = tokio::fs::remove_file(&pid_file).await;
     }
     output
-}
-
-/// Helper function to get the path to the NATS server pid file
-pub(crate) fn nats_pid_path<P>(install_dir: P) -> PathBuf
-where
-    P: AsRef<Path>,
-{
-    install_dir.as_ref().join(NATS_SERVER_PID)
 }

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -1,17 +1,20 @@
 use std::collections::HashMap;
 
 use crate::up::{credsfile::parse_credsfile, NatsOpts, WasmcloudOpts};
+use nkeys::KeyPair;
 
 pub const DOWNLOADS_DIR: &str = "downloads";
 pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 // NATS configuration values
 pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
-pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
-pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
+pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
+pub const DEFAULT_NATS_PORT: &str = "4222";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
 pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";
-pub(crate) const DEFAULT_DASHBOARD_PORT: &str = "4000";
+pub(crate) const LOCALHOST: &str = "127.0.0.1";
+pub(crate) const HOST_PORT_RANGE_START: u16 = 4000;
+pub(crate) const HOST_PORT_RANGE_END: u16 = 5000;
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";
@@ -20,6 +23,7 @@ pub(crate) const WASMCLOUD_JS_DOMAIN: &str = "WASMCLOUD_JS_DOMAIN";
 pub(crate) const WASMCLOUD_CLUSTER_ISSUERS: &str = "WASMCLOUD_CLUSTER_ISSUERS";
 pub(crate) const WASMCLOUD_CLUSTER_SEED: &str = "WASMCLOUD_CLUSTER_SEED";
 pub(crate) const WASMCLOUD_HOST_SEED: &str = "WASMCLOUD_HOST_SEED";
+pub(crate) const RELEASE_NODE: &str = "RELEASE_NODE";
 // NATS RPC connection configuration
 pub(crate) const WASMCLOUD_RPC_HOST: &str = "WASMCLOUD_RPC_HOST";
 pub(crate) const WASMCLOUD_RPC_PORT: &str = "WASMCLOUD_RPC_PORT";
@@ -62,6 +66,7 @@ pub(crate) const DEFAULT_ALLOW_FILE_LOAD: &str = "true";
 pub(crate) async fn configure_host_env(
     nats_opts: NatsOpts,
     wasmcloud_opts: WasmcloudOpts,
+    other_host_config_values: HashMap<String, String>,
 ) -> HashMap<String, String> {
     let mut host_config = HashMap::new();
     // NATS isolation configuration variables
@@ -74,9 +79,26 @@ pub(crate) async fn configure_host_env(
     }
 
     // Host / Cluster configuration
+    if let Some(port) = other_host_config_values.get(WASMCLOUD_DASHBOARD_PORT) {
+        host_config.insert(WASMCLOUD_DASHBOARD_PORT.to_string(), port.to_string());
+    }
     if let Some(seed) = wasmcloud_opts.host_seed {
         host_config.insert(WASMCLOUD_HOST_SEED.to_string(), seed);
+    } else {
+        host_config.insert(
+            WASMCLOUD_HOST_SEED.to_string(),
+            KeyPair::new_server()
+                .seed()
+                .unwrap_or_else(|_| "None".to_string()),
+        );
     }
+    if let Some(value) = host_config.get("WASMCLOUD_HOST_SEED") {
+        host_config.insert(
+            RELEASE_NODE.to_string(),
+            nkeys::KeyPair::from_seed(value).unwrap().public_key(),
+        );
+    }
+
     if let Some(seed) = wasmcloud_opts.cluster_seed {
         host_config.insert(WASMCLOUD_CLUSTER_SEED.to_string(), seed);
     }
@@ -197,14 +219,6 @@ pub(crate) async fn configure_host_env(
     host_config.insert(
         WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
         wasmcloud_opts.provider_delay.to_string(),
-    );
-
-    host_config.insert(
-        WASMCLOUD_DASHBOARD_PORT.to_string(),
-        wasmcloud_opts
-            .dashboard_port
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| DEFAULT_DASHBOARD_PORT.to_string()),
     );
 
     // Extras configuration

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use crate::up::{credsfile::parse_credsfile, NatsOpts, WasmcloudOpts};
-use nkeys::KeyPair;
 
 pub const DOWNLOADS_DIR: &str = "downloads";
 pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
@@ -66,7 +65,6 @@ pub(crate) const DEFAULT_ALLOW_FILE_LOAD: &str = "true";
 pub(crate) async fn configure_host_env(
     nats_opts: NatsOpts,
     wasmcloud_opts: WasmcloudOpts,
-    other_host_config_values: HashMap<String, String>,
 ) -> HashMap<String, String> {
     let mut host_config = HashMap::new();
     // NATS isolation configuration variables
@@ -79,25 +77,20 @@ pub(crate) async fn configure_host_env(
     }
 
     // Host / Cluster configuration
-    if let Some(port) = other_host_config_values.get(WASMCLOUD_DASHBOARD_PORT) {
+    if let Some(port) = wasmcloud_opts.dashboard_port {
         host_config.insert(WASMCLOUD_DASHBOARD_PORT.to_string(), port.to_string());
     }
-    if let Some(seed) = wasmcloud_opts.host_seed {
-        host_config.insert(WASMCLOUD_HOST_SEED.to_string(), seed);
-    } else {
-        host_config.insert(
-            WASMCLOUD_HOST_SEED.to_string(),
-            KeyPair::new_server()
-                .seed()
-                .unwrap_or_else(|_| "None".to_string()),
-        );
-    }
-    if let Some(value) = host_config.get("WASMCLOUD_HOST_SEED") {
-        host_config.insert(
-            RELEASE_NODE.to_string(),
-            nkeys::KeyPair::from_seed(value).unwrap().public_key(),
-        );
-    }
+    // RELEASE_NODE is a tag for the host to uniquely identify it
+    let keypair = wasmcloud_opts
+        .host_seed
+        .map(|seed| nkeys::KeyPair::from_seed(&seed))
+        .unwrap_or_else(|| Ok(nkeys::KeyPair::new_server()))
+        .unwrap_or_else(|_| nkeys::KeyPair::new_server());
+    host_config.insert(
+        WASMCLOUD_HOST_SEED.to_string(),
+        keypair.seed().unwrap_or_else(|_| "None".to_string()),
+    );
+    host_config.insert(RELEASE_NODE.to_string(), keypair.public_key());
 
     if let Some(seed) = wasmcloud_opts.cluster_seed {
         host_config.insert(WASMCLOUD_CLUSTER_SEED.to_string(), seed);

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -26,13 +26,14 @@ use wash_lib::start::{
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::down::stop_nats;
-use crate::down::stop_wasmcloud;
+use crate::down::{nats_pid_path, stop_wasmcloud};
+use crate::util::get_wasmcloud_hosts;
 
 mod config;
 mod credsfile;
 pub use config::DOWNLOADS_DIR;
 pub use config::WASMCLOUD_PID_FILE;
-use config::*;
+pub use config::*;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct UpCommand {
@@ -269,30 +270,35 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
 
     // Avoid downloading + starting NATS if the user already runs their own server. Ignore connect_only
     // if this server has a remote and credsfile as we have to start a leafnode in that scenario
+    let nats_is_running = is_nats_running(nats_listen_address.clone(), &install_dir).await?;
     let nats_opts = cmd.nats_opts.clone();
-    let nats_bin = if !cmd.nats_opts.connect_only
-        || cmd.nats_opts.nats_remote_url.is_some() && cmd.nats_opts.nats_credsfile.is_some()
-    {
-        // Download NATS if not already installed
-        spinner.update_spinner_message(" Downloading NATS ...".to_string());
-        let nats_binary = ensure_nats_server(&cmd.nats_opts.nats_version, &install_dir).await?;
+    if !nats_is_running {
+        if !cmd.nats_opts.connect_only
+            || cmd.nats_opts.nats_remote_url.is_some() && cmd.nats_opts.nats_credsfile.is_some()
+        {
+            // Download NATS if not already installed
+            spinner.update_spinner_message(" Downloading NATS ...".to_string());
+            let nats_binary = ensure_nats_server(&cmd.nats_opts.nats_version, &install_dir).await?;
 
-        spinner.update_spinner_message(" Starting NATS ...".to_string());
-        start_nats(&install_dir, &nats_binary, cmd.nats_opts.clone()).await?;
-        Some(nats_binary)
+            spinner.update_spinner_message(" Starting NATS ...".to_string());
+            start_nats(&install_dir, &nats_binary, cmd.nats_opts.clone()).await?;
+            Some(nats_binary)
+        } else {
+            // If we can connect to NATS, return None as we aren't managing the child process.
+            // Otherwise, exit with error since --nats-connect-only was specified
+            tokio::net::TcpStream::connect(&nats_listen_address)
+                .await
+                .map(|_| None)
+                .map_err(|_| {
+                    anyhow!(
+                        "Could not connect to NATS at {}, exiting since --nats-connect-only was set",
+                        nats_listen_address
+                    )
+                })?
+        };
     } else {
-        // If we can connect to NATS, return None as we aren't managing the child process.
-        // Otherwise, exit with error since --nats-connect-only was specified
-        tokio::net::TcpStream::connect(&nats_listen_address)
-            .await
-            .map(|_| None)
-            .map_err(|_| {
-                anyhow!(
-                    "Could not connect to NATS at {}, exiting since --nats-connect-only was set",
-                    nats_listen_address
-                )
-            })?
-    };
+        spinner.println("Detected a running NATS server");
+    }
 
     // Download wasmCloud if not already installed
     let wasmcloud_executable = if !cmd.wasmcloud_opts.start_only {
@@ -300,15 +306,40 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         ensure_wasmcloud(&cmd.wasmcloud_opts.wasmcloud_version, &install_dir).await?
     } else {
         // Ensure we clean up the NATS server if we can't start wasmCloud
-        if nats_bin.is_some() {
+        if nats_is_running {
             stop_nats(install_dir).await?;
         }
         return Err(anyhow!("wasmCloud was not installed, exiting without downloading as --wasmcloud-start-only was set"));
     };
 
+    // Find an open port for the host
+    let host_port = if let Some(port_number) = cmd.wasmcloud_opts.dashboard_port {
+        port_number
+    } else {
+        match find_open_port().await {
+            Ok(port_number) => port_number,
+            Err(e) => {
+                // Find number of hosts running. If they are 0, stop nats
+                if nats_is_running {
+                    let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone()).await?;
+                    if hosts.is_empty() {
+                        stop_nats(install_dir).await?;
+                    }
+                }
+                return Err(anyhow!("Error finding an open port {:?}", e));
+            }
+        }
+    };
+
+    let mut host_config_values = HashMap::new();
+    host_config_values.insert(
+        "WASMCLOUD_DASHBOARD_PORT".to_string(),
+        host_port.to_string(),
+    );
+
     // Redirect output (which is on stderr) to a log file in detached mode, or use the terminal
     spinner.update_spinner_message(" Starting wasmCloud ...".to_string());
-    let wasmcloud_log_path = install_dir.join("wasmcloud.log");
+    let wasmcloud_log_path = install_dir.join(format!("wasmcloud_host_{}.log", host_port));
     let stderr: Stdio = if cmd.detached {
         tokio::fs::File::create(&wasmcloud_log_path)
             .await?
@@ -318,24 +349,22 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     } else {
         Stdio::piped()
     };
-    let dashboard_port = cmd
-        .wasmcloud_opts
-        .dashboard_port
-        .map(|p| p.to_string())
-        .unwrap_or_else(|| DEFAULT_DASHBOARD_PORT.to_string());
+
     let version = cmd.wasmcloud_opts.wasmcloud_version.clone();
-    let host_env = configure_host_env(nats_opts, cmd.wasmcloud_opts).await;
+
+    let host_env = configure_host_env(nats_opts, cmd.wasmcloud_opts, host_config_values).await;
     let wasmcloud_child = match start_wasmcloud_host(
         &wasmcloud_executable,
         std::process::Stdio::null(),
         stderr,
-        host_env,
+        host_env.clone(),
     )
     .await
     {
         Ok(child) => child,
         Err(e) => {
             // Ensure we clean up the NATS server if we can't start wasmCloud
+            // TODO: check number of hosts before stopping nats
             if !cmd.nats_opts.connect_only {
                 stop_nats(install_dir).await?;
             }
@@ -343,9 +372,9 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         }
     };
 
-    let url = format!("{}:{}", "127.0.0.1", dashboard_port);
+    let url = format!("{}:{}", LOCALHOST, host_port);
     if wait_for_server(&url, "Washboard").await.is_err() {
-        if nats_bin.is_some() {
+        if nats_is_running {
             stop_nats(install_dir).await?;
         }
         return Err(anyhow!("wasmCloud host did not start. Failed to connect to washboard. Check host-logs at {:?}.", wasmcloud_log_path));
@@ -361,13 +390,22 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         );
 
         // Terminate wasmCloud and NATS processes
-        let output = stop_wasmcloud(wasmcloud_executable.clone()).await?;
+        let output = stop_wasmcloud(
+            wasmcloud_executable.clone(),
+            host_env.get("RELEASE_NODE").cloned(),
+        )
+        .await?;
         if !output.status.success() {
             log::warn!("wasmCloud exited with a non-zero exit status, processes may need to be cleaned up manually")
         }
-        if !cmd.nats_opts.connect_only {
-            stop_nats(&install_dir).await?;
-        }
+        // The following code does nothing as NATS is killed as soon as Ctrl+C is hit.
+        // This results in zombie processes if the non-detatched host was the first one to be run and NATS was spawned along with this first host.
+        // The zombie processes are the other hosts that were connected to this NATS server. Ref spawn vs group-spawn for these processes.
+
+        // let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone()).await?;
+        // if !cmd.nats_opts.connect_only && hosts.is_empty() {
+        //     stop_nats(&install_dir).await?;
+        // }
 
         spinner.finish_and_clear();
     }
@@ -381,7 +419,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     if cmd.detached {
         // Write the pid file with the selected version
         tokio::fs::write(install_dir.join(config::WASMCLOUD_PID_FILE), version).await?;
-        let url = format!("http://localhost:{}", dashboard_port);
+        let url = format!("{}:{}", "http://localhost", host_port);
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
         out_json.insert("kill_cmd".to_string(), json!("wash down"));
@@ -401,6 +439,50 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     }
 
     Ok(CommandOutput::new(out_text, out_json))
+}
+
+pub(crate) async fn is_nats_running(
+    nats_listen_address: String,
+    install_dir: &Path,
+) -> Result<bool> {
+    let is_nats_listening = tokio::net::TcpStream::connect(&nats_listen_address)
+        .await
+        .is_ok();
+    let pid_file_path = nats_pid_path(install_dir);
+    let pid_file_exists = pid_file_path.is_file();
+
+    match (is_nats_listening, pid_file_exists) {
+        (true, true) => {
+            // Nats server is running and PID file exists: it's our wasm NATS server
+            Ok(true)
+        }
+        (true, false) => {
+            // NATS is running, PID file doesn't exist: someone else is running NATS
+            Err(anyhow!(
+                "Cannot start NATS server. An unknown process is listening on {nats_listen_address}. Kill it and try again"
+            ))
+        }
+        (false, true) => {
+            // NATS isn't running but PID file exists: clean PID file and start server
+            let _ = tokio::fs::remove_file(&pid_file_path).await;
+            Ok(false)
+        }
+        (false, false) => {
+            // NATS server isn't running PID file doesn't exist: start a new NATS server
+            Ok(false)
+        }
+    }
+}
+
+pub(crate) async fn find_open_port() -> Result<u16> {
+    for i in HOST_PORT_RANGE_START..=HOST_PORT_RANGE_END {
+        if let Ok(conn) = tokio::net::TcpStream::connect((LOCALHOST, i)).await {
+            drop(conn);
+        } else {
+            return Ok(i);
+        }
+    }
+    Err(anyhow!("Failed to find open port for host"))
 }
 
 /// Helper function to start the NATS binary, redirecting output to nats.log
@@ -433,7 +515,15 @@ async fn start_nats(install_dir: &Path, nats_binary: &Path, nats_opts: NatsOpts)
         .await?
         .into_std()
         .await;
-    start_nats_server(nats_binary, nats_log_file, nats_opts.into()).await
+    let nats_process = start_nats_server(nats_binary, nats_log_file, nats_opts.into()).await?;
+    let nats_pid = nats_process.id();
+
+    // save the PID
+    if let Some(pid) = nats_pid {
+        let pid_file = nats_pid_path(install_dir);
+        tokio::fs::write(&pid_file, pid.to_string()).await?;
+    }
+    Ok(nats_process)
 }
 
 /// Helper function to run wasmCloud in interactive mode

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -8,6 +8,7 @@ use std::sync::{
     Arc,
 };
 
+use anyhow::bail;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use serde_json::json;
@@ -19,15 +20,15 @@ use tokio::{
 };
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::start::{
-    ensure_nats_server, ensure_wasmcloud, start_nats_server, start_wasmcloud_host, wait_for_server,
-    NatsConfig,
+    ensure_nats_server, ensure_wasmcloud, is_nats_running, nats_pid_path, start_nats_server,
+    start_wasmcloud_host, wait_for_server, NatsConfig,
 };
 
 use crate::appearance::spinner::Spinner;
 use crate::cfg::cfg_dir;
 use crate::down::stop_nats;
-use crate::down::{nats_pid_path, stop_wasmcloud};
-use crate::util::get_wasmcloud_hosts;
+use crate::down::stop_wasmcloud;
+use crate::util::{get_wasmcloud_hosts, nats_client_from_opts};
 
 mod config;
 mod credsfile;
@@ -265,14 +266,32 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     let install_dir = cfg_dir()?.join(DOWNLOADS_DIR);
     create_dir_all(&install_dir).await?;
     let spinner = Spinner::new(&output_kind)?;
+
+    // Find an open port for the host
+    let host_port = if let Some(port_number) = cmd.wasmcloud_opts.dashboard_port {
+        port_number
+    } else {
+        find_open_port().await?
+    };
+
+    if tokio::net::TcpStream::connect(format!("localhost:{host_port}"))
+        .await
+        .is_ok()
+    {
+        return Err(anyhow!(
+            "Could not start wasmCloud, a process is already listening on localhost:{}",
+            host_port
+        ));
+    }
+
     // Capture listen address to keep the value after the nats_opts are moved
     let nats_listen_address = format!("{}:{}", cmd.nats_opts.nats_host, cmd.nats_opts.nats_port);
 
     // Avoid downloading + starting NATS if the user already runs their own server. Ignore connect_only
     // if this server has a remote and credsfile as we have to start a leafnode in that scenario
-    let nats_is_running = is_nats_running(nats_listen_address.clone(), &install_dir).await?;
+    let mut nats_is_running = is_nats_running(nats_listen_address.clone(), &install_dir).await?;
     let nats_opts = cmd.nats_opts.clone();
-    if !nats_is_running {
+    let nats_bin = if !nats_is_running {
         if !cmd.nats_opts.connect_only
             || cmd.nats_opts.nats_remote_url.is_some() && cmd.nats_opts.nats_credsfile.is_some()
         {
@@ -282,23 +301,33 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
 
             spinner.update_spinner_message(" Starting NATS ...".to_string());
             start_nats(&install_dir, &nats_binary, cmd.nats_opts.clone()).await?;
+            nats_is_running = true;
             Some(nats_binary)
         } else {
-            // If we can connect to NATS, return None as we aren't managing the child process.
-            // Otherwise, exit with error since --nats-connect-only was specified
-            tokio::net::TcpStream::connect(&nats_listen_address)
-                .await
-                .map(|_| None)
-                .map_err(|_| {
-                    anyhow!(
-                        "Could not connect to NATS at {}, exiting since --nats-connect-only was set",
-                        nats_listen_address
-                    )
-                })?
-        };
+            bail!(
+                "Could not connect to NATS at {}, exiting since --nats-connect-only was set",
+                nats_listen_address
+            );
+        }
     } else {
         spinner.println("Detected a running NATS server");
-    }
+        None
+    };
+
+    let nats_client = nats_client_from_opts(
+        &cmd.wasmcloud_opts
+            .ctl_host
+            .clone()
+            .unwrap_or(DEFAULT_NATS_HOST.to_string()),
+        &cmd.wasmcloud_opts
+            .ctl_port
+            .map(|port| port.to_string())
+            .unwrap_or(DEFAULT_NATS_PORT.to_string()),
+        cmd.wasmcloud_opts.ctl_jwt.clone(),
+        cmd.wasmcloud_opts.ctl_seed.clone(),
+        cmd.wasmcloud_opts.ctl_credsfile.clone(),
+    )
+    .await?;
 
     // Download wasmCloud if not already installed
     let wasmcloud_executable = if !cmd.wasmcloud_opts.start_only {
@@ -306,36 +335,14 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         ensure_wasmcloud(&cmd.wasmcloud_opts.wasmcloud_version, &install_dir).await?
     } else {
         // Ensure we clean up the NATS server if we can't start wasmCloud
-        if nats_is_running {
+        if nats_bin.is_some() && cmd.wasmcloud_opts.start_only {
             stop_nats(install_dir).await?;
         }
         return Err(anyhow!("wasmCloud was not installed, exiting without downloading as --wasmcloud-start-only was set"));
     };
 
-    // Find an open port for the host
-    let host_port = if let Some(port_number) = cmd.wasmcloud_opts.dashboard_port {
-        port_number
-    } else {
-        match find_open_port().await {
-            Ok(port_number) => port_number,
-            Err(e) => {
-                // Find number of hosts running. If they are 0, stop nats
-                if nats_is_running {
-                    let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone()).await?;
-                    if hosts.is_empty() {
-                        stop_nats(install_dir).await?;
-                    }
-                }
-                return Err(anyhow!("Error finding an open port {:?}", e));
-            }
-        }
-    };
-
     let mut host_config_values = HashMap::new();
-    host_config_values.insert(
-        "WASMCLOUD_DASHBOARD_PORT".to_string(),
-        host_port.to_string(),
-    );
+    host_config_values.insert(WASMCLOUD_DASHBOARD_PORT.to_string(), host_port.to_string());
 
     // Redirect output (which is on stderr) to a log file in detached mode, or use the terminal
     spinner.update_spinner_message(" Starting wasmCloud ...".to_string());
@@ -352,7 +359,12 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
 
     let version = cmd.wasmcloud_opts.wasmcloud_version.clone();
 
-    let host_env = configure_host_env(nats_opts, cmd.wasmcloud_opts, host_config_values).await;
+    let wasmcloud_opts = WasmcloudOpts {
+        dashboard_port: Some(host_port),
+        ..cmd.wasmcloud_opts
+    };
+
+    let host_env = configure_host_env(nats_opts, wasmcloud_opts).await;
     let wasmcloud_child = match start_wasmcloud_host(
         &wasmcloud_executable,
         std::process::Stdio::null(),
@@ -364,9 +376,11 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         Ok(child) => child,
         Err(e) => {
             // Ensure we clean up the NATS server if we can't start wasmCloud
-            // TODO: check number of hosts before stopping nats
-            if !cmd.nats_opts.connect_only {
-                stop_nats(install_dir).await?;
+            if nats_is_running {
+                let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone(), nats_client).await?;
+                if !cmd.nats_opts.connect_only && hosts.is_empty() {
+                    stop_nats(install_dir).await?;
+                }
             }
             return Err(e);
         }
@@ -375,37 +389,33 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     let url = format!("{}:{}", LOCALHOST, host_port);
     if wait_for_server(&url, "Washboard").await.is_err() {
         if nats_is_running {
-            stop_nats(install_dir).await?;
+            let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone(), nats_client).await?;
+            if hosts.is_empty() {
+                stop_nats(install_dir).await?;
+            }
         }
         return Err(anyhow!("wasmCloud host did not start. Failed to connect to washboard. Check host-logs at {:?}.", wasmcloud_log_path));
     }
 
     spinner.finish_and_clear();
     if !cmd.detached {
-        run_wasmcloud_interactive(wasmcloud_child, output_kind).await?;
+        run_wasmcloud_interactive(wasmcloud_child, host_port.to_string(), output_kind).await?;
 
         let spinner = Spinner::new(&output_kind)?;
         spinner.update_spinner_message(
             "CTRL+c received, gracefully stopping wasmCloud and NATS...".to_string(),
         );
 
-        // Terminate wasmCloud and NATS processes
-        let output = stop_wasmcloud(
+        // Terminate wasmCloud
+        let output: std::process::Output = stop_wasmcloud(
             wasmcloud_executable.clone(),
-            host_env.get("RELEASE_NODE").cloned(),
+            host_env.get(RELEASE_NODE).cloned(),
         )
         .await?;
         if !output.status.success() {
             log::warn!("wasmCloud exited with a non-zero exit status, processes may need to be cleaned up manually")
         }
-        // The following code does nothing as NATS is killed as soon as Ctrl+C is hit.
-        // This results in zombie processes if the non-detatched host was the first one to be run and NATS was spawned along with this first host.
-        // The zombie processes are the other hosts that were connected to this NATS server. Ref spawn vs group-spawn for these processes.
-
-        // let hosts = get_wasmcloud_hosts(wasmcloud_executable.clone()).await?;
-        // if !cmd.nats_opts.connect_only && hosts.is_empty() {
-        //     stop_nats(&install_dir).await?;
-        // }
+        // NATS is terminated by Ctrl+C
 
         spinner.finish_and_clear();
     }
@@ -419,7 +429,7 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     if cmd.detached {
         // Write the pid file with the selected version
         tokio::fs::write(install_dir.join(config::WASMCLOUD_PID_FILE), version).await?;
-        let url = format!("{}:{}", "http://localhost", host_port);
+        let url: std::string::String = format!("http://{LOCALHOST}:{host_port}");
         out_json.insert("wasmcloud_url".to_string(), json!(url));
         out_json.insert("wasmcloud_log".to_string(), json!(wasmcloud_log_path));
         out_json.insert("kill_cmd".to_string(), json!("wash down"));
@@ -441,44 +451,12 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
     Ok(CommandOutput::new(out_text, out_json))
 }
 
-pub(crate) async fn is_nats_running(
-    nats_listen_address: String,
-    install_dir: &Path,
-) -> Result<bool> {
-    let is_nats_listening = tokio::net::TcpStream::connect(&nats_listen_address)
-        .await
-        .is_ok();
-    let pid_file_path = nats_pid_path(install_dir);
-    let pid_file_exists = pid_file_path.is_file();
-
-    match (is_nats_listening, pid_file_exists) {
-        (true, true) => {
-            // Nats server is running and PID file exists: it's our wasm NATS server
-            Ok(true)
-        }
-        (true, false) => {
-            // NATS is running, PID file doesn't exist: someone else is running NATS
-            Err(anyhow!(
-                "Cannot start NATS server. An unknown process is listening on {nats_listen_address}. Kill it and try again"
-            ))
-        }
-        (false, true) => {
-            // NATS isn't running but PID file exists: clean PID file and start server
-            let _ = tokio::fs::remove_file(&pid_file_path).await;
-            Ok(false)
-        }
-        (false, false) => {
-            // NATS server isn't running PID file doesn't exist: start a new NATS server
-            Ok(false)
-        }
-    }
-}
-
 pub(crate) async fn find_open_port() -> Result<u16> {
     for i in HOST_PORT_RANGE_START..=HOST_PORT_RANGE_END {
-        if let Ok(conn) = tokio::net::TcpStream::connect((LOCALHOST, i)).await {
-            drop(conn);
-        } else {
+        if tokio::net::TcpStream::connect((LOCALHOST, i))
+            .await
+            .is_err()
+        {
             return Ok(i);
         }
     }
@@ -529,6 +507,7 @@ async fn start_nats(install_dir: &Path, nats_binary: &Path, nats_opts: NatsOpts)
 /// Helper function to run wasmCloud in interactive mode
 async fn run_wasmcloud_interactive(
     mut wasmcloud_child: Child,
+    port: String,
     output_kind: OutputKind,
 ) -> Result<()> {
     use std::sync::mpsc::channel;
@@ -546,7 +525,10 @@ async fn run_wasmcloud_interactive(
     .expect("Error setting Ctrl-C handler, please file a bug issue https://github.com/wasmCloud/wash/issues/new/choose");
 
     if output_kind != OutputKind::Json {
-        println!("🏃 Running in interactive mode, your host is running at http://localhost:4000",);
+        println!(
+            "🏃 Running in interactive mode, your host is running at http://localhost:{}",
+            port
+        );
         println!("🚪 Press `CTRL+c` at any time to exit");
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,44 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
+use crate::up::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use anyhow::{anyhow, bail, Context, Result};
+use std::path::Path;
 use term_table::{Table, TableStyle};
 use wash_lib::config::DEFAULT_NATS_TIMEOUT_MS;
+use wash_lib::start::is_wasmcloud_running;
+use wasmcloud_control_interface::{ClientBuilder, Host};
+
+// filter based on pid
+pub(crate) async fn get_wasmcloud_hosts<P>(bin_path: P) -> Result<Vec<Host>>
+where
+    P: AsRef<Path>,
+{
+    let dummy_nats_client = async_nats::ConnectOptions::default()
+        .connect(format!("{DEFAULT_NATS_HOST}:{DEFAULT_NATS_PORT}"))
+        .await?;
+
+    let control_client = ClientBuilder::new(dummy_nats_client)
+        // .js_domain(WASMCLOUD_JS_DOMAIN.to_string()) // accept this as a var from wash up or env vars
+        .build()
+        .await
+        .map_err(|err| {
+            anyhow!(format!(
+                "Failed to construct local control interface client: {err:?}"
+            ))
+        })?;
+    let hosts = control_client.get_hosts().await.map_err(|err| {
+        anyhow!(format!(
+            "Was able to connect to NATS, but failed to get hosts: {err:?}"
+        ))
+    })?;
+    let mut running_hosts = Vec::new();
+    for host in hosts {
+        if is_wasmcloud_running(&bin_path, host.clone().id).await? {
+            running_hosts.push(host);
+        }
+    }
+    Ok(running_hosts)
+}
 
 pub(crate) fn format_optional(value: Option<String>) -> String {
     value.unwrap_or_else(|| "N/A".into())

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
-use std::{fs::File, io::Read, path::PathBuf};
+use std::{fs::File, io::Read, path::PathBuf, time::Duration};
 
-use crate::up::{DEFAULT_NATS_HOST, DEFAULT_NATS_PORT};
 use anyhow::{anyhow, bail, Context, Result};
 use std::path::Path;
 use term_table::{Table, TableStyle};
@@ -8,17 +7,15 @@ use wash_lib::config::DEFAULT_NATS_TIMEOUT_MS;
 use wash_lib::start::is_wasmcloud_running;
 use wasmcloud_control_interface::{ClientBuilder, Host};
 
-// filter based on pid
-pub(crate) async fn get_wasmcloud_hosts<P>(bin_path: P) -> Result<Vec<Host>>
+pub(crate) async fn get_wasmcloud_hosts<P>(
+    bin_path: P,
+    nats_client: async_nats::Client,
+) -> Result<Vec<Host>>
 where
     P: AsRef<Path>,
 {
-    let dummy_nats_client = async_nats::ConnectOptions::default()
-        .connect(format!("{DEFAULT_NATS_HOST}:{DEFAULT_NATS_PORT}"))
-        .await?;
-
-    let control_client = ClientBuilder::new(dummy_nats_client)
-        // .js_domain(WASMCLOUD_JS_DOMAIN.to_string()) // accept this as a var from wash up or env vars
+    let control_client = ClientBuilder::new(nats_client)
+        .auction_timeout(Duration::from_millis(2000))
         .build()
         .await
         .map_err(|err| {


### PR DESCRIPTION
## Feature: Resurrect multiple local wasmcloud hosts successively. 
These hosts can be in detached or interactive mode.
The default NATS port is 4222 and the unless explicitly specified, the hosts will use ports from 4000 to 5000.

Usage: 
To spin a host run `wash up` or `wash up -d`. Specify the host port with `dashboard-port` flag.

To spin a host down, run `wash down --host-id <HOST-ID>` with the respective host-id or `wash down --all` for shutting down all hosts. The host-id can be obtained from `wash ctl get hosts`.

Details:
This host-id is generated using the `WASMCLOUD_HOST_SEED` environment variable. Unless specified by the user, a new n-keys key-pair is generated where the seed is passed on to this variable. A public key is generated and stored as `RELEASE_NODE` which is used to uniquely identify each host. The `RELEASE_NODE` is the host-id that the user gets on running `wash ctl get hosts`. 
When resurrecting consecutive hosts, if a NATS server is already running and a PID file exists, the consecutive hosts attach to this NATS server.

## Related Issues
Fixes #464 

## Release Information
Next

## Consumer Impact
The method to operate `wash up` and `wash down` will change with added options.


## Testing
Locally tested

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
Manually verified!
