### PR TITLE
feat(*): Adds `wash spy` command with experimental flag support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "handlebars"
 version = "4.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,11 +3030,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-transcode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -4163,6 +4188,7 @@ dependencies = [
  "async-nats 0.29.0",
  "cargo_metadata",
  "cargo_toml",
+ "chrono",
  "claims",
  "clap 4.3.0",
  "cloudevents-sdk 0.6.0",
@@ -4182,8 +4208,11 @@ dependencies = [
  "provider-archive",
  "regex",
  "reqwest",
+ "rmp-serde",
  "semver",
  "serde",
+ "serde-transcode",
+ "serde_cbor",
  "serde_json",
  "serde_with",
  "tempfile",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -26,6 +26,7 @@ async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async-nats = { workspace = true, optional = true}
 cargo_metadata = "0.15"
 cargo_toml = { workspace = true }
+chrono = "0.4"
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 cloudevents-sdk = { workspace = true }
 command-group = { workspace = true, features = ["with-tokio"] }
@@ -44,9 +45,12 @@ path-absolutize = { workspace = true, features = ["once_cell_cache"], optional =
 provider-archive = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
+rmp-serde = "1"
 semver = { workspace = true, features = ["serde"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
+serde_cbor = "0.11"
 serde_json = { workspace = true, optional = true }
+serde-transcode = "1"
 serde_with = { workspace = true }
 tempfile = { workspace = true }
 term-table = { workspace = true, optional = true }

--- a/crates/wash-lib/src/cli/get.rs
+++ b/crates/wash-lib/src/cli/get.rs
@@ -58,7 +58,7 @@ pub async fn get_host_inventory(cmd: GetHostInventoryCommand) -> Result<HostInve
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
     client
-        .get_host_inventory(&cmd.host_id.to_string())
+        .get_host_inventory(&cmd.host_id)
         .await
         .map_err(boxed_err_to_anyhow)
         .context("Was able to connect to NATS, but failed to get host inventory.")

--- a/crates/wash-lib/src/cli/link.rs
+++ b/crates/wash-lib/src/cli/link.rs
@@ -125,7 +125,7 @@ pub async fn delete_link(
 ) -> Result<CtlOperationAck> {
     wco.into_ctl_client(None)
         .await?
-        .remove_link(&actor_id.to_string(), contract_id, link_name)
+        .remove_link(actor_id, contract_id, link_name)
         .await
         .map_err(boxed_err_to_anyhow)
         .with_context(|| {
@@ -170,8 +170,8 @@ pub async fn create_link(
     wco.into_ctl_client(None)
         .await?
         .advertise_link(
-            &actor_id.to_string(),
-            &provider_id.to_string(),
+            actor_id,
+            provider_id,
             contract_id,
             link_name,
             labels_vec_to_hashmap(link_values.clone())?,

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -40,6 +40,7 @@ pub mod get;
 pub mod inspect;
 pub mod link;
 pub mod output;
+pub mod spy;
 pub mod start;
 pub mod stop;
 

--- a/crates/wash-lib/src/cli/spy.rs
+++ b/crates/wash-lib/src/cli/spy.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use clap::Parser;
+use futures::StreamExt;
+
+use super::{CliConnectionOpts, CommandOutput};
+use crate::{config::WashConnectionOptions, spier::Spier};
+
+#[derive(Debug, Parser, Clone)]
+pub struct SpyCommand {
+    /// Actor ID or name to match on. If a name is provided, we will attempt to resolve it to an ID
+    /// by checking if the actor_name or call_alias fields from the actor's claims contains the
+    /// given string. If more than one matches, then an error will be returned indicating the
+    /// options to choose from
+    #[clap(name = "actor")]
+    pub actor: String,
+
+    #[clap(flatten)]
+    pub opts: CliConnectionOpts,
+}
+
+/// Handles the spy command, printing all output to stdout until the command is interrupted
+pub async fn handle_command(cmd: SpyCommand) -> Result<CommandOutput> {
+    let wco: WashConnectionOptions = cmd.opts.try_into()?;
+    let ctl_client = wco.clone().into_ctl_client(None).await?;
+    let nats_client = wco.into_nats_client().await?;
+
+    let mut spier = Spier::new(&cmd.actor, &ctl_client, &nats_client).await?;
+
+    println!("Spying on actor {}\n", spier.actor_id());
+
+    while let Some(msg) = spier.next().await {
+        println!(
+            r#"
+[{}]
+From: {:<25}To: {:<25}Host: {}
+
+Operation: {}
+Message: {}"#,
+            msg.timestamp,
+            msg.from,
+            msg.to,
+            msg.invocation.host_id,
+            msg.invocation.operation,
+            msg.message
+        );
+    }
+
+    println!("Message subscribers closed");
+
+    Ok(CommandOutput::default())
+}

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -107,7 +107,7 @@ pub async fn start_actor(cmd: StartActorCommand) -> Result<CommandOutput> {
         .context("Failed to get lattice event channel")?;
 
     let ack = client
-        .start_actor(&host.to_string(), &cmd.actor_ref, cmd.count, None)
+        .start_actor(&host, &cmd.actor_ref, cmd.count, None)
         .await
         .map_err(boxed_err_to_anyhow)
         .with_context(|| format!("Failed to start actor: {}", &cmd.actor_ref))?;
@@ -268,7 +268,7 @@ pub async fn start_provider(cmd: StartProviderCommand) -> Result<CommandOutput> 
 
     let ack = client
         .start_provider(
-            &host.to_string(),
+            &host,
             &cmd.provider_ref,
             Some(cmd.link_name.clone()),
             None,

--- a/crates/wash-lib/src/cli/stop.rs
+++ b/crates/wash-lib/src/cli/stop.rs
@@ -110,8 +110,8 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
 
     let ack = client
         .stop_provider(
-            &cmd.host_id.to_string(),
-            &cmd.provider_id.to_string(),
+            &cmd.host_id,
+            &cmd.provider_id,
             &cmd.link_name,
             &cmd.contract_id,
             None,
@@ -178,12 +178,7 @@ pub async fn stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
         .map_err(boxed_err_to_anyhow)?;
 
     let ack = client
-        .stop_actor(
-            &cmd.host_id.to_string(),
-            &cmd.actor_id.to_string(),
-            cmd.count,
-            None,
-        )
+        .stop_actor(&cmd.host_id, &cmd.actor_id, cmd.count, None)
         .await
         .map_err(boxed_err_to_anyhow)?;
 
@@ -231,7 +226,7 @@ pub async fn stop_host(cmd: StopHostCommand) -> Result<CommandOutput> {
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
     let ack = client
-        .stop_host(&cmd.host_id.to_string(), Some(cmd.host_shutdown_timeout))
+        .stop_host(&cmd.host_id, Some(cmd.host_shutdown_timeout))
         .await
         .map_err(boxed_err_to_anyhow)?;
 

--- a/crates/wash-lib/src/common.rs
+++ b/crates/wash-lib/src/common.rs
@@ -1,4 +1,89 @@
+use std::str::FromStr;
+
+use crate::id::ModuleId;
+
+const CLAIMS_CALL_ALIAS: &str = "call_alias";
+pub(crate) const CLAIMS_NAME: &str = "name";
+pub(crate) const CLAIMS_SUBJECT: &str = "sub";
+
 /// Converts error from Send + Sync error to standard anyhow error
 pub(crate) fn boxed_err_to_anyhow(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
     anyhow::anyhow!(e.to_string())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FindIdError {
+    /// No matches were found
+    #[error("No actor found with the search term")]
+    NoMatches,
+    /// Multiple matches were found. The vector contains the list of actors that matched
+    #[error("Multiple actors found with the search term: {0:?}")]
+    MultipleMatches(Vec<String>),
+    #[error(transparent)]
+    Error(#[from] anyhow::Error),
+}
+
+/// Given a string, attempts to resolve an actor ID. Returning the actor ID and an optional friendly name
+///
+/// If the string is a valid actor ID, it will be returned unchanged. Resolution works by checking
+/// if the actor_name or call_alias fields from the actor's claims contains the given string. If
+/// more than one matches, then an error will be returned indicating the options to choose from
+pub async fn find_actor_id(
+    value: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<(ModuleId, Option<String>), FindIdError> {
+    if let Ok(id) = ModuleId::from_str(value) {
+        return Ok((id, None));
+    }
+
+    // Case insensitive searching here to make things nicer
+    let value = value.to_lowercase();
+    // If it wasn't an ID, get the claims
+    let claims = ctl_client
+        .get_claims()
+        .await
+        .map_err(|e| FindIdError::Error(anyhow::anyhow!("Unable to get claims: {}", e)))?;
+    let all_matches = claims
+        .claims
+        .iter()
+        .filter_map(|v| {
+            let id = v
+                .get(CLAIMS_SUBJECT)
+                .map(|s| s.as_str())
+                .unwrap_or_default();
+            // If it isn't a module, just skip
+            let id = match ModuleId::from_str(id) {
+                Ok(id) => id,
+                Err(_) => return None,
+            };
+            (v.get(CLAIMS_CALL_ALIAS)
+                .map(|s| s.to_lowercase())
+                .unwrap_or_default()
+                .contains(&value)
+                || v.get(CLAIMS_NAME)
+                    .map(|s| s.to_ascii_lowercase())
+                    .unwrap_or_default()
+                    .contains(&value))
+            .then(|| (id, v.get(CLAIMS_NAME).map(|s| s.to_string())))
+        })
+        .collect::<Vec<_>>();
+    if all_matches.is_empty() {
+        Err(FindIdError::NoMatches)
+    } else if all_matches.len() > 1 {
+        Err(FindIdError::MultipleMatches(
+            all_matches
+                .into_iter()
+                .map(|(id, friendly_name)| {
+                    if let Some(name) = friendly_name {
+                        format!("{} ({})", id, name)
+                    } else {
+                        id.into_string()
+                    }
+                })
+                .collect(),
+        ))
+    } else {
+        // SAFETY: We know we have exactly one match at this point
+        Ok(all_matches.into_iter().next().unwrap())
+    }
 }

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -61,6 +61,7 @@ pub fn downloads_dir() -> IoResult<PathBuf> {
     cfg_dir().map(|p| p.join(DOWNLOADS_DIR))
 }
 
+#[derive(Clone)]
 /// Connection options for a Wash instance
 pub struct WashConnectionOptions {
     /// CTL Host for connection, defaults to 127.0.0.1 for local nats

--- a/crates/wash-lib/src/id.rs
+++ b/crates/wash-lib/src/id.rs
@@ -1,6 +1,6 @@
 //! Types and tools for basic validation of seeds and IDs used in configuration
 
-use std::{convert::AsRef, fmt::Display, str::FromStr};
+use std::{convert::AsRef, fmt::Display, ops::Deref, str::FromStr};
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -39,9 +39,34 @@ impl<const PREFIX: char> FromStr for Id<PREFIX> {
     }
 }
 
+impl<const PREFIX: char> AsRef<str> for Id<PREFIX> {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl<const PREFIX: char> Deref for Id<PREFIX> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
 impl<const PREFIX: char> Display for Id<PREFIX> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl<const PREFIX: char> Id<PREFIX> {
+    /// Converts the wrapped key back into a plain string
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    pub fn prefix() -> char {
+        PREFIX
     }
 }
 
@@ -70,11 +95,30 @@ impl<const PREFIX: char> AsRef<str> for Seed<PREFIX> {
     }
 }
 
+impl<const PREFIX: char> Deref for Seed<PREFIX> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
 impl<const PREFIX: char> FromStr for Seed<PREFIX> {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(parse(s, PREFIX, true)?))
+    }
+}
+
+impl<const PREFIX: char> Seed<PREFIX> {
+    /// Converts the wrapped key back into a plain string
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    pub fn prefix() -> char {
+        PREFIX
     }
 }
 

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -35,4 +35,5 @@ pub mod drain;
 pub mod id;
 pub mod keys;
 pub mod registry;
+pub mod spier;
 pub mod wait;

--- a/crates/wash-lib/src/spier.rs
+++ b/crates/wash-lib/src/spier.rs
@@ -1,0 +1,258 @@
+use std::{collections::HashMap, str::FromStr, task::Poll};
+
+use anyhow::Result;
+use chrono::{DateTime, Local};
+use futures::{Stream, StreamExt};
+use wasmbus_rpc::core::Invocation;
+
+use crate::{
+    common::{find_actor_id, CLAIMS_NAME, CLAIMS_SUBJECT},
+    id::{ModuleId, ServiceId},
+};
+
+/// A struct that represents an invocation that was observed by the spier.
+#[derive(Debug)]
+pub struct ObservedInvocation {
+    /// The actual invocation from the wire, but the `.msg` field will always be empty as we are
+    /// consuming it to attempt to parse it.
+    pub invocation: Invocation,
+    /// The timestamp when this was received
+    pub timestamp: DateTime<Local>,
+    /// The name or id of the entity that sent this invocation
+    pub from: String,
+    /// The name or id of the entity that received this invocation
+    pub to: String,
+    /// The inner message that was received. We will attempt to parse the inner message from CBOR
+    /// and JSON into a JSON string and fall back to the raw bytes if we are unable to do so
+    pub message: ObservedMessage,
+}
+
+/// A inner message that we've seen in an invocation message. This will either be a raw bytes or a
+/// parsed value if it was a format we recognized.
+///
+/// Please note that this struct is meant for debugging, so its `Display` implementation does some
+/// heavier lifting like contructing strings from the raw bytes.
+#[derive(Debug)]
+pub enum ObservedMessage {
+    Raw(Vec<u8>),
+    Parsed(String),
+}
+
+impl std::fmt::Display for ObservedMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObservedMessage::Raw(bytes) => write!(f, "{}", String::from_utf8_lossy(bytes)),
+            ObservedMessage::Parsed(v) => {
+                write!(f, "{}", v)
+            }
+        }
+    }
+}
+
+impl ObservedMessage {
+    pub fn parse(data: Vec<u8>) -> Self {
+        // Try parsing with msgpack and then with cbor. If neither work, then just return the raw
+        // NOTE(thomastaylor312): I don't think anyone else does their own encoding, but if that
+        // becomes popular, we can add support for it here
+        let mut serializer = serde_json::Serializer::pretty(Vec::new());
+        let parsed = match serde_transcode::transcode(
+            &mut rmp_serde::Deserializer::new(&data[..]),
+            &mut serializer,
+        ) {
+            // SAFETY: We know that JSON writes to valid UTF-8
+            Ok(_) => String::from_utf8(serializer.into_inner()).unwrap(),
+            Err(_) => {
+                // Reset the buffer in case we wrote some data on previous failure
+                let mut serializer = serde_json::Serializer::pretty(Vec::new());
+                match serde_transcode::transcode(
+                    &mut serde_cbor::Deserializer::from_reader(&data[..]),
+                    &mut serializer,
+                ) {
+                    Ok(_) => String::from_utf8(serializer.into_inner()).unwrap(),
+                    Err(_) => return Self::Raw(data),
+                }
+            }
+        };
+        Self::Parsed(parsed)
+    }
+}
+
+/// A struct that can spy on the RPC messages sent to and from an actor, consumable as a stream
+pub struct Spier {
+    stream: futures::stream::SelectAll<async_nats::Subscriber>,
+    actor_id: ModuleId,
+    friendly_name: Option<String>,
+    provider_info: HashMap<String, ProviderDetails>,
+}
+
+impl Spier {
+    /// Creates a new Spier instance for the given actor. Will return an error if the actor cannot
+    /// be found or if there are connection issues
+    pub async fn new(
+        actor_id_or_name: &str,
+        ctl_client: &wasmcloud_control_interface::Client,
+        nats_client: &async_nats::Client,
+    ) -> Result<Self> {
+        let (actor_id, friendly_name) = find_actor_id(actor_id_or_name, ctl_client).await?;
+        let linked_providers = get_linked_providers(&actor_id, ctl_client).await?;
+
+        let rpc_topic_prefix = format!("wasmbus.rpc.{}", ctl_client.lattice_prefix);
+        let actor_stream = nats_client
+            .subscribe(format!("{}.{}", rpc_topic_prefix, actor_id.as_ref()))
+            .await?;
+
+        let mut subs = futures::future::join_all(linked_providers.iter().map(|prov| {
+            let topic = format!(
+                "{}.{}.{}",
+                rpc_topic_prefix,
+                prov.id.as_ref(),
+                &prov.link_name
+            );
+            nats_client.subscribe(topic)
+        }))
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+        subs.push(actor_stream);
+
+        let stream = futures::stream::select_all(subs);
+
+        Ok(Self {
+            stream,
+            actor_id,
+            friendly_name,
+            provider_info: linked_providers
+                .into_iter()
+                .map(|prov| (prov.id.clone().into_string(), prov))
+                .collect(),
+        })
+    }
+
+    /// Returns the actor name, or id if no name is set, that this spier is spying on
+    pub fn actor_id(&self) -> &str {
+        self.friendly_name
+            .as_deref()
+            .unwrap_or_else(|| self.actor_id.as_ref())
+    }
+}
+
+impl Stream for Spier {
+    type Item = ObservedInvocation;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.stream.poll_next_unpin(cx) {
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(msg)) => {
+                // Try to parse the invocation first
+                let mut inv: Invocation = match rmp_serde::from_slice(&msg.payload) {
+                    Ok(inv) => inv,
+                    Err(_e) => {
+                        // TODO: We should probably have some logging here
+                        // Just skip it if we can't parse it. This means we need to tell the executor to automatically wake up and poll immediately if we skip
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
+                };
+                let body = inv.msg;
+                inv.msg = Vec::new();
+
+                if inv.origin.is_provider() && inv.target.public_key() != self.actor_id.as_ref() {
+                    // This is a provider invocation that isn't for us, so we should skip it
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                let from = if inv.origin.is_actor() {
+                    self.friendly_name
+                        .clone()
+                        .unwrap_or_else(|| inv.origin.public_key())
+                } else {
+                    let pubkey = inv.origin.public_key();
+                    self.provider_info
+                        .get(&pubkey)
+                        .and_then(|prov| prov.friendly_name.clone())
+                        .unwrap_or(pubkey)
+                };
+                let to = if inv.target.is_actor() {
+                    self.friendly_name
+                        .clone()
+                        .unwrap_or_else(|| inv.target.public_key())
+                } else {
+                    let pubkey = inv.target.public_key();
+                    self.provider_info
+                        .get(&pubkey)
+                        .and_then(|prov| prov.friendly_name.clone())
+                        .unwrap_or(pubkey)
+                };
+                // NOTE(thomastaylor312): Ideally we'd consume `msg.payload` above with a
+                // `Cursor` and `from_reader` and then manually reconstruct the acking using the
+                // message context, but I didn't want to waste time optimizing yet
+                Poll::Ready(Some(ObservedInvocation {
+                    invocation: inv,
+                    timestamp: Local::now(),
+                    from,
+                    to,
+                    message: ObservedMessage::parse(body),
+                }))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProviderDetails {
+    id: ServiceId,
+    link_name: String,
+    friendly_name: Option<String>,
+}
+
+/// Fetches all providers linked to the given actor, along with their link names
+async fn get_linked_providers(
+    actor_id: &ModuleId,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<Vec<ProviderDetails>> {
+    let mut details = ctl_client
+        .query_links()
+        .await
+        .map_err(|e| anyhow::anyhow!("Unable to get linkdefs: {e:?}"))
+        .map(|linkdefs| {
+            linkdefs
+                .links
+                .into_iter()
+                .filter_map(|link| {
+                    if link.actor_id == actor_id.as_ref() {
+                        let provider_id = ServiceId::from_str(&link.provider_id).ok()?;
+                        Some(ProviderDetails {
+                            id: provider_id,
+                            link_name: link.link_name,
+                            friendly_name: None,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        })?;
+    let mut claim_names: HashMap<String, String> = ctl_client
+        .get_claims()
+        .await
+        .map_err(|e| anyhow::anyhow!("Unable to get claims: {e:?}"))?
+        .claims
+        .into_iter()
+        .filter_map(|mut claims| {
+            let id = claims.remove(CLAIMS_SUBJECT).unwrap_or_default();
+            // If it isn't a provider, skip
+            if !id.starts_with(ServiceId::prefix()) {
+                return None;
+            }
+            // Only return it if it has a name
+            claims.remove(CLAIMS_NAME).map(|name| (id, name))
+        })
+        .collect();
+    details.iter_mut().for_each(|detail| {
+        detail.friendly_name = claim_names.remove(detail.id.as_ref());
+    });
+    Ok(details)
+}

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -240,9 +240,9 @@ pub(crate) async fn scale_actor(cmd: ScaleActorCommand) -> Result<CommandOutput>
 
     let ack = client
         .scale_actor(
-            &cmd.host_id.to_string(),
+            &cmd.host_id,
             &cmd.actor_ref,
-            &cmd.actor_id.to_string(),
+            &cmd.actor_id,
             cmd.count,
             Some(annotations),
         )
@@ -266,12 +266,7 @@ pub(crate) async fn update_actor(cmd: UpdateActorCommand) -> Result<CtlOperation
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
     client
-        .update_actor(
-            &cmd.host_id.to_string(),
-            &cmd.actor_id.to_string(),
-            &cmd.new_actor_ref,
-            None,
-        )
+        .update_actor(&cmd.host_id, &cmd.actor_id, &cmd.new_actor_ref, None)
         .await
         .map_err(convert_error)
 }
@@ -298,10 +293,7 @@ async fn apply_manifest_actors(
     let mut results = vec![];
 
     for actor in hm.actors.iter() {
-        match client
-            .start_actor(&host_id.to_string(), actor, ONE_ACTOR, None)
-            .await
-        {
+        match client.start_actor(host_id, actor, ONE_ACTOR, None).await {
             Ok(ack) => {
                 if ack.accepted {
                     results.push(format!("Instruction to start actor {actor} acknowledged."));
@@ -362,13 +354,7 @@ async fn apply_manifest_providers(
 
     for cap in hm.capabilities.iter() {
         match client
-            .start_provider(
-                &host_id.to_string(),
-                &cap.image_ref,
-                cap.link_name.clone(),
-                None,
-                None,
-            )
+            .start_provider(host_id, &cap.image_ref, cap.link_name.clone(), None, None)
             .await
         {
             Ok(ack) => {


### PR DESCRIPTION
## Feature or Problem

Adds a helpful debugging tool that allows you to observe what is being called between your actors and providers

## Related Issues

Closes #599 

## Release Information
0.18? (If it gets reviewed fast enough) 0.19 otherwise

## Consumer Impact

None, new experimental feature

## Testing

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)/Integration

None. To actually test this you need a full setup of actors and then have to test output. Since this is experimental, I figure the manual testing is fine

### Manual Verification

I tried spinning up several actors and providers (both provider -> actor and actor -> provider) to test that we could get messages
