### PR TITLE
Adding the ability to inspect and inject configuration schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,13 +2519,14 @@ dependencies = [
 
 [[package]]
 name = "provider-archive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f02e3a69a868e932a76ee5e026ae1923e761f157aaf3ad0b9d4906eaebf62fc"
+checksum = "b3e73940ae67588b3e7f1d29798ee5b76b32217fcfb3d9f64d28bd5d6d72c113"
 dependencies = [
  "async-compression",
  "data-encoding",
  "ring",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tokio-tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ nkeys = "0.3.0"
 oci-distribution = { version = "0.9.4", default-features = false, features = ["rustls-tls"] }
 once_cell = "1.18"
 path-absolutize = "3.1"
-provider-archive = "0.7.0"
+provider-archive = "0.8.0"
 regex = "1.9"
 remove_dir_all = "0.7"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/crates/wash-lib/src/cli/inspect.rs
+++ b/crates/wash-lib/src/cli/inspect.rs
@@ -295,6 +295,10 @@ pub(crate) async fn handle_provider_archive(
     map.insert("version".to_string(), json!(friendly_ver));
     map.insert("revision".to_string(), json!(friendly_rev));
     map.insert("targets".to_string(), json!(artifact.targets()));
+    if let Some(schema) = artifact.schema() {
+        map.insert("schema".to_string(), json!(schema));
+    }
+
     let text_table = {
         let mut table = Table::new();
         super::configure_table_style(&mut table);
@@ -343,6 +347,20 @@ pub(crate) async fn handle_provider_archive(
             2,
             Alignment::Left,
         )]));
+
+        if artifact.schema().is_some() {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "\nLink Definition Schema",
+                2,
+                Alignment::Center,
+            )]));
+
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "\nUse the JSON output option to extract the schema",
+                2,
+                Alignment::Left,
+            )]));
+        }
 
         table.render()
     };

--- a/src/par.rs
+++ b/src/par.rs
@@ -42,6 +42,15 @@ pub(crate) struct CreateCommand {
     #[clap(long = "version")]
     version: Option<String>,
 
+    /// Optional path to a JSON schema describing the link definition specification for this provider.
+    #[clap(
+        short = 'j',
+        long = "schema",
+        env = "WASH_JSON_SCHEMA",
+        hide_env_values = true
+    )]
+    schema: Option<PathBuf>,
+
     /// Location of key files for signing. Defaults to $WASH_KEYS ($HOME/.wash/keys)
     #[clap(
         short = 'd',
@@ -258,6 +267,11 @@ pub(crate) async fn handle_create(
             extension
         ),
     };
+    if let Some(schema) = cmd.schema {
+        let bytes = std::fs::read(schema)?;
+        par.set_schema(serde_json::from_slice::<serde_json::Value>(&bytes)?)
+            .map_err(convert_error)?;
+    }
 
     par.write(&outfile, &issuer, &subject, cmd.compress)
         .await
@@ -387,6 +401,7 @@ mod test {
                 vendor,
                 revision,
                 version,
+                schema,
                 directory,
                 issuer,
                 subject,
@@ -408,6 +423,7 @@ mod test {
                 assert_eq!(destination.unwrap(), "./test.par.gz");
                 assert_eq!(revision.unwrap(), 1);
                 assert_eq!(version.unwrap(), "1.11.111");
+                assert_eq!(schema, None);
                 assert!(disable_keygen);
                 assert!(compress);
             }
@@ -446,6 +462,7 @@ mod test {
                 vendor,
                 revision,
                 version,
+                schema,
                 directory,
                 issuer,
                 subject,
@@ -467,6 +484,7 @@ mod test {
                 assert_eq!(destination.unwrap(), "./test.par.gz");
                 assert_eq!(revision.unwrap(), 1);
                 assert_eq!(version.unwrap(), "1.11.111");
+                assert_eq!(schema, None);
                 assert!(!disable_keygen);
                 assert!(!compress);
             }

--- a/src/par.rs
+++ b/src/par.rs
@@ -267,10 +267,14 @@ pub(crate) async fn handle_create(
             extension
         ),
     };
-    if let Some(schema) = cmd.schema {
+    if let Some(ref schema) = cmd.schema {
         let bytes = std::fs::read(schema)?;
-        par.set_schema(serde_json::from_slice::<serde_json::Value>(&bytes)?)
-            .map_err(convert_error)?;
+        par.set_schema(
+            serde_json::from_slice::<serde_json::Value>(&bytes)
+                .with_context(|| "Unable to parse JSON from file contents".to_string())?,
+        )
+        .map_err(convert_error)
+        .with_context(|| format!("Error parsing JSON schema from file '{:?}'", schema))?;
     }
 
     par.write(&outfile, &issuer, &subject, cmd.compress)


### PR DESCRIPTION
## Feature or Problem
Developers need the ability to store JSON schema inside a PAR file to describe the specification for configuring a provider's link definitions

## Related Issues
None

## Release Information
vNext

## Consumer Impact
No impact as "schemaless" PARs will remain the default

## Testing
Verified for local capability providers

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Added schema verification to round trip test

### Manual Verification
Manually verified storing and inspecting JSON schemas in a PAR
