### PR TITLE
Minor fix to update actor in wash-lib

### DIFF
--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -6,7 +6,7 @@ use wasmcloud_control_interface::{Client as CtlClient, CtlOperationAck};
 
 use crate::{
     common::boxed_err_to_anyhow,
-    config::{WashConnectionOptions, DEFAULT_START_ACTOR_TIMEOUT_MS},
+    config::DEFAULT_START_ACTOR_TIMEOUT_MS,
     wait::{
         wait_for_actor_start_event, wait_for_actor_stop_event, ActorStoppedInfo, FindEventOutcome,
     },
@@ -163,12 +163,11 @@ pub async fn stop_actor(
 }
 
 pub async fn update_actor(
-    opts: WashConnectionOptions,
+    client: &CtlClient,
     host_id: &str,
     actor_id: &str,
     actor_ref: &str,
 ) -> Result<CtlOperationAck> {
-    let client = opts.into_ctl_client(None).await?;
     client
         .update_actor(host_id, actor_id, actor_ref, None)
         .await

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -208,13 +208,11 @@ pub(crate) async fn handle_command(
                 cmd.actor_id, cmd.new_actor_ref
             ));
 
-            let ack = update_actor(
-                cmd.opts.try_into()?,
-                &cmd.host_id,
-                &cmd.actor_id,
-                &cmd.new_actor_ref,
-            )
-            .await?;
+            let wco: WashConnectionOptions = cmd.opts.try_into()?;
+            let client = wco.into_ctl_client(None).await?;
+
+            let ack =
+                update_actor(&client, &cmd.host_id, &cmd.actor_id, &cmd.new_actor_ref).await?;
             if !ack.accepted {
                 bail!("Operation failed: {}", ack.error);
             }


### PR DESCRIPTION
## Feature or Problem
Fix: Update actor in wash-lib accepted `WashConnectionOptions`.
Changed this to `CtlClient` for reusability.

## Related Issues

## Release Information
next

## Consumer Impact
NA

## Testing
manually tested

 platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Manual Verification
manually verified
