### PR TITLE
bumped cargo versions for wash-lib 0.9.1 wash 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
Bumps wash-lib and wash a patch bump to release some bug fixes

## Related Issues
#621 #622 #631 #635 #636


## Release Information
wash-lib 0.9.1
wash-cli 0.18.1

## Consumer Impact
See descriptions above

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
It builds!
