### PR TITLE
fix(ci): update name of dependent job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -90,7 +90,7 @@ jobs:
 
   test-windows:
     runs-on: windows-2022
-    needs: build-linux
+    needs: build-bin
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
## Feature or Problem
This updates the name of a dependent job in CI which was renamed in https://github.com/wasmCloud/wash/pull/734
