### PR TITLE
chore: re-add serial test for non-nextest runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3175,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4160,6 +4199,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "serial_test",
  "sha2 0.10.6",
  "sysinfo",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ scopeguard = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+# serial_test ensures serial execution when running with cargo, '<test name>_serial' works with nextest
+serial_test = { workspace = true }
 rand = "0.8.5"
 
 [[bin]]

--- a/tests/integration_build.rs
+++ b/tests/integration_build.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serial_test::serial;
 use std::{fs::File, io::Write, path::PathBuf};
 use tempfile::TempDir;
 use tokio::process::Command;
@@ -6,6 +7,7 @@ use tokio::process::Command;
 mod common;
 
 #[tokio::test]
+#[serial]
 async fn build_rust_actor_unsigned_serial() -> Result<()> {
     let test_setup = init(
         /* actor_name= */ "hello", /* template_name= */ "hello",
@@ -31,6 +33,7 @@ async fn build_rust_actor_unsigned_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn build_rust_actor_signed_serial() -> Result<()> {
     let test_setup = init(
         /* actor_name= */ "hello", /* template_name= */ "hello",
@@ -54,6 +57,7 @@ async fn build_rust_actor_signed_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn build_rust_actor_in_workspace_unsigned_serial() -> Result<()> {
     let test_setup = init_workspace(vec![/* actor_names= */ "hello-1", "hello-2"]).await?;
     let project_dir = test_setup.project_dirs.get(0).unwrap();
@@ -78,6 +82,7 @@ async fn build_rust_actor_in_workspace_unsigned_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn build_tinygo_actor_unsigned_serial() -> Result<()> {
     let test_setup = init(
         /* actor_name= */ "echo",
@@ -105,6 +110,7 @@ async fn build_tinygo_actor_unsigned_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn build_tinygo_actor_signed_serial() -> Result<()> {
     let test_setup = init(
         /* actor_name= */ "echo",
@@ -220,6 +226,7 @@ async fn init_actor_from_template(actor_name: &str, template_name: &str) -> Resu
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_build_handles_dashed_names_serial() -> Result<()> {
     let actor_name = "dashed-actor";
     // This tests runs against a temp directory since cargo gets confused

--- a/tests/integration_get.rs
+++ b/tests/integration_get.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serial_test::serial;
 use tokio::process::Command;
 use wash_lib::cli::output::{
     GetClaimsOutput, GetHostInventoryOutput, GetHostsOutput, LinkQueryOutput,
@@ -8,6 +9,7 @@ mod common;
 use common::TestWashInstance;
 
 #[tokio::test]
+#[serial]
 async fn integration_get_hosts_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
@@ -32,6 +34,7 @@ async fn integration_get_hosts_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_get_links_serial() -> Result<()> {
     let _wash_instance = TestWashInstance::create().await?;
 
@@ -52,6 +55,7 @@ async fn integration_get_links_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_get_host_inventory_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
@@ -109,6 +113,7 @@ async fn integration_get_host_inventory_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_get_claims_serial() -> Result<()> {
     let _wash_instance = TestWashInstance::create().await?;
 

--- a/tests/integration_link.rs
+++ b/tests/integration_link.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serial_test::serial;
 use tokio::process::Command;
 use wash_lib::cli::output::LinkQueryOutput;
 
@@ -6,6 +7,7 @@ mod common;
 use common::TestWashInstance;
 
 #[tokio::test]
+#[serial]
 async fn integration_link_serial() -> Result<()> {
     let _wash = TestWashInstance::create().await?;
 

--- a/tests/integration_start.rs
+++ b/tests/integration_start.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serial_test::serial;
 use tokio::process::Command;
 use wash_lib::cli::output::StartCommandOutput;
 
@@ -6,6 +7,7 @@ mod common;
 use common::{TestWashInstance, ECHO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 
 #[tokio::test]
+#[serial]
 async fn integration_start_actor_serial() -> Result<()> {
     let _wash_instance = TestWashInstance::create().await?;
 
@@ -34,6 +36,7 @@ async fn integration_start_actor_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_start_provider_serial() -> Result<()> {
     let _wash_instance = TestWashInstance::create().await?;
 

--- a/tests/integration_stop.rs
+++ b/tests/integration_stop.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serial_test::serial;
 use tokio::process::Command;
 
 mod common;
@@ -6,6 +7,7 @@ use common::{TestWashInstance, ECHO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 use wash_lib::cli::output::{StartCommandOutput, StopCommandOutput};
 
 #[tokio::test]
+#[serial]
 async fn integration_stop_actor_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
@@ -55,6 +57,7 @@ async fn integration_stop_actor_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_stop_provider_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
@@ -119,6 +122,7 @@ async fn integration_stop_provider_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_stop_host_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use std::{
     fs::{read_to_string, remove_dir_all},
     path::PathBuf,
@@ -15,6 +16,7 @@ mod common;
 const RGX_ACTOR_START_MSG: &str = r"Actor \[(?P<actor_id>[^]]+)\] \(ref: \[(?P<actor_ref>[^]]+)\]\) started on host \[(?P<host_id>[^]]+)\]";
 
 #[tokio::test]
+#[serial]
 async fn integration_up_can_start_wasmcloud_and_actor_serial() -> Result<()> {
     let dir = test_dir_with_subfolder("can_start_wasmcloud");
     let path = dir.join("washup.log");
@@ -110,6 +112,7 @@ async fn integration_up_can_start_wasmcloud_and_actor_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_up_can_stop_detached_host_serial() -> Result<()> {
     let dir = test_dir_with_subfolder("can_stop_wasmcloud");
     let path = dir.join("washup.log");
@@ -178,6 +181,7 @@ async fn integration_up_can_stop_detached_host_serial() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn integration_up_doesnt_kill_unowned_nats_serial() -> Result<()> {
     let dir = test_dir_with_subfolder("doesnt_kill_unowned_nats");
     let path = dir.join("washup.log");


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Although we've switched to `nextest` it's nice to be able to run this:

```console
cargo test 'integration_start' -- --nocapture 
```

and have serial execution work properly.

This PR re-adds [`serial_test`](https://crates.io/crates/serial_test) and uses `#[serial]` everywhere that `<test name>_serial` is used, so that people can run serial tests a bit easier without knowing the `cargo-nextest` incantation (though it's very similar to cargo anyway, there's some more advanced filtering)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Developers can more easily run tests

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Tested locally