### PR TITLE
feat(capture): Adds a new experimental `wash capture` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -4186,6 +4189,7 @@ dependencies = [
  "anyhow",
  "async-compression",
  "async-nats 0.29.0",
+ "bytes",
  "cargo_metadata",
  "cargo_toml",
  "chrono",
@@ -4219,6 +4223,7 @@ dependencies = [
  "term-table",
  "test-case",
  "thiserror",
+ "time 0.3.20",
  "tokio",
  "tokio-stream",
  "tokio-tar",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -24,6 +24,7 @@ nats = ["async-nats", "wadm"]
 anyhow = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async-nats = { workspace = true, optional = true}
+bytes = { version = "1", features = ["serde"] }
 cargo_metadata = "0.15"
 cargo_toml = { workspace = true }
 chrono = "0.4"
@@ -55,6 +56,7 @@ serde_with = { workspace = true }
 tempfile = { workspace = true }
 term-table = { workspace = true, optional = true }
 thiserror = { workspace = true }
+time = "0.3"
 tokio = { workspace = true, features = ["process"] }
 tokio-stream = { workspace = true }
 tokio-tar = { workspace = true }

--- a/crates/wash-lib/src/capture.rs
+++ b/crates/wash-lib/src/capture.rs
@@ -1,0 +1,229 @@
+use std::convert::TryFrom;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use async_compression::tokio::{bufread::GzipDecoder, write::GzipEncoder};
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+use tokio_tar::Archive;
+use wasmcloud_control_interface::HostInventory;
+
+pub const INVENTORY_FILE: &str = "inventory.json";
+pub const MESSAGES_DIR: &str = "messages";
+
+/// A subset of NATS message info that we need to serialize for now. Basically it is all the types that easily
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableMessage {
+    pub subject: String,
+    pub reply: Option<String>,
+    pub payload: bytes::Bytes,
+    pub description: Option<String>,
+    pub length: usize,
+    pub published: time::OffsetDateTime,
+}
+
+impl TryFrom<async_nats::jetstream::Message> for SerializableMessage {
+    type Error = anyhow::Error;
+
+    fn try_from(msg: async_nats::jetstream::Message) -> Result<Self, Self::Error> {
+        let published = msg.info().map_err(|e| anyhow::anyhow!("{e:?}"))?.published;
+        Ok(Self {
+            subject: msg.message.subject,
+            reply: msg.message.reply,
+            payload: msg.message.payload,
+            description: msg.message.description,
+            length: msg.message.length,
+            published,
+        })
+    }
+}
+
+/// A read capture is a parsed tarball that contains all of the messages and inventory for a given
+/// capture.
+///
+/// Currently this only loads the data into memory, but we might add additional helper methods in
+/// the future.
+///
+/// NOTE: The interior structure of the tarball is not a guaranteed API and may change in the
+/// future. All interactions should be done through this type
+pub struct ReadCapture {
+    pub inventory: Vec<HostInventory>,
+    // NOTE: A further optimization would be to only load based off of a filter here rather than
+    // possibly having thousands of messages
+    pub messages: Vec<SerializableMessage>,
+}
+
+impl ReadCapture {
+    /// Loads the given capture file from the path and returns all of the data
+    pub async fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let file = File::open(path).await?;
+        let mut archive = Archive::new(GzipDecoder::new(tokio::io::BufReader::new(file)));
+
+        let mut capture = ReadCapture {
+            inventory: Vec::new(),
+            messages: Vec::new(),
+        };
+        let mut entries = archive.entries()?;
+        while let Some(mut entry) = entries.try_next().await? {
+            let path = entry.path()?;
+            if path.file_name().unwrap_or_default() == INVENTORY_FILE {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf).await?;
+                // We can't use a reader because it is async
+                capture.inventory = serde_json::from_slice(&buf)?;
+            } else if path
+                .parent()
+                .and_then(|p| p.file_name())
+                .unwrap_or_default()
+                == MESSAGES_DIR
+                && path.extension().unwrap_or_default() == "json"
+            {
+                // For any path that matches messages/*.json, we want to read the file and
+                // deserialize it. Ordering should be the same as we wrote it (in order), so reading
+                // out should be ok
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf).await?;
+                let msg: SerializableMessage = serde_json::from_slice(&buf)?;
+                capture.messages.push(msg);
+            }
+        }
+        Ok(capture)
+    }
+}
+
+pub struct WriteCapture {
+    builder: tokio_tar::Builder<GzipEncoder<File>>,
+    current_index: usize,
+}
+
+impl WriteCapture {
+    /// Create a new WriteCapture that will write the capture tarball to the given path with the
+    /// expected inventory
+    pub async fn start(inventory: Vec<HostInventory>, path: impl AsRef<Path>) -> Result<Self> {
+        let file = File::create(path).await?;
+        let encoder = GzipEncoder::new(file);
+        let mut builder = tokio_tar::Builder::new(encoder);
+        // We always start by encoding the inventory first
+        let inventory_data = serde_json::to_vec(&inventory)?;
+        let mut header = tokio_tar::Header::new_gnu();
+        header.set_size(inventory_data.len() as u64);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, INVENTORY_FILE, Cursor::new(inventory_data))
+            .await?;
+        Ok(Self {
+            builder,
+            current_index: 0,
+        })
+    }
+
+    /// Adds an observed message to the capture
+    pub async fn add_message(&mut self, msg: SerializableMessage) -> Result<()> {
+        // NOTE(thomastaylor312): If encoding in json becomes a bottleneck, we can switch to a more
+        // efficient format, but I figured this could be easier for people to read if someone
+        // unpacks the message themselves
+        let data = serde_json::to_vec(&msg)?;
+        let mut header = tokio_tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        // Name of the file is an incrementing index and the timestamp of the message
+        let path = PathBuf::from(MESSAGES_DIR).join(format!(
+            "{}-{}.json",
+            self.current_index,
+            msg.published
+                .format(&time::format_description::well_known::Rfc3339)?
+        ));
+        self.builder
+            .append_data(&mut header, path, Cursor::new(data))
+            .await?;
+        self.current_index += 1;
+        Ok(())
+    }
+
+    /// Marks the tarball write as complete and flushes the underlying writer to disk
+    pub async fn finish(self) -> Result<()> {
+        let mut encoder = self.builder.into_inner().await?;
+        encoder.flush().await?;
+        encoder.shutdown().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_roundtrip() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let tarball = tempdir.path().join("capture.tar.gz");
+        let mut capture = WriteCapture::start(
+            vec![HostInventory {
+                host_id: "test".to_string(),
+                ..Default::default()
+            }],
+            &tarball,
+        )
+        .await
+        .expect("Should be able to start a capture");
+        capture
+            .add_message(SerializableMessage {
+                subject: "first".to_string(),
+                reply: None,
+                payload: bytes::Bytes::from("test"),
+                description: None,
+                length: 5,
+                published: time::OffsetDateTime::now_utc(),
+            })
+            .await
+            .expect("Should be able to add a message");
+        capture
+            .add_message(SerializableMessage {
+                subject: "second".to_string(),
+                reply: None,
+                payload: bytes::Bytes::from("test"),
+                description: None,
+                length: 6,
+                published: time::OffsetDateTime::now_utc(),
+            })
+            .await
+            .expect("Should be able to add a message");
+
+        capture
+            .finish()
+            .await
+            .expect("Should be able to finish a capture");
+
+        let capture = ReadCapture::load(&tarball)
+            .await
+            .expect("Should be able to load a capture");
+
+        assert_eq!(
+            capture.inventory.len(),
+            1,
+            "Should have the correct inventory"
+        );
+        assert_eq!(
+            capture.inventory[0].host_id, "test",
+            "Should have the correct inventory"
+        );
+        assert_eq!(
+            capture.messages.len(),
+            2,
+            "Should have the right amount of messages"
+        );
+        assert_eq!(
+            capture.messages[0].subject, "first",
+            "Should have the right ordering"
+        );
+        assert_eq!(
+            capture.messages[1].subject, "second",
+            "Should have the right ordering"
+        );
+    }
+}

