### PR TITLE
release: wash-lib v0.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ wascap = "0.11.2"
 wasm-encoder = "0.33.2"
 wash-lib = { version = "0.11", path = "./crates/wash-lib" }
 wasmbus-rpc = "0.14"
-wasmcloud-component-adapters = { version = "0.2.4" }
+wasmcloud-component-adapters = { version = "0.2.4", default-features = false }
 wasmcloud-control-interface = "0.27"
 wasmcloud-test-util = "0.10.0"
 weld-codegen = "0.7.0"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"
@@ -14,7 +14,7 @@ repository = "https://github.com/wasmcloud/wash"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["start", "parser", "nats"]
+default = ["start", "parser", "nats", "build-adapters"]
 start = ["semver"]
 parser = ["config", "semver", "serde", "serde_json"]
 cli = [
@@ -28,6 +28,11 @@ cli = [
     "path-absolutize",
 ]
 nats = ["async-nats", "wadm"]
+build-adapters = [ "wasmcloud-component-adapters/build-adapters" ]
+
+[package.metadata.docs.rs]
+no-default-features = true # skip building adapters (which requires internet access)
+features = ["start", "parser", "nats"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -78,7 +83,7 @@ walkdir = { workspace = true }
 wascap = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmbus-rpc = { workspace = true }
-wasmcloud-component-adapters = { workspace = true }
+wasmcloud-component-adapters = { workspace = true, default-features = false  }
 wasmcloud-control-interface = { workspace = true }
 wat = { workspace = true }
 weld-codegen = { workspace = true }


### PR DESCRIPTION
Okay I **know**\* it will work this time:

```
cd crates/wash-lib
cargo build --no-default-features --features start,parser,nats
```

Note that the component adapter docs are up now: https://docs.rs/wasmcloud-component-adapters/0.2.4/wasmcloud_component_adapters/ 

This disables the feature flag transitively when building docs for wash-lib

\* Note that "knowledge" conveys confidence, not an epistemologically valid truth claim