### PR TITLE
fix(app): display deployed version in app list

### DIFF
--- a/src/app/output.rs
+++ b/src/app/output.rs
@@ -33,19 +33,27 @@ pub(crate) fn list_models_table(models: Vec<ModelSummary>) -> String {
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Name", 1, Alignment::Left),
         TableCell::new_with_alignment("Latest Version", 1, Alignment::Left),
-        TableCell::new_with_alignment("Description", 1, Alignment::Left),
+        TableCell::new_with_alignment("Deployed Version", 1, Alignment::Left),
         TableCell::new_with_alignment("Deploy Status", 1, Alignment::Right),
+        TableCell::new_with_alignment("Description", 1, Alignment::Left),
     ]));
     models.iter().for_each(|m| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(m.name.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(m.version.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(
-                m.description.clone().unwrap_or_else(|| "N/A".to_string()),
+                m.deployed_version
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
                 1,
                 Alignment::Left,
             ),
             TableCell::new_with_alignment(format!("{:?}", m.status), 1, Alignment::Right),
+            TableCell::new_with_alignment(
+                m.description.clone().unwrap_or_else(|| "N/A".to_string()),
+                1,
+                Alignment::Left,
+            ),
         ]))
     });
 


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR adds the `Deployed Version` table column into `wash app list`, displaying information that was already available in the JSON output mode.

## Related Issues
Fixes #699

## Release Information
wash-cli 0.20.3

This does change the display order of description (since that's the most likely to overflow the table) but I'd be willing to push this out as a patch release since it's just adding another piece of information. It's honestly fixing the "bug" where we omitted the information from the table in the first place.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
