### PR TITLE
Set up 0.18.0 alpha release for testing

### DIFF
--- a/.github/workflows/washlib.yml
+++ b/.github/workflows/washlib.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.18.0"
+version = "0.18.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.9.0"
+version = "0.9.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.18.0"
+version = "0.18.0-alpha.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -135,7 +135,7 @@ toml = "0.7.2"
 wadm = "0.4.0-alpha.2"
 walkdir = "2.3"
 wascap = "0.10.1"
-wash-lib = { version = "0.9.0", path = "./crates/wash-lib" }
+wash-lib = { version = "0.9.0-alpha.1", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.13.0"
 wasmcloud-control-interface = "0.25"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.9.0"
+version = "0.9.0-alpha.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
## Feature or Problem
This PR changes the versions in `Cargo.toml` for both wash-cli and wash-lib to alpha versions so we can cut releases for testing.

## Related Issues
N/A

## Release Information
`0.18.0-alpha.1`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
