### PR TITLE
ref(ci): bump windows builds to beeger runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           args: --all-features
 
   windows_build:
-    runs-on: windows-latest
+    runs-on: windows-latest-8-cores
     needs: [cargo_check]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, windows-latest-8-cores, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v3

--- a/.github/workflows/washlib.yml
+++ b/.github/workflows/washlib.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-20.04, windows-latest-8-cores, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
windows builds are seemingly running out of disk space, so I created a larger runner (300GB of disk instead of the standard 14GB). Hopefully it helps 🤞 

Note this is a temporary ™️ workaround, until we know for sure we need to be paying for a beeger runner for windows builds