### PR TITLE
feat: add preview2 target to wasmcloud.toml

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -35,6 +35,23 @@ jobs:
           shared-key: "${{ matrix.os }}-shared-cache"
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+
+      # Sometimes, unit tests will get stuck executing wash during the
+      # loading CA certificates from the :otp store step. All you see is:
+      #
+      # > stderr log: 14:38:03.656 [info] Loading 467 CA(s) from :otp store
+      #
+      # when this happens, tests like can_download_and_start_wasmcloud get stuck and fail.
+      # to avoid this, we can call wash up/down and at least cause this loading as early as possible,
+      # hoping it does not happen again (or completes near instantaneously) during a test.
+      - name: Build wash
+        run: make build
+      - name: Cycle wash
+        run: |
+          cargo run -- up --detached;
+          sleep 10;
+          cargo run -- down;
+
       - name: Run all wash & wash-lib unit tests
         run: make test-wash-ci
 

--- a/crates/wash-lib/tests/parser/files/minimal_rust_actor_core_module.toml
+++ b/crates/wash-lib/tests/parser/files/minimal_rust_actor_core_module.toml
@@ -1,0 +1,8 @@
+language = "rust"
+type = "actor"
+name = "testactor"
+version = "0.1.0"
+
+[actor]
+claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-unknown-unknown"

--- a/crates/wash-lib/tests/parser/files/minimal_rust_actor_preview1.toml
+++ b/crates/wash-lib/tests/parser/files/minimal_rust_actor_preview1.toml
@@ -1,0 +1,8 @@
+language = "rust"
+type = "actor"
+name = "testactor"
+version = "0.1.0"
+
+[actor]
+claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-wasi-preview1"

--- a/crates/wash-lib/tests/parser/files/minimal_rust_actor_preview2.toml
+++ b/crates/wash-lib/tests/parser/files/minimal_rust_actor_preview2.toml
@@ -1,0 +1,8 @@
+language = "rust"
+type = "actor"
+name = "testactor"
+version = "0.1.0"
+
+[actor]
+claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-wasi-preview2"

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -4,6 +4,7 @@ use claims::{assert_err, assert_ok};
 use semver::Version;
 use wash_lib::parser::{
     get_config, ActorConfig, CommonConfig, LanguageConfig, RustConfig, TinyGoConfig, TypeConfig,
+    WasmTarget,
 };
 
 #[test]
@@ -32,7 +33,7 @@ fn rust_actor() {
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
-            wasm_target: "wasm32-unknown-unknown".to_string(),
+            wasm_target: WasmTarget::CoreModule,
             call_alias: Some("testactor".to_string())
         })
     );
@@ -74,7 +75,7 @@ fn tinygo_actor() {
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
-            wasm_target: "wasm32-unknown-unknown".to_string(),
+            wasm_target: WasmTarget::CoreModule,
             call_alias: Some("testactor".to_string())
         })
     );
@@ -256,7 +257,7 @@ fn minimal_rust_actor() {
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: None,
-            wasm_target: "wasm32-unknown-unknown".to_string(),
+            wasm_target: WasmTarget::CoreModule,
             call_alias: None
         })
     );
@@ -301,7 +302,7 @@ fn cargo_toml_actor() {
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: None,
-            wasm_target: "wasm32-unknown-unknown".to_string(),
+            wasm_target: WasmTarget::CoreModule,
             call_alias: None
         })
     );
@@ -317,4 +318,67 @@ fn cargo_toml_actor() {
             wasm_bin_name: None,
         }
     )
+}
+
+/// wasm_target=wasm32-wasi-preview2 is properly parsed
+/// see: https://github.com/wasmCloud/wash/issues/640
+#[test]
+fn minimal_rust_actor_preview2() {
+    let result = get_config(
+        Some(PathBuf::from(
+            "./tests/parser/files/minimal_rust_actor_preview2.toml",
+        )),
+        None,
+    );
+
+    let config = assert_ok!(result);
+    assert!(matches!(
+        config.project_type,
+        TypeConfig::Actor(ActorConfig {
+            wasm_target: WasmTarget::WasiPreview2,
+            ..
+        })
+    ));
+}
+
+/// wasm_target=wasm32-wasi-preview1 is properly parsed
+/// see: https://github.com/wasmCloud/wash/issues/640
+#[test]
+fn minimal_rust_actor_preview1() {
+    let result = get_config(
+        Some(PathBuf::from(
+            "./tests/parser/files/minimal_rust_actor_preview1.toml",
+        )),
+        None,
+    );
+
+    let config = assert_ok!(result);
+    assert!(matches!(
+        config.project_type,
+        TypeConfig::Actor(ActorConfig {
+            wasm_target: WasmTarget::WasiPreview1,
+            ..
+        })
+    ));
+}
+
+/// wasm_target=wasm32-unknown-unknown is properly parsed
+/// see: https://github.com/wasmCloud/wash/issues/640
+#[test]
+fn minimal_rust_actor_core_module() {
+    let result = get_config(
+        Some(PathBuf::from(
+            "./tests/parser/files/minimal_rust_actor_core_module.toml",
+        )),
+        None,
+    );
+
+    let config = assert_ok!(result);
+    assert!(matches!(
+        config.project_type,
+        TypeConfig::Actor(ActorConfig {
+            wasm_target: WasmTarget::CoreModule,
+            ..
+        })
+    ));
 }

--- a/tests/integration_dev.rs
+++ b/tests/integration_dev.rs
@@ -8,7 +8,9 @@ use tokio::{process::Command, sync::RwLock, time::Duration};
 
 mod common;
 
-use crate::common::{init, start_nats, test_dir_with_subfolder, wait_for_no_hosts};
+use crate::common::{
+    init, start_nats, test_dir_with_subfolder, wait_for_no_hosts, wait_for_no_nats,
+};
 
 #[tokio::test]
 #[serial]
@@ -95,6 +97,12 @@ async fn integration_dev_hello_actor_serial() -> Result<()> {
         .await
         .context("wasmcloud instance failed to exit cleanly (processes still left over)")?;
 
+    // Kill the nats instance
     nats.kill().await.map_err(|e| anyhow!(e))?;
+
+    wait_for_no_nats()
+        .await
+        .context("nats instance failed to exit cleanly (processes still left over")?;
+
     Ok(())
 }

--- a/tests/integration_get.rs
+++ b/tests/integration_get.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serial_test::serial;
 use tokio::process::Command;
 use wash_lib::cli::output::{
@@ -73,7 +73,13 @@ async fn integration_get_host_inventory_serial() -> Result<()> {
         .await
         .context("failed to execute get inventory")?;
 
-    assert!(output.status.success(), "executed get inventory");
+    if !output.status.success() {
+        bail!(
+            "failed to execute `wash get inventory`, stdout: {} \nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
 
     let cmd_output: GetHostInventoryCommandOutput = serde_json::from_slice(&output.stdout)?;
     assert!(cmd_output.success, "command returned success");


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Add a more explicit WASI target to wasmcloud.toml configuration, in preparation for building in support for adding post-build support for preview2 components.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

#640 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Customers will be able to specify `wasm32-wasi-preview2` to target a wasm32-wasi-preview build

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

Tests with different configuration options were added

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

This was tested locally by:

- Templating out a new rust actor
- `wash build` with `wasm_target=wasm32-unknown-unknown`
- `wash build` with `wasm_target=wasm32-wasi`
- `wash build` with `wasm_target=wasm32-wasi-preview1`
- `wash build` with `wasm_target=wasm32-wasi-preview2` (errored as expected)
