### PR TITLE
fix(up): Allows multiple hosts to run without sharing data

### DIFF
--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -59,7 +59,7 @@ pub async fn wait_for_server(url: &str, service: &str) -> Result<()> {
     loop {
         // Magic number: 10 + 1, since we are starting at 1 for humans
         if wait_count >= 11 {
-            anyhow::bail!("Ran out of retries waiting for host to start");
+            anyhow::bail!("Ran out of retries waiting for {service} to start");
         }
         match tokio::net::TcpStream::connect(url).await {
             Ok(_) => break,

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -215,7 +215,7 @@ leafnodes {{
             r#"
 jetstream {{
     domain={}
-    store_dir={}
+    store_dir={:?}
 }}
 {}
 "#,
@@ -425,7 +425,7 @@ mod test {
         let mut contents = String::new();
         credsfile.read_to_string(&mut contents).await?;
 
-        assert_eq!(contents, format!("\njetstream {{\n    domain={}\n    store_dir={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", std::env::temp_dir().join("wash-jetstream-4243").display(), "connect.ngs.global", creds.to_string_lossy()));
+        assert_eq!(contents, format!("\njetstream {{\n    domain={}\n    store_dir={:?}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", std::env::temp_dir().join("wash-jetstream-4243").display(), "connect.ngs.global", creds.to_string_lossy()));
         // A simple check to ensure we are properly escaping quotes, this is unescaped and checks for "\\"
         #[cfg(target_family = "windows")]
         assert!(creds.to_string_lossy().contains("\\"));

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -115,6 +115,9 @@ where
 pub struct NatsConfig {
     pub host: String,
     pub port: u16,
+    /// The path where the NATS server will store its jetstream data. This must be different for
+    /// each NATS server you spin up, otherwise they will share stream data
+    pub store_dir: PathBuf,
     pub js_domain: Option<String>,
     pub remote_url: Option<String>,
     pub credentials: Option<PathBuf>,
@@ -131,6 +134,7 @@ impl Default for NatsConfig {
         NatsConfig {
             host: "127.0.0.1".to_string(),
             port: 4222,
+            store_dir: std::env::temp_dir().join("wash-jetstream-4222"),
             js_domain: Some("core".to_string()),
             remote_url: None,
             credentials: None,
@@ -160,6 +164,7 @@ impl NatsConfig {
         NatsConfig {
             host: host.to_owned(),
             port,
+            store_dir: std::env::temp_dir().join(format!("wash-jetstream-{}", port)),
             js_domain,
             remote_url: Some(remote_url),
             credentials: Some(credentials),
@@ -179,6 +184,7 @@ impl NatsConfig {
         NatsConfig {
             host: host.to_owned(),
             port,
+            store_dir: std::env::temp_dir().join(format!("wash-jetstream-{}", port)),
             js_domain,
             ..Default::default()
         }
@@ -209,10 +215,12 @@ leafnodes {{
             r#"
 jetstream {{
     domain={}
+    store_dir={}
 }}
 {}
 "#,
             self.js_domain.unwrap_or_else(|| "core".to_string()),
+            self.store_dir.as_os_str().to_string_lossy(),
             leafnode_section
         );
         write(path, config).await.map_err(anyhow::Error::from)
@@ -417,7 +425,7 @@ mod test {
         let mut contents = String::new();
         credsfile.read_to_string(&mut contents).await?;
 
-        assert_eq!(contents, format!("\njetstream {{\n    domain={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", "connect.ngs.global", creds.to_string_lossy()));
+        assert_eq!(contents, format!("\njetstream {{\n    domain={}\n    store_dir={}\n}}\n\nleafnodes {{\n    remotes = [\n        {{\n            url: \"{}\"\n            credentials: {:?}\n        }}\n    ]\n}}\n                \n", "core", std::env::temp_dir().join("wash-jetstream-4243").display(), "connect.ngs.global", creds.to_string_lossy()));
         // A simple check to ensure we are properly escaping quotes, this is unescaped and checks for "\\"
         #[cfg(target_family = "windows")]
         assert!(creds.to_string_lossy().contains("\\"));

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -106,6 +106,7 @@ impl From<NatsOpts> for NatsConfig {
         NatsConfig {
             host: other.nats_host,
             port: other.nats_port,
+            store_dir: std::env::temp_dir().join(format!("wash-jetstream-{}", other.nats_port)),
             js_domain: other.nats_js_domain,
             remote_url: other.nats_remote_url,
             credentials: other.nats_credsfile,


### PR DESCRIPTION
## Feature or Problem

I found out when running some blobby tests that if you spin up multiple hosts, the NATS servers are separate, but they actually use the same data directory by default for jetstream. This means that two different locally running hosts _technically_ have the same streams and data available, which could lead to conflicts.

This segments it off into different data directories depending on the port the nats server is listening on. Technically there are still bugs when running two different nats servers as they write to the same log file, but we can solve that one later

## Release Information

This should probably be a patch release for 0.18 and for wash-lib. If we decide to do so, I'll follow up with a version bump

## Consumer Impact

Right now this is limited mostly to testing scenarios, so the current bug isn't super bad. But it is definitely annoying for users using wash for integration testing

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

None

### Acceptance or Integration

None

### Manual Verification

I started two `wash up` processes with different NATS ports and validated that they were running with different store directories and information
