### PR TITLE
feat(ux): add deprecation warnings for changed CLI commands

### DIFF
--- a/src/common/registry_cmd.rs
+++ b/src/common/registry_cmd.rs
@@ -149,8 +149,14 @@ pub(crate) async fn handle_command(
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
     match command {
-        RegistryCommand::Pull(cmd) => registry_pull(cmd, output_kind).await,
-        RegistryCommand::Push(cmd) => registry_push(cmd, output_kind).await,
+        RegistryCommand::Pull(cmd) => {
+            eprintln!("[warn] `wash reg pull` has been deprecated in favor of `wash pull` and will be removed in a future version.");
+            registry_pull(cmd, output_kind).await
+        }
+        RegistryCommand::Push(cmd) => {
+            eprintln!("[warn] `wash reg push` has been deprecated in favor of `wash push` and will be removed in a future version.");
+            registry_push(cmd, output_kind).await
+        }
         RegistryCommand::Ping(cmd) => registry_ping(cmd).await,
     }
 }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -168,19 +168,28 @@ pub(crate) async fn handle_command(
             apply_manifest_output(results)
         }
         Get(CtlGetCommand::Hosts(cmd)) => {
+            eprintln!("[warn] `wash ctl get hosts` has been deprecated in favor of `wash get hosts` and will be removed in a future version.");
             handle_get_command(GetCommand::Hosts(cmd), output_kind).await?
         }
         Get(CtlGetCommand::HostInventory(cmd)) => {
+            eprintln!("[warn] `wash ctl get inventory` has been deprecated in favor of `wash get inventory` and will be removed in a future version.");
             handle_get_command(GetCommand::HostInventory(cmd), output_kind).await?
         }
         Get(CtlGetCommand::Claims(cmd)) => {
+            eprintln!("[warn] `wash ctl get claims` has been deprecated in favor of `wash get claims` and will be removed in a future version.");
             handle_get_command(GetCommand::Claims(cmd), output_kind).await?
         }
-        Link(cmd) => handle_link_command(cmd, output_kind).await?,
-        Start(cmd) => handle_start_command(cmd, output_kind).await?,
+        Link(cmd) => {
+            eprintln!("[warn] `wash ctl link` has been deprecated in favor of `wash link` and will be removed in a future version.");
+            handle_link_command(cmd, output_kind).await?
+        }
+        Start(cmd) => {
+            eprintln!("[warn] `wash ctl start` has been deprecated in favor of `wash start` and will be removed in a future version.");
+            handle_start_command(cmd, output_kind).await?
+        }
         Stop(StopCommand::Actor(cmd)) => {
+            eprintln!("[warn] `wash ctl stop` has been deprecated in favor of `wash stop` and will be removed in a future version.");
             sp.update_spinner_message(format!(" Stopping actor {} ... ", cmd.actor_id));
-
             stop_actor(cmd.clone()).await?
         }
         Stop(StopCommand::Provider(cmd)) => {


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Add deprecation warnings for refactored CLI commands

The commands look like this to stderr:

```
eprintln!("[warn] `wash reg pull` has been deprecated in favor of `wash pull` and will be removed in a future version.");
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
