### PR TITLE
Fix wash-lib CI by running it on PR, fix wadm test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test: ## Run unit test suite
 
 test-wash-ci:
 	@$(CARGO) nextest run --profile ci --workspace --bin wash
+	@$(CARGO) nextest run --profile ci -p wash-lib
 
 test-watch: ## Run unit tests continously, can optionally specify a target test filter.
 	@$(CARGO) watch -- $(CARGO) nextest run $(TARGET)


### PR DESCRIPTION
## Feature or Problem
This PR ensures we run wash-lib CI on PR so we don't get surprised when we try to release, https://github.com/wasmCloud/wash/actions/runs/4949296556, and fixes a wadm test that ended up connecting to the NATS server running in parallel on accident.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
None
## Testing


<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tests work for me now
