### PR TITLE
Bumps wadm to 0.4.0 stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.18.0-alpha.2"
+version = "0.18.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.18.0-alpha.2"
+version = "0.18.0-alpha.3"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -136,7 +136,7 @@ toml = "0.7.4"
 wadm = "0.4.0"
 walkdir = "2.3"
 wascap = "0.10.1"
-wash-lib = { version = "0.9.0-alpha.2", path = "./crates/wash-lib" }
+wash-lib = { version = "0.9.0-alpha.3", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.13.0"
 wasmcloud-control-interface = "0.25"
 wasmcloud-test-util = "0.6.4"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -9,7 +9,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub(crate) const WADM_VERSION: &str = "v0.4.0-alpha.3";
+pub(crate) const WADM_VERSION: &str = "v0.4.0";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.62.1";
 pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";


### PR DESCRIPTION
## Feature or Problem
This PR bumps wash to use the stably-released version of `wadm`, 0.4.0

## Related Issues
#592 actually bumped the version, but not the version we download with `wash up`

## Release Information
v0.18.0-alpha.3

## Consumer Impact
stable wadm!

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
