### PR TITLE
Added kvcounter template to wash favorites

### DIFF
--- a/crates/wash-lib/src/generate/favorites.toml
+++ b/crates/wash-lib/src/generate/favorites.toml
@@ -30,6 +30,12 @@ description = "a hello-world actor (in Rust) that echoes a request back over a N
 git = "wasmCloud/project-templates"
 subfolder = "actor/echo-messaging"
 
+[[actor]]
+name = "kvcounter"
+description = "an example actor (in Rust) that increments a counter in a key-value store"
+git = "wasmCloud/project-templates"
+subfolder = "actor/kvcounter"
+
 [[interface]]
 name = "converter-interface"
 description = "an interface for actor-to-actor messages with a single Convert method"


### PR DESCRIPTION
## Feature or Problem
We have a kvcounter actor template that's not utilized yet, so we should add it! It would be nice to be able to modify these without changing a toml file, but we can tackle that later

## Related Issues
N/A

## Release Information
`next` as I think this would be fine as a patch bump.

## Consumer Impact
New template!

## Testing
I ran this to make sure it worked

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<img width="1219" alt="image" src="https://github.com/wasmCloud/wash/assets/12040685/47a9cb0d-2bb0-46f4-8cd6-39ae7c588df2">
