### PR TITLE
Override help text with RFC command structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -9,7 +9,7 @@ keywords = ["webassembly", "wasmcloud", "wash", "cli"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/wasmcloud/wash"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 
 [badges]
 maintenance = {status = "actively-developed"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ mod smithy;
 mod up;
 mod util;
 
-const ASCII: &str = r#"
+const HELP: &str = r#"
 _________________________________________________________________________________
                                _____ _                 _    _____ _          _ _
                               / ____| |               | |  / ____| |        | | |
@@ -49,11 +49,44 @@ ________________________________________________________________________________
    \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
 _________________________________________________________________________________
 
-A single CLI to handle all of your wasmCloud tooling needs
+Interact and manage wasmCloud applications, projects, and runtime environments
+
+Usage: wash [OPTIONS] <COMMAND>
+
+Applications:
+  app          Manage declarative applications and deployments (wadm) (experimental)
+  call         Invoke a wasmCloud actor
+  ctl          Interact with a wasmCloud control interface
+
+Projects:
+  build        Build (and sign) a wasmCloud actor, provider, or interface
+  claims       Generate and manage JWTs for wasmCloud actors
+  gen          Generate code from smithy IDL files
+  inspect      Inspect capability provider or actor module
+  lint         Perform lint checks on smithy models
+  new          Create a new project from template
+  par          Create, inspect, and modify capability provider archive files
+  reg          Push an actor or provider component to an OCI or Bindle registry
+  validate     Perform validation checks on smithy models
+
+Configuration:
+  completions  Generate shell completions
+  ctx          Manage wasmCloud host configuration contexts
+  drain        Manage contents of local wasmCloud caches
+  keys         Utilities for generating and managing keys
+
+Runtime environments:
+  up           Bootstrap a wasmCloud environment
+  down         Tear down a wasmCloud environment launched with wash up
+
+Options:
+  -o, --output <OUTPUT>  Specify output format (text or json) [default: text]
+  -h, --help             Print help
+  -V, --version          Print version
 "#;
 
 #[derive(Debug, Clone, Parser)]
-#[clap(name = "wash", about = ASCII, version)]
+#[clap(name = "wash", version, override_help = HELP)]
 struct Cli {
     #[clap(
         short = 'o',
@@ -68,6 +101,7 @@ struct Cli {
     command: CliCommand,
 }
 
+// NOTE: If you change the description here, ensure you also change it in the help text constant above
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Subcommand)]
 enum CliCommand {


### PR DESCRIPTION
## Feature or Problem
This PR overrides the help text when you run `wash --help` with a constant format string. This will notably need to be updated _every time_ we add new subcommands, but there isn't quite a way to add "subcommand headers" or similar.

The point of this PR is to move our help organization closer to the proposal in #538. I changed no commands in order to get this to work, but I've bumped to 0.18 since this is a change in the top level help text. You can think of this as part 1, while part 2 will be a large refactor of commands like the `ctl` command and moving `gen` / `lint` / `validate` into `interface`.

This help looks like this!
```bash
~/github.com/wasmcloud/wash ➜ cargo run
_________________________________________________________________________________
                               _____ _                 _    _____ _          _ _
                              / ____| |               | |  / ____| |        | | |
 __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
 \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
_________________________________________________________________________________

Interact and manage wasmCloud applications, projects, and runtime environments

Usage: wash [OPTIONS] <COMMAND>

Applications:
  app          Manage declarative applications and deployments (wadm) (experimental)
  call         Invoke a wasmCloud actor
  ctl          Interact with a wasmCloud control interface

Projects:
  build        Build (and sign) a wasmCloud actor, provider, or interface
  gen          Generate code from smithy IDL files
  inspect      Inspect capability provider or actor module
  lint         Perform lint checks on smithy models
  new          Create a new project from template
  par          Create, inspect, and modify capability provider archive files
  reg          Push an actor or provider component to an OCI or Bindle registry
  validate     Perform validation checks on smithy models

Configuration:
  completions  Generate shell completions
  ctx          Manage wasmCloud host configuration contexts
  drain        Manage contents of local wasmCloud caches
  keys         Utilities for generating and managing keys

Runtime environments:
  up           Bootstrap a wasmCloud environment
  down         Tear down a wasmCloud environment launched with wash up

Options:
  -o, --output <OUTPUT>  Specify output format (text or json) [default: text]
  -h, --help             Print help
  -V, --version          Print version
```

## Related Issues
#538 

## Release Information
v0.18.0

## Consumer Impact
Consumers will see commands ordered in four different sections, but no existing wash commands will change.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

I considered adding a unit test to ensure the subcommand text matches, but I'd much rather bring in a crate that does const format strings or something instead.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I ran `cargo run` and `cargo run --help` to make sure it worked 🎉 
