### PR TITLE
fix(sign): move generate key message to info log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -15,6 +15,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use clap::Args;
+use log::info;
 use nkeys::{KeyPair, KeyPairType};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -290,16 +291,16 @@ pub fn extract_keypair(
             // No default key, generating for user
             None if !disable_keygen => {
                 match output_kind {
-                    OutputKind::Text => println!(
+                    OutputKind::Text => info!(
                         "No keypair found in \"{}\".
                     We will generate one for you and place it there.
-                    If you'd like to use alternative keys, you can supply them as a flag.\n",
+                    If you'd like to use an existing key, you can supply it on the CLI as a flag.\n",
                         path.display()
                     ),
                     OutputKind::Json => {
-                        println!(
+                        info!(
                             "{}",
-                            json!({"status": "No keypair found", "path": path, "keygen": "true"})
+                            json!({"status": "No existing keypair found, automatically generated and stored a new one", "path": path, "keygen": "true"})
                         )
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR moves the `println` inside of wash-lib to an `info` level log that can be controlled by the user. This will avoid printing the message about generating keypairs to stdout every time, and it also adjusts the messaging there to make the log sound less error-ey

## Related Issues
Fixes #698

## Release Information
wash-lib v0.10.2

## Consumer Impact
Consumers of wash-lib no longer need to address rogue generate messages on stdout.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
