### PR TITLE
Added par support to wash-lib

### DIFF
--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -43,6 +43,7 @@ pub mod get;
 pub mod inspect;
 pub mod link;
 pub mod output;
+pub mod par;
 pub mod registry;
 pub mod spy;
 pub mod start;

--- a/crates/wash-lib/src/cli/par.rs
+++ b/crates/wash-lib/src/cli/par.rs
@@ -42,7 +42,7 @@ pub async fn create_provider_archive(
     Ok(par)
 }
 
-pub async fn insert_provider_archive(
+pub async fn insert_provider_binary(
     arch: String,
     binary_bytes: &[u8],
     mut par: ProviderArchive,

--- a/crates/wash-lib/src/cli/par.rs
+++ b/crates/wash-lib/src/cli/par.rs
@@ -1,11 +1,6 @@
-use std::{fs::File, io::prelude::*, path::PathBuf};
-
-use crate::cli::{extract_keypair, OutputKind};
-use anyhow::{anyhow, bail, Context, Result};
-use nkeys::KeyPairType;
+use anyhow::{anyhow, Context, Result};
 use provider_archive::ProviderArchive;
-
-const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+use std::path::PathBuf;
 
 pub struct ParCreateArgs {
     pub capid: String,
@@ -13,86 +8,27 @@ pub struct ParCreateArgs {
     pub revision: Option<i32>,
     pub version: Option<String>,
     pub schema: Option<PathBuf>,
-    pub issuer: Option<String>,
-    pub subject: Option<String>,
     pub name: String,
-    pub directory: Option<PathBuf>,
     pub arch: String,
-    pub binary: String,
-    pub destination: Option<String>,
-    pub compress: bool,
-    pub disable_keygen: bool,
-}
-pub struct ParInsertArgs {
-    pub archive: String,
-    pub arch: String,
-    pub binary: String,
-    pub directory: Option<PathBuf>,
-    pub issuer: Option<String>,
-    pub subject: Option<String>,
-    pub disable_keygen: bool,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn handle_par_create(
+pub async fn create_provider_archive(
     ParCreateArgs {
-        // claims related options
         capid,
         vendor,
         revision,
         version,
         schema,
-        issuer,
-        subject,
         name,
-        // par related options
-        directory,
         arch,
-        binary,
-        destination,
-        compress,
-        disable_keygen,
     }: ParCreateArgs,
-    output_kind: OutputKind,
-) -> Result<String> {
+    binary_bytes: &[u8],
+) -> Result<ProviderArchive> {
     let mut par = ProviderArchive::new(&capid, &name, &vendor, revision, version);
 
-    let mut f = File::open(binary.clone())?;
-    let mut lib = Vec::new();
-    f.read_to_end(&mut lib)?;
+    par.add_library(&arch, binary_bytes)
+        .map_err(convert_error)?;
 
-    let issuer = extract_keypair(
-        issuer,
-        Some(binary.clone()),
-        directory.clone(),
-        KeyPairType::Account,
-        disable_keygen,
-        output_kind,
-    )?;
-    let subject = extract_keypair(
-        subject,
-        Some(binary.clone()),
-        directory,
-        KeyPairType::Service,
-        disable_keygen,
-        output_kind,
-    )?;
-
-    par.add_library(&arch, &lib).map_err(convert_error)?;
-
-    let extension = if compress { ".par.gz" } else { ".par" };
-    let outfile = match destination {
-        Some(path) => path,
-        None => format!(
-            "{}{}",
-            PathBuf::from(binary.clone())
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            extension
-        ),
-    };
     if let Some(ref schema) = schema {
         let bytes = std::fs::read(schema)?;
         par.set_schema(
@@ -103,77 +39,21 @@ pub async fn handle_par_create(
         .with_context(|| format!("Error parsing JSON schema from file '{:?}'", schema))?;
     }
 
-    par.write(&outfile, &issuer, &subject, compress)
-        .await
-        .map_err(|e| anyhow!("{}", e))
-        .with_context(|| {
-            format!(
-                "Error writing PAR. Please ensure directory {:?} exists",
-                PathBuf::from(outfile.clone()).parent().unwrap(),
-            )
-        })?;
-    Ok(outfile)
+    Ok(par)
 }
 
-pub async fn handle_par_insert(
-    ParInsertArgs {
-        archive,
-        arch,
-        binary,
-        directory,
-        issuer,
-        subject,
-        disable_keygen,
-    }: ParInsertArgs,
-    output_kind: OutputKind,
-) -> Result<()> {
-    let mut buf = Vec::new();
-    let mut f = File::open(archive.clone())?;
-    f.read_to_end(&mut buf)?;
-
-    let mut par = ProviderArchive::try_load(&buf)
-        .await
+pub async fn insert_provider_archive(
+    arch: String,
+    binary_bytes: &[u8],
+    mut par: ProviderArchive,
+) -> Result<ProviderArchive> {
+    par.add_library(&arch, binary_bytes)
         .map_err(convert_error)?;
 
-    let issuer = extract_keypair(
-        issuer,
-        Some(binary.clone().to_owned()),
-        directory.clone(),
-        KeyPairType::Account,
-        disable_keygen,
-        output_kind,
-    )?;
-    let subject = extract_keypair(
-        subject,
-        Some(binary.clone().to_owned()),
-        directory,
-        KeyPairType::Service,
-        disable_keygen,
-        output_kind,
-    )?;
-
-    let mut f = File::open(binary.clone())?;
-    let mut lib = Vec::new();
-    f.read_to_end(&mut lib)?;
-
-    par.add_library(&arch, &lib).map_err(convert_error)?;
-
-    par.write(&archive, &issuer, &subject, is_compressed(&buf)?)
-        .await
-        .map_err(convert_error)?;
-
-    Ok(())
+    Ok(par)
 }
 
 /// Converts error from Send + Sync error to standard anyhow error
-pub(crate) fn convert_error(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
+pub fn convert_error(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
     anyhow!(e.to_string())
-}
-
-/// Inspects the byte slice for a GZIP header, and returns true if the file is compressed
-fn is_compressed(input: &[u8]) -> Result<bool> {
-    if input.len() < 2 {
-        bail!("Not enough bytes to be a valid PAR file");
-    }
-    Ok(input[0..2] == GZIP_MAGIC)
 }

--- a/crates/wash-lib/src/cli/par.rs
+++ b/crates/wash-lib/src/cli/par.rs
@@ -1,0 +1,179 @@
+use std::{fs::File, io::prelude::*, path::PathBuf};
+
+use crate::cli::{extract_keypair, OutputKind};
+use anyhow::{anyhow, bail, Context, Result};
+use nkeys::KeyPairType;
+use provider_archive::ProviderArchive;
+
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+pub struct ParCreateArgs {
+    pub capid: String,
+    pub vendor: String,
+    pub revision: Option<i32>,
+    pub version: Option<String>,
+    pub schema: Option<PathBuf>,
+    pub issuer: Option<String>,
+    pub subject: Option<String>,
+    pub name: String,
+    pub directory: Option<PathBuf>,
+    pub arch: String,
+    pub binary: String,
+    pub destination: Option<String>,
+    pub compress: bool,
+    pub disable_keygen: bool,
+}
+pub struct ParInsertArgs {
+    pub archive: String,
+    pub arch: String,
+    pub binary: String,
+    pub directory: Option<PathBuf>,
+    pub issuer: Option<String>,
+    pub subject: Option<String>,
+    pub disable_keygen: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_par_create(
+    ParCreateArgs {
+        // claims related options
+        capid,
+        vendor,
+        revision,
+        version,
+        schema,
+        issuer,
+        subject,
+        name,
+        // par related options
+        directory,
+        arch,
+        binary,
+        destination,
+        compress,
+        disable_keygen,
+    }: ParCreateArgs,
+    output_kind: OutputKind,
+) -> Result<String> {
+    let mut par = ProviderArchive::new(&capid, &name, &vendor, revision, version);
+
+    let mut f = File::open(binary.clone())?;
+    let mut lib = Vec::new();
+    f.read_to_end(&mut lib)?;
+
+    let issuer = extract_keypair(
+        issuer,
+        Some(binary.clone()),
+        directory.clone(),
+        KeyPairType::Account,
+        disable_keygen,
+        output_kind,
+    )?;
+    let subject = extract_keypair(
+        subject,
+        Some(binary.clone()),
+        directory,
+        KeyPairType::Service,
+        disable_keygen,
+        output_kind,
+    )?;
+
+    par.add_library(&arch, &lib).map_err(convert_error)?;
+
+    let extension = if compress { ".par.gz" } else { ".par" };
+    let outfile = match destination {
+        Some(path) => path,
+        None => format!(
+            "{}{}",
+            PathBuf::from(binary.clone())
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            extension
+        ),
+    };
+    if let Some(ref schema) = schema {
+        let bytes = std::fs::read(schema)?;
+        par.set_schema(
+            serde_json::from_slice::<serde_json::Value>(&bytes)
+                .with_context(|| "Unable to parse JSON from file contents".to_string())?,
+        )
+        .map_err(convert_error)
+        .with_context(|| format!("Error parsing JSON schema from file '{:?}'", schema))?;
+    }
+
+    par.write(&outfile, &issuer, &subject, compress)
+        .await
+        .map_err(|e| anyhow!("{}", e))
+        .with_context(|| {
+            format!(
+                "Error writing PAR. Please ensure directory {:?} exists",
+                PathBuf::from(outfile.clone()).parent().unwrap(),
+            )
+        })?;
+    Ok(outfile)
+}
+
+pub async fn handle_par_insert(
+    ParInsertArgs {
+        archive,
+        arch,
+        binary,
+        directory,
+        issuer,
+        subject,
+        disable_keygen,
+    }: ParInsertArgs,
+    output_kind: OutputKind,
+) -> Result<()> {
+    let mut buf = Vec::new();
+    let mut f = File::open(archive.clone())?;
+    f.read_to_end(&mut buf)?;
+
+    let mut par = ProviderArchive::try_load(&buf)
+        .await
+        .map_err(convert_error)?;
+
+    let issuer = extract_keypair(
+        issuer,
+        Some(binary.clone().to_owned()),
+        directory.clone(),
+        KeyPairType::Account,
+        disable_keygen,
+        output_kind,
+    )?;
+    let subject = extract_keypair(
+        subject,
+        Some(binary.clone().to_owned()),
+        directory,
+        KeyPairType::Service,
+        disable_keygen,
+        output_kind,
+    )?;
+
+    let mut f = File::open(binary.clone())?;
+    let mut lib = Vec::new();
+    f.read_to_end(&mut lib)?;
+
+    par.add_library(&arch, &lib).map_err(convert_error)?;
+
+    par.write(&archive, &issuer, &subject, is_compressed(&buf)?)
+        .await
+        .map_err(convert_error)?;
+
+    Ok(())
+}
+
+/// Converts error from Send + Sync error to standard anyhow error
+pub(crate) fn convert_error(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
+    anyhow!(e.to_string())
+}
+
+/// Inspects the byte slice for a GZIP header, and returns true if the file is compressed
+fn is_compressed(input: &[u8]) -> Result<bool> {
+    if input.len() < 2 {
+        bail!("Not enough bytes to be a valid PAR file");
+    }
+    Ok(input[0..2] == GZIP_MAGIC)
+}

--- a/src/par.rs
+++ b/src/par.rs
@@ -8,7 +8,7 @@ use log::warn;
 use nkeys::KeyPairType;
 use provider_archive::ProviderArchive;
 use serde_json::json;
-use wash_lib::cli::par::{convert_error, create_provider_archive, insert_provider_archive};
+use wash_lib::cli::par::{convert_error, create_provider_archive, insert_provider_binary};
 use wash_lib::cli::{extract_keypair, inspect, par, CommandOutput, OutputKind};
 
 const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
@@ -328,7 +328,7 @@ pub(crate) async fn handle_insert(
         .await
         .map_err(convert_error)?;
 
-    par = insert_provider_archive(cmd.arch, &lib, par).await?;
+    par = insert_provider_binary(cmd.arch, &lib, par).await?;
     par.write(&cmd.archive, &issuer, &subject, is_compressed(&buf)?)
         .await
         .map_err(convert_error)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use term_table::{Table, TableStyle};
 use wash_lib::config::DEFAULT_NATS_TIMEOUT_MS;
 
@@ -23,11 +23,6 @@ pub(crate) fn extract_arg_value(arg: &str) -> Result<String> {
 
 pub(crate) fn default_timeout_ms() -> u64 {
     DEFAULT_NATS_TIMEOUT_MS
-}
-
-/// Converts error from Send + Sync error to standard anyhow error
-pub(crate) fn convert_error(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
-    anyhow!(e.to_string())
 }
 
 /// Transform a json string (e.g. "{"hello": "world"}") into msgpack bytes


### PR DESCRIPTION
## Feature or Problem
Feat: Move `wash par` to `wash-lib`

## Release Information
next

## Consumer Impact
Internal code refactoring.
No impact to existing functionality

## Testing
unit and manual tests


Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
manually verified
