### PR TITLE
Document Sign Off Requirements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,12 @@
 		}
 	},
 	"workspaceMount": "source=${localWorkspaceFolder},target=/wash,type=bind,consistency=cached",
-	"workspaceFolder": "/wash"
+	"workspaceFolder": "/wash",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"git.alwaysSignOff": true
+			}
+		}
+	}
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,6 +9,7 @@ This document serves as a guide and reference for people looking to develop `was
     - [Optional Tools](#optional-tools)
   - [Building the project](#building-the-project)
   - [Testing the project](#testing-the-project)
+  - [Making Commits](#making-commits)
 
 ## Development Prerequistes
 
@@ -75,3 +76,14 @@ To test a *specific* target test(s) continuously:
 ```console
 TARGET=integration_new_handles_dashed_names make test-watch
 ```
+
+## Making Commits
+
+For us to be able to merge in any commits, they need to be signed off. If you didn't do so, the PR bot will let you know how to fix it, but it's worth knowing how to do it in advance.
+
+There are a few options:
+- use `git commit -s` in the CLI
+- in `vscode`, go to settings and set the `git.alwaysSignOff` setting. Note that the dev container configuration in this repo sets this up by default.
+- manually add "Signed-off-by: NAME <EMAIL>" at the end of each commit
+
+You may also be able to use GPG signing in leu of a sign off.


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
The repository requires all commits to be signed off, but that information isn't documented in the developer guide - leading to possible confusion from new contributors. This PR adds to the documentation, as well as sets up the dev container to automatically sign off all commits.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Checked that the commit being pushed was signed when using the dev container as set up in this PR.