### PR TITLE
chore(wash-lib): bump to 0.10.1 to release wadm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,7 +4368,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"
@@ -11,19 +11,28 @@ readme = "README.md"
 repository = "https://github.com/wasmcloud/wash"
 
 [badges]
-maintenance = {status = "actively-developed"}
+maintenance = { status = "actively-developed" }
 
 [features]
 default = ["start", "parser", "nats"]
 start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
-cli = ["clap", "term-table", "console", "dialoguer", "heck", "ignore", "indicatif", "path-absolutize"]
+cli = [
+    "clap",
+    "term-table",
+    "console",
+    "dialoguer",
+    "heck",
+    "ignore",
+    "indicatif",
+    "path-absolutize",
+]
 nats = ["async-nats", "wadm"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
-async-nats = { workspace = true, optional = true}
+async-nats = { workspace = true, optional = true }
 bytes = { version = "1", features = ["serde"] }
 cargo_metadata = "0.17"
 cargo_toml = { workspace = true }
@@ -42,7 +51,9 @@ indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 nkeys = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
-path-absolutize = { workspace = true, features = ["once_cell_cache"], optional = true }
+path-absolutize = { workspace = true, features = [
+    "once_cell_cache",
+], optional = true }
 provider-archive = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
@@ -62,7 +73,7 @@ tokio-stream = { workspace = true }
 tokio-tar = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
-wadm = { workspace = true, optional = true}
+wadm = { workspace = true, optional = true }
 walkdir = { workspace = true }
 wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }


### PR DESCRIPTION
## Feature or Problem
This PR bumps wash-lib so we can release 0.10.1 which didn't auto-update to wadm 0.6.0.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wash-lib 0.10.1

## Consumer Impact
Consumers of wash-lib, if they also depend on wadm, will need to update to v0.6.0. So, we'll want to yank 0.10.0 of wash-lib.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
