### PR TITLE
Moved update_actor to wash-lib for wash ctl

### DIFF
--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
 use tokio::time::Duration;
-use wasmcloud_control_interface::Client as CtlClient;
+use wasmcloud_control_interface::{Client as CtlClient, CtlOperationAck};
 
 use crate::{
     common::boxed_err_to_anyhow,
-    config::DEFAULT_START_ACTOR_TIMEOUT_MS,
+    config::{WashConnectionOptions, DEFAULT_START_ACTOR_TIMEOUT_MS},
     wait::{
         wait_for_actor_start_event, wait_for_actor_stop_event, ActorStoppedInfo, FindEventOutcome,
     },
@@ -160,4 +160,17 @@ pub async fn stop_actor(
         FindEventOutcome::Success(info) => Ok(info),
         FindEventOutcome::Failure(err) => Err(err),
     }
+}
+
+pub async fn update_actor(
+    opts: WashConnectionOptions,
+    host_id: &str,
+    actor_id: &str,
+    actor_ref: &str,
+) -> Result<CtlOperationAck> {
+    let client = opts.into_ctl_client(None).await?;
+    client
+        .update_actor(host_id, actor_id, actor_ref, None)
+        .await
+        .map_err(boxed_err_to_anyhow)
 }


### PR DESCRIPTION
## Feature or Problem
FEAT: Move update-actor for `wash ctl update` to wash-lib.

## Release Information
next

## Consumer Impact
Functionality persists in wash. It has been moved to wash-lib for reuse.

## Testing
Tested using existing test suite

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
manually verified
