### PR TITLE
fix typo im Completions.md

### DIFF
--- a/Completions.md
+++ b/Completions.md
@@ -31,7 +31,7 @@ $HOME/.cargo/bin/wash completions -d $HOME/.wash bash
 source $HOME/.wash/wash.bash 
 ```
 
-Completions will be enabled the next time you start a shell. Or, you can `source ~/.zshrc` for the completions to take effect in the current shell.
+Completions will be enabled the next time you start a shell. Or, you can `source ~/.bashrc` for the completions to take effect in the current shell.
 
 
 ## Fish


### PR DESCRIPTION
## Feature or Problem

I just noticed that there is a typo in the docs about adding completions for bash. Once the completions are added to `.bashrc` the `.bashrc` needs to be sourced. Not the `.zshrc` :)