### PR TITLE
chore: run wasmcloud 0.78.0-rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -11,7 +11,7 @@ pub(crate) const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
 pub(crate) const WADM_VERSION: &str = "v0.6.0";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.78.0-rc4";
+pub(crate) const WASMCLOUD_HOST_VERSION: &str = "v0.78.0-rc6";
 // NATS isolation configuration variables
 pub(crate) const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub(crate) const DEFAULT_LATTICE_PREFIX: &str = "default";


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR changes the wasmCloud host version to run v0.78.0-rc6 which includes some of the latest bug fixes in the Rust host.

## Related Issues
https://github.com/wasmCloud/wasmCloud/pull/630
https://github.com/wasmCloud/wasmCloud/pull/631

## Release Information
v0.20.2

## Consumer Impact
This PR adds additional context on error messages when using a host call, fixes a bug with outbound invocation chunking, and an issue where `/` characters in a call alias broke actor-to-actor calls.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
