### PR TITLE
build(adapters): update WASI adapters to 12.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fd922bc88ce3f73c5ade24efa395e4b50167aca0cea114c2bd32318bb484f5"
+checksum = "87e7898314621e1d4e000e3505c9a7d1db72260decb9b4fd5593b58aafe9fe08"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ walkdir = "2.3"
 wascap = "0.11.0"
 wash-lib = { version = "0.9", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.14.0"
-wasmcloud-component-adapters = { version = "0.2.0" }
+wasmcloud-component-adapters = { version = "0.2.1" }
 wasmcloud-control-interface = "0.27"
 wasmcloud-test-util = "0.10.0"
 weld-codegen = "0.7.0"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
This bumps the component adapters to use Wasmtime's latest release `12.0.1`.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
This resolves the error:
```bash
failed to adapt component at [/Users/bhayes/repos/cosmonic/wasmcon-workshop/hello-cosmo-rust/build/hello_cosmo_rust.wasm] to WASI preview2

Caused by:
    0: failed to set adapter during encoding
    1: decoding custom section component-type:reactor
    2: record type must have at least one field (at offset 0xd)
error: Recipe `build` failed on line 26 with exit code 1
```

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
I verified that the updated adapters work for the workshop rust component.
