### PR TITLE
ci(windows): avoid rust cache on Windows

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
       - name: npm install
         run: npm install --prefix ./packages/washboard
       - name: npm run build
@@ -44,9 +44,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
+        if: matrix.os != 'windows-latest-8-cores'
         with:
           shared-key: "${{ matrix.os }}-shared-cache"
       - name: Install nextest
@@ -81,8 +82,8 @@ jobs:
           shared-key: "ubuntu-22.04-shared-cache"
       - uses: acifani/setup-tinygo@v1
         with:
-          tinygo-version: '0.27.0'
-          install-binaryen: 'false'
+          tinygo-version: "0.27.0"
+          install-binaryen: "false"
       - name: Add wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
       - name: Launch integration test services

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
-        os: [ubuntu-22.04, windows-latest-8-cores, macos-11]
+        os: [ubuntu-22.04, windows-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v3
@@ -47,7 +47,7 @@ jobs:
           node-version: "18.x"
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-        if: matrix.os != 'windows-latest-8-cores'
+        if: matrix.os != 'windows-latest'
         with:
           shared-key: "${{ matrix.os }}-shared-cache"
       - name: Install nextest


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR is an interim attempt to solve the various failures we see in PRs related to the windows test. My hypothesis is that restoring from cache causes issues for the Windows runner. I considered making the ccache key more complicated to hash off of Cargo.lock, but I'm unsure if that would still cause issues. Would love to figure out how to cache in a future PR.

## Related Issues
All the dependabot PRs out right now

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
