### PR TITLE
add Ubuntu 23 and Fedora 38 to list of distros

### DIFF
--- a/.github/workflows/release_debrpm.yml
+++ b/.github/workflows/release_debrpm.yml
@@ -71,13 +71,13 @@ jobs:
           nfpm pkg --packager rpm -f build/nfpm.${{matrix.arch}}.yaml
       - name: Push amd64 (deb)
         run: |
-          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261)
+          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261 266)
           for distro_version in "${debs[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_${{matrix.arch}}.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done
       - name: Push x86_64 (rpm)
         run: |
-          rpms=(194 204 209 216 226 231 236 239 240 244 260)
+          rpms=(194 204 209 216 226 231 236 239 240 244 260 273)
           for distro_version in "${rpms[@]}"; do 
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.${{matrix.rpmarch}}.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
           done


### PR DESCRIPTION
## Feature or Problem
Ubuntu 23 and Fedora 38 are available now

## Testing
I'm not sure how to test this 🤔 