### PR TITLE
release: wash-lib v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
We could wait for https://github.com/wasmCloud/control-interface-client/pull/56 and do a minor bump, but since docs aren't building for v0.11.1, a patch before then feels warranted