### PR TITLE
fix(gen): preserve interactive terminal when checking git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -136,7 +136,13 @@ fn validate(project: &Project) -> Result<()> {
     }
 
     if project.git.is_some() || !project.no_git_init {
-        if let Err(err) = Command::new("git").args(["version"]).spawn() {
+        if let Err(err) = std::process::Command::new("git")
+            .args(["version"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+        {
             if err.kind() == ErrorKind::NotFound {
                 return Err(anyhow!(
                     "Error in 'new {}' options: required 'git' to be installed in PATH",


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where spawning the `git version` command check during `wash new` would break the interactive terminal. I didn't spend too long confirming my suspicion, but essentially I believe that spawning this command with connected stdio/stdout/stderr pipes broke the `interactif` prompt.

## Related Issues
No issue filed

## Release Information
wash-lib v0.9.3
wash-cli v0.19.1

## Consumer Impact
Consumers of wash that don't supply the template name will see `wash new` work again

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This resolved my issue 👍🏻 I can still reproduce breaking interactivity if you `CTRL+c` in the middle of the selection process, but that seems more involved to fix and can be approached later.
