### PR TITLE
Bumped wadm to 0.4.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,9 +4044,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add1c2aa376d24ab5592fd0949d09f5d04559f2a61b07a213832bc29cd8769ce"
+checksum = "ac1f43286a28056f987429e3c347d561a726d68d2b892e9d2b6756287486381d"
 dependencies = [
  "anyhow",
  "async-nats 0.29.0",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.18.0-alpha.1"
+version = "0.18.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.18.0-alpha.1"
+version = "0.18.0-alpha.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -132,10 +132,10 @@ tokio = { version = "1.28.1", default-features = false, features = ["fs"] }
 tokio-stream = "0.1"
 tokio-tar = "0.3"
 toml = "0.7.4"
-wadm = "0.4.0-alpha.2"
+wadm = "0.4.0-alpha.3"
 walkdir = "2.3"
 wascap = "0.10.1"
-wash-lib = { version = "0.9.0-alpha.1", path = "./crates/wash-lib" }
+wash-lib = { version = "0.9.0-alpha.2", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.13.0"
 wasmcloud-control-interface = "0.25"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -1,7 +1,6 @@
 //! Generate wasmCloud projects (WebAssembly actors, native capability providers, or contract interfaces) from templates
 
 use std::{
-    borrow::Borrow,
     fmt, fs,
     path::{Path, PathBuf},
     process::Stdio,
@@ -316,7 +315,7 @@ where
         .as_ref()
         .map_or_else(|| template_folder.to_owned(), |s| template_folder.join(s));
     loop {
-        let file_path = search_folder.join(name.borrow());
+        let file_path = search_folder.join(name);
         if file_path.exists() {
             return Ok(file_path);
         }

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -9,7 +9,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.2";
+pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.3";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
 pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";


### PR DESCRIPTION
This PR bumps wadm to the latest alpha release, v0.4.0-alpha.3, which includes a few changes and fixes. Also bumps our wash-lib and wash-cli versions in order to release the next alpha testing release.