### PR TITLE
fix: config loading for preview2 adapter path

### DIFF
--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -70,6 +70,8 @@ struct RawActorConfig {
     pub filename: Option<String>,
     /// The target wasm target to build for. Defaults to "wasm32-unknown-unknown".
     pub wasm_target: Option<String>,
+    /// Path to a wasm adapter that can be used for preview2
+    pub wasi_preview2_adapter_path: Option<PathBuf>,
     /// The call alias of the actor. Defaults to no alias.
     pub call_alias: Option<String>,
 }
@@ -90,7 +92,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
                 .wasm_target
                 .map(WasmTarget::from)
                 .unwrap_or_default(),
-            wasi_preview2_adapter_path: None,
+            wasi_preview2_adapter_path: raw_config.wasi_preview2_adapter_path,
             call_alias: raw_config.call_alias,
         })
     }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Preview2 adapter path loading wasn't being loaded from config properly

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