--- a/crates/wash-lib/src/cli/capture.rs
+++ b/crates/wash-lib/src/cli/capture.rs
@@ -1,0 +1,331 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::Result;
+use async_nats::jetstream::{
+    consumer::{pull::Config as ConsumerConfig, AckPolicy, DeliverPolicy},
+    stream::Config,
+};
+use clap::{Parser, Subcommand};
+use futures::TryStreamExt;
+use tokio::io::{stdin, stdout, AsyncReadExt, AsyncWriteExt};
+use tokio::time::Instant;
+use wasmbus_rpc::core::Invocation;
+
+use super::{CliConnectionOpts, CommandOutput};
+use crate::config::WashConnectionOptions;
+use crate::{
+    capture::{ReadCapture, WriteCapture},
+    id::{ModuleId, ServiceId},
+    spier::{ObservedInvocation, ObservedMessage},
+};
+
+pub const CAPTURE_STREAM_NAME: &str = "wash-capture";
+
+#[derive(Debug, Parser, Clone)]
+pub struct CaptureCommand {
+    /// Enable wash capture. This will setup a NATS JetStream stream to capture all invocations
+    #[clap(name = "enable", long = "enable", conflicts_with = "disable")]
+    pub enable: bool,
+
+    /// Disable wash capture. This will removed the NATS JetStream stream that was setup to capture
+    /// all invocations
+    #[clap(name = "disable", long = "disable", conflicts_with = "enable")]
+    pub disable: bool,
+
+    /// The length of time in minutes to keep messages in the stream.
+    #[clap(name = "window_size", long = "window-size", default_value = "60")]
+    pub window_size_minutes: u64,
+
+    #[clap(flatten)]
+    pub opts: CliConnectionOpts,
+
+    /// Replay through a stream of captured invocations
+    #[clap(subcommand)]
+    pub replay: Option<CaptureSubcommand>,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum CaptureSubcommand {
+    Replay(CaptureReplayCommand),
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct CaptureReplayCommand {
+    /// An actor ID to filter captured invocations by. This will filter anywhere the actor is the
+    /// source or the target of the invocation. If provided with an provider ID, it will filter down
+    /// to interactions only between the actor and provider
+    #[clap(name = "actor_id", long = "actor-id", value_parser)]
+    pub actor_id: Option<ModuleId>,
+
+    /// A provider ID to filter captured invocations by. This will filter anywhere the provider is
+    /// the source or the target of the invocation. If provided with an actor ID, it will filter
+    /// down to interactions only between the actor and provider
+    #[clap(name = "provider_id", long = "provider-id", value_parser)]
+    pub provider_id: Option<ServiceId>,
+
+    /// Whether or not to step through the replay one message at a time
+    #[clap(name = "interactive", long = "interactive")]
+    pub interactive: bool,
+
+    /// The file path to the capture file to read from
+    #[clap(name = "capturefile")]
+    pub capture_file_path: PathBuf,
+}
+
+pub async fn handle_replay_command(cmd: CaptureReplayCommand) -> Result<CommandOutput> {
+    let capture = ReadCapture::load(cmd.capture_file_path).await?;
+
+    let filtered = capture.messages.into_iter().filter_map(|msg| {
+        let mut inv: Invocation = rmp_serde::from_slice(&msg.payload).ok()?;
+
+        if let Some(actor_id) = &cmd.actor_id {
+            if (inv.origin.is_actor() && inv.origin.public_key != actor_id.as_ref())
+                || (inv.target.is_actor() && inv.target.public_key != actor_id.as_ref())
+            {
+                return None;
+            }
+        }
+
+        if let Some(provider_id) = &cmd.provider_id {
+            if (inv.origin.is_provider() && inv.origin.public_key != provider_id.as_ref())
+                || (inv.target.is_provider() && inv.target.public_key != provider_id.as_ref())
+            {
+                return None;
+            }
+        }
+
+        let body = inv.msg;
+        inv.msg = Vec::new();
+        let from = inv.origin.public_key();
+        let to = inv.target.public_key();
+
+        Some((
+            ObservedInvocation {
+                invocation: inv,
+                timestamp: chrono::Local::now(),
+                from,
+                to,
+                message: ObservedMessage::parse(body),
+            },
+            msg.published,
+        ))
+    });
+
+    let mut out = stdout();
+    for (msg, published) in filtered {
+        println!(
+            r#"
+[{}]
+From: {}  To: {}  Host: {}
+
+Operation: {}
+Message: {}"#,
+            published,
+            msg.from,
+            msg.to,
+            msg.invocation.host_id,
+            msg.invocation.operation,
+            msg.message
+        );
+        if cmd.interactive {
+            out.write_all(b"Press Enter to continue...").await.unwrap();
+            out.flush().await.unwrap();
+            stdin().read_exact(&mut [0]).await.unwrap();
+        }
+    }
+    Ok(CommandOutput::default())
+}
+
+/// Handles the spy command, printing all output to stdout until the command is interrupted
+pub async fn handle_command(cmd: CaptureCommand) -> Result<CommandOutput> {
+    let wco: WashConnectionOptions = cmd.opts.try_into()?;
+    let nats_client = wco.clone().into_nats_client().await?;
+    let ctl_client = wco.clone().into_ctl_client(None).await?;
+    let js_context = if let Some(domain) = wco.js_domain {
+        async_nats::jetstream::with_domain(nats_client, domain)
+    } else {
+        async_nats::jetstream::new(nats_client)
+    };
+
+    if cmd.enable {
+        let window_size = Duration::from_secs(cmd.window_size_minutes * 60);
+        return enable(
+            js_context,
+            wco.lattice_prefix.as_deref().unwrap_or("default"),
+            window_size,
+        )
+        .await;
+    } else if cmd.disable {
+        return disable(
+            js_context,
+            wco.lattice_prefix.as_deref().unwrap_or("default"),
+        )
+        .await;
+    }
+
+    capture(
+        js_context,
+        ctl_client,
+        wco.lattice_prefix.as_deref().unwrap_or("default"),
+    )
+    .await
+}
+
+pub async fn enable(
+    ctx: async_nats::jetstream::Context,
+    lattice_id: &str,
+    window_size: Duration,
+) -> Result<CommandOutput> {
+    // Until we get concrete errors, we should check for the stream and if it exists return a nice message that we're already enabled
+    if ctx.get_stream(CAPTURE_STREAM_NAME).await.is_ok() {
+        return Ok(CommandOutput::from_key_and_text(
+            "message",
+            format!("Capture is already enabled for lattice {lattice_id}"),
+        ));
+    }
+    ctx.create_stream(Config {
+        name: stream_name(lattice_id),
+        storage: async_nats::jetstream::stream::StorageType::File,
+        max_age: window_size,
+        // This needs to be set or it breaks invocations
+        no_ack: true,
+        subjects: vec![format!("wasmbus.rpc.{}.>", lattice_id)],
+        ..Default::default()
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    Ok(CommandOutput::from_key_and_text(
+        "message",
+        "Successfully enabled capture mode for lattice",
+    ))
+}
+
+pub async fn disable(
+    ctx: async_nats::jetstream::Context,
+    lattice_id: &str,
+) -> Result<CommandOutput> {
+    ctx.delete_stream(stream_name(lattice_id))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    Ok(CommandOutput::from_key_and_text(
+        "message",
+        "Successfully disabled capture mode for lattice",
+    ))
+}
+
+pub async fn capture(
+    ctx: async_nats::jetstream::Context,
+    ctl_client: wasmcloud_control_interface::Client,
+    lattice_id: &str,
+) -> Result<CommandOutput> {
+    let stream = ctx.get_stream(stream_name(lattice_id)).await.map_err(|e| {
+        anyhow::anyhow!("Unable to find stream. Have you run `wash capture --enable`? Error: {e:?}")
+    })?;
+
+    // Timestamp for cutoff of messages to capture
+    let capture_start_time = time::OffsetDateTime::now_utc();
+
+    let inventory = get_all_inventory(&ctl_client).await?;
+
+    let consumer = stream
+        .create_consumer(ConsumerConfig {
+            description: Some("Wash capture consumer".to_string()),
+            deliver_policy: DeliverPolicy::All,
+            ack_policy: AckPolicy::None,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    let mut messages = consumer
+        .messages()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    let max_time_without_message = Duration::from_secs(1);
+    let mut expiry = tokio::time::interval_at(
+        Instant::now() + max_time_without_message,
+        max_time_without_message,
+    );
+
+    let filename = format!(
+        "{}.{}.washcapture",
+        chrono::Local::now().to_rfc3339(),
+        lattice_id
+    );
+    let mut capture = WriteCapture::start(inventory, &filename).await?;
+
+    loop {
+        tokio::select! {
+            _ = expiry.tick() => {
+                println!("No messages received in the last second. Ending capture");
+                break
+            },
+            res = messages.try_next() => {
+                // If we get a message, reset the tick
+                expiry.reset();
+                let msg = match res {
+                    Ok(None) => {
+                        eprintln!("WARN: Message stream ended early");
+                        break;
+                    }
+                    Ok(Some(m)) => m,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+                if let Ok(info) = msg.info() {
+                    if info.published > capture_start_time {
+                        println!("Reached end of capture");
+                        break;
+                    }
+                }
+                if let Ok(m) = msg.try_into() {
+                    capture.add_message(m).await?;
+                }
+            }
+        }
+    }
+
+    capture.finish().await?;
+
+    Ok(CommandOutput::new(
+        format!("Completed capture and output to file {filename}"),
+        [
+            (
+                "message".to_string(),
+                serde_json::Value::String("Completed capture".to_owned()),
+            ),
+            (
+                "output_path".to_string(),
+                serde_json::Value::String(filename),
+            ),
+        ]
+        .into(),
+    ))
+}
+
+async fn get_all_inventory(
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> anyhow::Result<Vec<wasmcloud_control_interface::HostInventory>> {
+    let futs = ctl_client
+        .get_hosts()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?
+        .into_iter()
+        .map(|host| (ctl_client.clone(), host.id))
+        .map(|(client, host_id)| async move {
+            let inventory = client
+                .get_host_inventory(&host_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+            Ok(inventory)
+        });
+    futures::future::join_all(futs).await.into_iter().collect()
+}
+
+fn stream_name(lattice_id: &str) -> String {
+    format!("{}-{lattice_id}", CAPTURE_STREAM_NAME)
+}

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     },
 };
 
+pub mod capture;
 pub mod claims;
 pub mod get;
 pub mod inspect;

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -28,6 +28,7 @@ pub mod parser;
 #[cfg(feature = "start")]
 pub mod start;
 
+pub mod capture;
 pub mod common;
 pub mod config;
 pub mod context;


### PR DESCRIPTION
This one is very experimental, so I didn't even add it to the top level help text, but it is all manually tested and good to go. `wash capture` allows you to have a sliding window of captured events that you can dump to disk to debug any issues that occur

## Related Issues

Closes #601

## Release Information

0.18 if we get it in in time

## Consumer Impact

None, as it is a new feature

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

Unit tests to check the proper creation of the output tarball and that it can be read properly

### Acceptance or Integration

All manual verification

### Manual Verification

Manually verified all operations locally by enabling, disabling, capturing, and replaying
