### PR TITLE
Chores, update wadm, update dashboard message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,9 +4188,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516b68c9d02fe1f1e6e409279a4020f103bf87ed6dce94cf9ef2804d936716e"
+checksum = "ef6c64ba64334c53b804202726b62ad769ed75ddc61516820f2a8ee26fdf3071"
 dependencies = [
  "anyhow",
  "async-nats 0.31.0",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"
@@ -71,7 +71,7 @@ nix = { version = "0.26.2", default-features = false, features = ["signal"] }
 rand = "0.8.5"
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 scopeguard = { workspace = true }
-serial_test = { workspace = true } # serial_test works with cargo, '<test name>_serial' works with nextest
+serial_test = { workspace = true }                                            # serial_test works with cargo, '<test name>_serial' works with nextest
 sysinfo = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
@@ -122,7 +122,9 @@ path-absolutize = "3.1"
 provider-archive = "0.8.0"
 regex = "1.9"
 remove_dir_all = "0.7"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+] }
 rmp-serde = "1.1.2"
 rmpv = "1.0"
 sanitize-filename = "0.4.0"
@@ -145,7 +147,7 @@ tokio-stream = "0.1"
 tokio-tar = "0.3"
 tokio-util = "0.7.8"
 toml = "0.7.6"
-wadm = "0.5.0"
+wadm = "0.6.0"
 walkdir = "2.3"
 wascap = "0.11.0"
 wash-lib = { version = "0.10", path = "./crates/wash-lib" }
@@ -155,4 +157,4 @@ wasmcloud-control-interface = "0.27"
 wasmcloud-test-util = "0.10.0"
 weld-codegen = "0.7.0"
 which = "4.4.0"
-wit-component = "0.13.2" 
+wit-component = "0.13.2"

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -24,7 +24,6 @@ pub const WASMCLOUD_HOST_BIN: &str = "wasmcloud_host.exe";
 // Any version of wasmCloud under 0.63.0 uses Elixir releases and is incompatible
 // See https://github.com/wasmCloud/wasmcloud-otp/pull/616 for the move to burrito releases
 const MINIMUM_WASMCLOUD_VERSION: &str = "0.78.0-rc2";
-const DEFAULT_DASHBOARD_PORT: u16 = 4000;
 
 /// A wrapper around the [ensure_wasmcloud_for_os_arch_pair] function that uses the
 /// architecture and operating system of the current host machine.
@@ -192,7 +191,7 @@ where
 }
 
 /// Helper function to start a wasmCloud host given the path to the burrito release application
-/// /// # Arguments
+/// # Arguments
 ///
 /// * `bin_path` - Path to the wasmcloud_host burrito application
 /// * `stdout` - Specify where wasmCloud stdout logs should be written to. Logs can be written to stdout by the erlang process
@@ -209,21 +208,6 @@ where
     T: Into<Stdio>,
     S: Into<Stdio>,
 {
-    // If we can connect to the local port, a wasmCloud host won't be able to listen on that port
-    let port = env_vars
-        .get("WASMCLOUD_DASHBOARD_PORT")
-        .cloned()
-        .unwrap_or_else(|| DEFAULT_DASHBOARD_PORT.to_string());
-    if tokio::net::TcpStream::connect(format!("localhost:{port}"))
-        .await
-        .is_ok()
-    {
-        return Err(anyhow!(
-            "Could not start wasmCloud, a process is already listening on localhost:{}",
-            port
-        ));
-    }
-
     // Constructing this object in one step results in a temporary value that's dropped
     let mut cmd = Command::new(bin_path.as_ref());
     let cmd = cmd

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -9,7 +9,7 @@ pub(crate) const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub(crate) const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub(crate) const WADM_VERSION: &str = "v0.5.0";
+pub(crate) const WADM_VERSION: &str = "v0.6.0";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.78.0-rc4";
 // NATS isolation configuration variables

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -11,10 +11,7 @@ pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
 pub(crate) const WADM_VERSION: &str = "v0.5.0";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.78.0-rc2";
-pub(crate) const WASMCLOUD_DASHBOARD_PORT: &str = "WASMCLOUD_DASHBOARD_PORT";
-// NOTE: We scan from this port up to 1000 ports higher, should always be under 64535
-pub(crate) const DEFAULT_DASHBOARD_PORT: &str = "4000";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.78.0-rc4";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";
@@ -200,14 +197,6 @@ pub(crate) async fn configure_host_env(
     host_config.insert(
         WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
         wasmcloud_opts.provider_delay.to_string(),
-    );
-
-    host_config.insert(
-        WASMCLOUD_DASHBOARD_PORT.to_string(),
-        wasmcloud_opts
-            .dashboard_port
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| DEFAULT_DASHBOARD_PORT.to_string()),
     );
 
     // Extras configuration

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -601,7 +601,8 @@ async fn run_wasmcloud_interactive(
     });
 
     if output_kind != OutputKind::Json {
-        println!("🏃 Running in interactive mode. Start the dashboard by executing `wash ui --experimental`",);
+        println!("🏃 Running in interactive mode.",);
+        println!("🎛️ If you enabled --nats-websocket-port, start the dashboard by executing `wash ui --experimental`");
         println!("🚪 Press `CTRL+c` at any time to exit");
     }
 

