### PR TITLE
chore: update dockerfile to rust 1.71

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.71-alpine3.18 as builder
 
 WORKDIR /build
-RUN apk add --no-cache clang clang-dev libressl-dev ca-certificates musl-dev llvm-dev clang-libs curl gcompat libgit2-dev
+RUN apk add --no-cache clang clang-dev ca-certificates musl-dev llvm-dev clang-libs curl gcompat libgit2-dev
 RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip && \
     mkdir -p $HOME/.local/bin && \
     unzip protoc-3.15.8-linux-x86_64.zip -d $HOME/.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-alpine3.16 as builder
+FROM rust:1.71-alpine3.18 as builder
 
 WORKDIR /build
 RUN apk add --no-cache clang clang-dev libressl-dev ca-certificates musl-dev llvm-dev clang-libs curl gcompat libgit2-dev

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ build-ui: ## Build the UI from source
 	@$(NPM) install --prefix ./packages/washboard
 	@$(NPM) run build --prefix ./packages/washboard
 
+build-docker: ## Build the docker image
+	@$(DOCKER) build -t wash .
+
 ##@ Testing
 
 test: ## Run unit test suite


### PR DESCRIPTION
This PR just updates our dockerfile to a newer version of rust.

#717 and #718 should be able to rebase off of this to fix the build issue.

Still need to verify this truly works.