### PR TITLE
chore: update wasmcloud-component-adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d813d93f11b2ebb9446c8fb3d9bc80def039f7542e563088c9a83d91bc91d5"
+checksum = "afd9b5eb11bb4ec9d92ca28a75da5ab1f947534a04f1bd6d095e2429981d4595"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ walkdir = "2.4"
 wascap = "0.11.2"
 wash-lib = { version = "0.11", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.14.0"
-wasmcloud-component-adapters = { version = "0.2.2" }
+wasmcloud-component-adapters = { version = "0.2.3" }
 wasmcloud-control-interface = "0.27"
 wasmcloud-test-util = "0.10.0"
 weld-codegen = "0.7.0"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1694620341,
-        "narHash": "sha256-5hV38PQ1roGn5oxWdmv7YRp684/9hypW/7nzcdLARZI=",
+        "lastModified": 1695911503,
+        "narHash": "sha256-3Jb9jRuYnB3U0OKZ0SRr1OGzznb+jAOMCd0ouYxKA60=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "12719bd23b88573977c7ad7fe818b05e8fbc33b3",
+        "rev": "9b6403d856f71291aabb91511b53fa79c2758745",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1695190922,
-        "narHash": "sha256-X4pQTj34pNbQK8MMIxYeuuOniNzzI5A79amorTmMloQ=",
+        "lastModified": 1695882118,
+        "narHash": "sha256-hRJn6+hgRl3lGhhkHyDSJJtTv566PDlwR1kJ/ORDABI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a00ca48f236fc574e6932d78e27f25f21006fb1a",
+        "rev": "8fd2f98fdf23c372cbac5a4ab79a02541f0bd475",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1695747847,
-        "narHash": "sha256-DsJEQ30k6fpu44mZ3GLEudsUR2gb3C26Jmx3lUTsN7w=",
+        "lastModified": 1695931678,
+        "narHash": "sha256-21mE4qytFh0L2YniJguHOtEZhn2Gp6OR7dvDLAGNGf8=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "d0b4d8fa9946c9529b725d14e46af9f4e9f4a4c3",
+        "rev": "90b58578f5dea686486051f7c3d72f525c81f91e",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
     },
     "nixlib_3": {
       "locked": {
-        "lastModified": 1694911725,
-        "narHash": "sha256-8YqI+YU1DGclEjHsnrrGfqsQg3Wyga1DfTbJrN3Ud0c=",
+        "lastModified": 1695516402,
+        "narHash": "sha256-pL7m8iu1OLs/7ywhh+Q8ltPgmtwbMpi7484yr32zgYI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "819180647f428a3826bfc917a54449da1e532ce0",
+        "rev": "01fc4cd75e577ac00e7c50b7e5f16cd9b6d633e8",
         "type": "github"
       },
       "original": {
@@ -775,11 +775,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1695106126,
-        "narHash": "sha256-5BDOEo5miK+46ByqhooW32viYzDUmHrw++UK8zkMbPg=",
+        "lastModified": 1695825837,
+        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "53d337b63c8f9d7e0f8709cae0008a9655bee33e",
+        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
         "type": "github"
       },
       "original": {
@@ -846,11 +846,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695155769,
-        "narHash": "sha256-1eoWaMkGpqADYaMIabnKiMzxHNhoO1L7Z2XPHJgVn4Y=",
+        "lastModified": 1695834317,
+        "narHash": "sha256-UNIrnTUD3c4LZ/3n3bdUhFhIL3PmVulrDteFFbQqEoE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0427a239eba36a87914dca2c7760f125b6d8fbb0",
+        "rev": "f93b6acb7ff149c8dda6d444a9b32ea9240af382",
         "type": "github"
       },
       "original": {
@@ -952,11 +952,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695175880,
-        "narHash": "sha256-TBR5/K3jkrd+U5mjxvRvUhlcT1Hw9jFywz1TjAGZRm4=",
+        "lastModified": 1695867081,
+        "narHash": "sha256-TP1ocrZSKvfGgpdjw7bUd+jEuF1/OBfuKHvK5EEAhww=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e054ca37ee416efe9d8fc72d249ec332ef74b6d4",
+        "rev": "9d8f850c3de67597c65271f3088aced0a671677f",
         "type": "github"
       },
       "original": {
@@ -1084,16 +1084,16 @@
         "wasi-preview1-reactor-component-adapter": "wasi-preview1-reactor-component-adapter"
       },
       "locked": {
-        "lastModified": 1695412554,
-        "narHash": "sha256-fi6Oo2h4C1X3D1qWhgPBFdBv7GhVRNkerRKxtb9qg1c=",
+        "lastModified": 1696460780,
+        "narHash": "sha256-xg6m9O1dgbgb3jQQWAaD/JulCPD3re8cJyn+qIJDREw=",
         "owner": "wasmCloud",
         "repo": "wasmcloud-component-adapters",
-        "rev": "aac0e4ec74dc7a9fe91a2435be413831fc18b96e",
+        "rev": "dd8197ed8e854e3603bbeab6f25118df262add14",
         "type": "github"
       },
       "original": {
         "owner": "wasmCloud",
-        "ref": "v0.2.2",
+        "ref": "v0.2.3",
         "repo": "wasmcloud-component-adapters",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   description = "wash - wasmCloud Shell";
 
   inputs.nixify.url = github:rvolosatovs/nixify;
-  inputs.wasmcloud-component-adapters.url = github:wasmCloud/wasmcloud-component-adapters/v0.2.2;
+  inputs.wasmcloud-component-adapters.url = github:wasmCloud/wasmcloud-component-adapters/v0.2.3;
 
   outputs = {
     self,


### PR DESCRIPTION
## Feature or Problem
This bumps the version of wasmcloud-component-adapters, so when we next release wash-lib/wash, the docs should build 🤞, as this dependency no longer requires an internet connection to build in docs.rs 

## Related Issues
Resolves https://github.com/wasmCloud/wash/issues/831
