### PR TITLE
Add npm package to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: npm
+  directory: "/packages/washboard"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Added a new npm package ecosystem to the dependabot.yml file to automate the regular checking for updates of npm dependencies in the /packages/washboard
