### PR TITLE
feat(ctl)!: allow get inventory to query the only host

### DIFF
--- a/src/common/get_cmd.rs
+++ b/src/common/get_cmd.rs
@@ -32,10 +32,11 @@ pub(crate) async fn handle_command(
             get_hosts_output(hosts)
         }
         GetCommand::HostInventory(cmd) => {
-            sp.update_spinner_message(format!(
-                " Retrieving inventory for host {} ...",
-                cmd.host_id
-            ));
+            if let Some(id) = cmd.host_id.as_ref() {
+                sp.update_spinner_message(format!(" Retrieving inventory for host {} ...", id));
+            } else {
+                sp.update_spinner_message(" Retrieving hosts for inventory query ...".to_string());
+            }
             let inv = get_host_inventory(cmd).await?;
             get_host_inventory_output(inv)
         }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -522,7 +522,7 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(host_id, HOST_ID.parse()?);
+                assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
             }
             cmd => panic!("ctl get inventory constructed incorrect command {cmd:?}"),
         }


### PR DESCRIPTION
## Feature or Problem
Often when running a single wasmcloud host with `wash up` and developing, I find myself doing the same annoying process.
```bash
wash get hosts
# manually copy the host ID
wash get inventory <id>
```

This PR addresses this by allowing `wash get inventory` to optionally, if no host ID is provided, query the hosts and return the inventory of a single host. If there's more than one available, we return an error asking for the ID.

Now, if you are just interacting with one host, `wash get inventory` will return the inventory of that host.

A few things I considered but didn't add out of simplicity:
1. We could print the available host IDs if we don't find one
1. We could allow wash to go interactive if no host ID is provided and allow users to select from that (only in normal output mode)
1. We could just fetch the first host ID that comes back even if no host ID is provided.

I'm leaning towards a combination of 1 and 2 which would make this even better, but would like a little input before implementing that.

## Related Issues
N/A

## Release Information
v0.19.0

## Consumer Impact
This is purely an enhancement and won't modify any existing scripts or flows that use `wash get inventory <id>`. 

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I made sure it worked!