--- a/tests/integration_get.rs
+++ b/tests/integration_get.rs
@@ -15,7 +15,14 @@ async fn integration_get_hosts_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["get", "hosts", "--output", "json"])
+        .args([
+            "get",
+            "hosts",
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
         .kill_on_drop(true)
         .output()
         .await
@@ -37,10 +44,17 @@ async fn integration_get_hosts_serial() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn integration_get_links_serial() -> Result<()> {
-    let _wash_instance = TestWashInstance::create().await?;
+    let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["get", "links", "--output", "json"])
+        .args([
+            "get",
+            "links",
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
         .kill_on_drop(true)
         .output()
         .await
@@ -67,6 +81,8 @@ async fn integration_get_host_inventory_serial() -> Result<()> {
             &wash_instance.host_id,
             "--output",
             "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .kill_on_drop(true)
         .output()
@@ -122,10 +138,17 @@ async fn integration_get_host_inventory_serial() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn integration_get_claims_serial() -> Result<()> {
-    let _wash_instance = TestWashInstance::create().await?;
+    let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["get", "claims", "--output", "json"])
+        .args([
+            "get",
+            "claims",
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
         .kill_on_drop(true)
         .output()
         .await

--- a/tests/integration_link.rs
+++ b/tests/integration_link.rs
@@ -9,10 +9,17 @@ use common::TestWashInstance;
 #[tokio::test]
 #[serial]
 async fn integration_link_serial() -> Result<()> {
-    let _wash = TestWashInstance::create().await?;
+    let wash = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["link", "query", "--output", "json"])
+        .args([
+            "link",
+            "query",
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash.nats_port.to_string(),
+        ])
         .kill_on_drop(true)
         .output()
         .await

--- a/tests/integration_start.rs
+++ b/tests/integration_start.rs
@@ -9,7 +9,7 @@ use common::{TestWashInstance, ECHO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 #[tokio::test]
 #[serial]
 async fn integration_start_actor_serial() -> Result<()> {
-    let _wash_instance = TestWashInstance::create().await?;
+    let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
         .args([
@@ -20,6 +20,8 @@ async fn integration_start_actor_serial() -> Result<()> {
             "json",
             "--timeout-ms",
             "40000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .kill_on_drop(true)
         .output()
@@ -38,7 +40,7 @@ async fn integration_start_actor_serial() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn integration_start_provider_serial() -> Result<()> {
-    let _wash_instance = TestWashInstance::create().await?;
+    let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
         .args([
@@ -49,6 +51,8 @@ async fn integration_start_provider_serial() -> Result<()> {
             "json",
             "--timeout-ms",
             "40000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .kill_on_drop(true)
         .output()

--- a/tests/integration_stop.rs
+++ b/tests/integration_stop.rs
@@ -20,6 +20,8 @@ async fn integration_stop_actor_serial() -> Result<()> {
             "json",
             "--timeout-ms",
             "20000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .output()
         .await
@@ -42,7 +44,16 @@ async fn integration_stop_actor_serial() -> Result<()> {
 
     // Stop the actor
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["stop", "actor", &host_id, &actor_id, "--output", "json"])
+        .args([
+            "stop",
+            "actor",
+            &host_id,
+            &actor_id,
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
         .output()
         .await
         .context("failed to stop actor")?;
@@ -70,6 +81,8 @@ async fn integration_stop_provider_serial() -> Result<()> {
             "json",
             "--timeout-ms",
             "20000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .output()
         .await
@@ -107,6 +120,8 @@ async fn integration_stop_provider_serial() -> Result<()> {
             &contract_id,
             "--output",
             "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
         ])
         .output()
         .await
@@ -127,7 +142,15 @@ async fn integration_stop_host_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["stop", "host", &wash_instance.host_id, "--output", "json"])
+        .args([
+            "stop",
+            "host",
+            &wash_instance.host_id,
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
         .output()
         .await
         .context("failed to stop provider")?;

--- a/tests/integration_up.rs
+++ b/tests/integration_up.rs
@@ -30,8 +30,6 @@ async fn integration_up_can_start_wasmcloud_and_actor_serial() -> Result<()> {
             "up",
             "--nats-port",
             "5893",
-            "--dashboard-port",
-            "5002",
             "-o",
             "json",
             "--detached",


### PR DESCRIPTION
- chore: remove references to DASHBOARD_PORT
- chore: bump wadm 0.6.0
- chore: update dashboard message

## Feature or Problem
This PR
- Bumps wasmcloud to 0.78.0-rc4
- Bumps wadm to 0.6.0
- Updates the dashboard message from `wash up` to indicate that you need to enable `--nats-websocket-port` to see the dashboard.

## Related Issues
N/A

## Release Information
v0.20.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
It works!
