### PR TITLE
feature(up): ensure that the wasmcloud-host can be stopped gracefully

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ notify = "6.0.1"
 rust-embed = "6.8.1"
 warp = "0.3.5"
 warp-embed = "0.4.0"
+nix = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
@@ -75,7 +76,6 @@ futures = { workspace = true }
 # serial_test ensures serial execution when running with cargo, '<test name>_serial' works with nextest
 serial_test = { workspace = true }
 rand = "0.8.5"
-nix = { version = "0.26.2", default-features = false, features = [ "signal" ] }
 
 [[bin]]
 bench = true
@@ -151,3 +151,4 @@ weld-codegen = "0.7.0"
 which = "4.4.0"
 chrono = "0.4.26"
 clap_complete = "4.3.2"
+nix = { version = "0.26.2", default-features = false, features = ["signal"] }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
the `wash up` can gracefully stop wasmcloud-host when it receives ctrl-c, for example by sending SIGTERM to it.

This allows the host to broadcast that it has stopped, and ensures that wasmcloud stops gracefully

In the previous logic, when terminating `wash up` with ctrl-c, nats and wadm would both receive the SIGINT signal and they would be shut down gracefully, but `wash up` uses SIGKILL to stop wasmcloud.

On unix, because wasmcloud was not stopped gracefully due to the use of SIGKILL, none of the providers it started were stopped and became orphaned processes

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
