### PR TITLE
feat: query all host inventories

### DIFF
--- a/crates/wash-lib/src/cli/get.rs
+++ b/crates/wash-lib/src/cli/get.rs
@@ -13,12 +13,11 @@ pub struct GetClaimsCommand {
 }
 
 #[derive(Debug, Clone, Parser)]
-pub struct GetHostInventoryCommand {
+pub struct GetHostInventoriesCommand {
     #[clap(flatten)]
     pub opts: CliConnectionOpts,
 
-    /// Host ID to retrieve inventory for. If not provided, wash will attempt to query the inventory of a single running host.
-    /// If more than one host is found, an error will be returned prompting for a specific ID.
+    /// Host ID to retrieve inventory for. If not provided, wash will query the inventories of all running hosts.
     #[clap(name = "host-id", value_parser)]
     pub host_id: Option<ServerId>,
 }
@@ -50,34 +49,38 @@ pub enum GetCommand {
     Hosts(GetHostsCommand),
 
     /// Retrieve inventory a given host on in the lattice
-    #[clap(name = "inventory")]
-    HostInventory(GetHostInventoryCommand),
+    #[clap(name = "inventory", alias = "inventories")]
+    HostInventories(GetHostInventoriesCommand),
 }
 
 /// Retreive host inventory
-pub async fn get_host_inventory(cmd: GetHostInventoryCommand) -> Result<HostInventory> {
+pub async fn get_host_inventories(cmd: GetHostInventoriesCommand) -> Result<Vec<HostInventory>> {
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
 
-    let host_id = if let Some(host_id) = cmd.host_id {
-        host_id.to_string()
+    let host_ids = if let Some(host_id) = cmd.host_id {
+        vec![host_id.to_string()]
     } else {
         let hosts = client.get_hosts().await.map_err(boxed_err_to_anyhow)?;
         match hosts.len() {
             0 => anyhow::bail!("No hosts are available for inventory query."),
-            // SAFETY: We know that the length is 1, so we can safely unwrap the first element
-            1 => hosts.first().unwrap().id.clone(),
-            _ => {
-                anyhow::bail!("No host id provided and more than one host is available. Please specify a host id.")
-            }
+            _ => hosts.iter().map(|h| h.id.clone()).collect(),
         }
     };
 
-    client
-        .get_host_inventory(&host_id)
+    let futs = host_ids
+        .into_iter()
+        .map(|host_id| (client.clone(), host_id))
+        .map(|(client, host_id)| async move {
+            client
+                .get_host_inventory(&host_id.clone())
+                .await
+                .map_err(boxed_err_to_anyhow)
+        });
+    futures::future::join_all(futs)
         .await
-        .map_err(boxed_err_to_anyhow)
-        .context("Was able to connect to NATS, but failed to get host inventory.")
+        .into_iter()
+        .collect::<Result<Vec<HostInventory>>>()
 }
 
 /// Retrieve hosts

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -52,9 +52,9 @@ pub struct GetHostsCommandOutput {
 
 /// JSON output representation of the `wash get inventory` command
 #[derive(Debug, Clone, Deserialize)]
-pub struct GetHostInventoryCommandOutput {
+pub struct GetHostInventoriesCommandOutput {
     pub success: bool,
-    pub inventory: HostInventory,
+    pub inventories: Vec<HostInventory>,
 }
 
 /// JSON output representation of the `wash get claims` command

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -299,7 +299,7 @@ mod test {
     use tokio::net::TcpStream;
     use tokio::time::Duration;
 
-    const WASMCLOUD_VERSION: &str = "v0.78.0-rc2";
+    const WASMCLOUD_VERSION: &str = "v0.79.0-rc3";
     const RANDOM_PORT_RANGE_START: u16 = 5000;
     const RANDOM_PORT_RANGE_END: u16 = 6000;
     const LOCALHOST: &str = "127.0.0.1";

--- a/src/common/get_cmd.rs
+++ b/src/common/get_cmd.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
 use wash_lib::cli::{
     claims::get_claims,
-    get::{get_host_inventory, get_hosts, GetCommand, GetLinksCommand},
+    get::{get_host_inventories, get_hosts, GetCommand, GetLinksCommand},
     link::{LinkCommand, LinkQueryCommand},
 };
 
 use crate::{
     appearance::spinner::Spinner,
     common::link_cmd::handle_command as handle_link_command,
-    ctl::{get_claims_output, get_host_inventory_output, get_hosts_output},
+    ctl::{get_claims_output, get_host_inventories_output, get_hosts_output},
     CommandOutput, OutputKind,
 };
 
@@ -31,14 +31,14 @@ pub(crate) async fn handle_command(
             let hosts = get_hosts(cmd).await?;
             get_hosts_output(hosts)
         }
-        GetCommand::HostInventory(cmd) => {
+        GetCommand::HostInventories(cmd) => {
             if let Some(id) = cmd.host_id.as_ref() {
                 sp.update_spinner_message(format!(" Retrieving inventory for host {} ...", id));
             } else {
                 sp.update_spinner_message(" Retrieving hosts for inventory query ...".to_string());
             }
-            let inv = get_host_inventory(cmd).await?;
-            get_host_inventory_output(inv)
+            let invs = get_host_inventories(cmd).await?;
+            get_host_inventories_output(invs)
         }
     };
 

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Subcommand;
 use wash_lib::cli::{
-    get::{GetClaimsCommand, GetCommand, GetHostInventoryCommand, GetHostsCommand},
+    get::{GetClaimsCommand, GetCommand, GetHostInventoriesCommand, GetHostsCommand},
     link::LinkCommand,
     scale::{handle_scale_actor, ScaleCommand},
     start::StartCommand,
@@ -56,7 +56,7 @@ pub(crate) enum CtlGetCommand {
 
     /// Query a single host for its inventory of labels, actors and providers
     #[clap(name = "inventory")]
-    HostInventory(GetHostInventoryCommand),
+    HostInventories(GetHostInventoriesCommand),
 
     /// Query lattice for its claims cache
     #[clap(name = "claims")]
@@ -74,9 +74,9 @@ pub(crate) async fn handle_command(
             eprintln!("[warn] `wash ctl get hosts` has been deprecated in favor of `wash get hosts` and will be removed in a future version.");
             handle_get_command(GetCommand::Hosts(cmd), output_kind).await?
         }
-        Get(CtlGetCommand::HostInventory(cmd)) => {
+        Get(CtlGetCommand::HostInventories(cmd)) => {
             eprintln!("[warn] `wash ctl get inventory` has been deprecated in favor of `wash get inventory` and will be removed in a future version.");
-            handle_get_command(GetCommand::HostInventory(cmd), output_kind).await?
+            handle_get_command(GetCommand::HostInventories(cmd), output_kind).await?
         }
         Get(CtlGetCommand::Claims(cmd)) => {
             eprintln!("[warn] `wash ctl get claims` has been deprecated in favor of `wash get claims` and will be removed in a future version.");
@@ -279,7 +279,7 @@ mod test {
             HOST_ID,
         ])?;
         match get_host_inventory_all.command {
-            CtlCliCommand::Get(CtlGetCommand::HostInventory(GetHostInventoryCommand {
+            CtlCliCommand::Get(CtlGetCommand::HostInventories(GetHostInventoriesCommand {
                 opts,
                 host_id,
             })) => {

--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -19,10 +19,10 @@ pub(crate) fn get_hosts_output(hosts: Vec<Host>) -> CommandOutput {
     CommandOutput::new(hosts_table(hosts), map)
 }
 
-pub(crate) fn get_host_inventory_output(inv: HostInventory) -> CommandOutput {
+pub(crate) fn get_host_inventories_output(invs: Vec<HostInventory>) -> CommandOutput {
     let mut map = HashMap::new();
-    map.insert("inventory".to_string(), json!(inv));
-    CommandOutput::new(host_inventory_table(inv), map)
+    map.insert("inventories".to_string(), json!(invs));
+    CommandOutput::new(host_inventories_table(invs), map)
 }
 
 pub(crate) fn get_claims_output(claims: Vec<HashMap<String, String>>) -> CommandOutput {
@@ -96,90 +96,97 @@ pub(crate) fn hosts_table(hosts: Vec<Host>) -> String {
 }
 
 /// Helper function to transform a HostInventory into a table string for printing
-pub(crate) fn host_inventory_table(inv: HostInventory) -> String {
+pub(crate) fn host_inventories_table(invs: Vec<HostInventory>) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table);
 
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        format!("Host Inventory ({})", inv.host_id),
-        4,
-        Alignment::Center,
-    )]));
+    invs.into_iter().for_each(|inv| {
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            format!("Host Inventory ({})", inv.host_id),
+            4,
+            Alignment::Center,
+        )]));
 
-    if !inv.labels.is_empty() {
+        if !inv.labels.is_empty() {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "",
+                4,
+                Alignment::Center,
+            )]));
+            inv.labels.iter().for_each(|(k, v)| {
+                table.add_row(Row::new(vec![
+                    TableCell::new_with_alignment(k, 2, Alignment::Left),
+                    TableCell::new_with_alignment(v, 2, Alignment::Left),
+                ]))
+            });
+        } else {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "No labels present",
+                4,
+                Alignment::Center,
+            )]));
+        }
+
         table.add_row(Row::new(vec![TableCell::new_with_alignment(
             "",
             4,
             Alignment::Center,
         )]));
-        inv.labels.iter().for_each(|(k, v)| {
+        if !inv.actors.is_empty() {
             table.add_row(Row::new(vec![
-                TableCell::new_with_alignment(k, 2, Alignment::Left),
-                TableCell::new_with_alignment(v, 2, Alignment::Left),
-            ]))
-        });
-    } else {
+                TableCell::new_with_alignment("Actor ID", 1, Alignment::Left),
+                TableCell::new_with_alignment("Name", 1, Alignment::Left),
+                TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
+            ]));
+            inv.actors.iter().for_each(|a| {
+                let a = a.clone();
+                table.add_row(Row::new(vec![
+                    TableCell::new_with_alignment(a.id, 1, Alignment::Left),
+                    TableCell::new_with_alignment(format_optional(a.name), 1, Alignment::Left),
+                    TableCell::new_with_alignment(format_optional(a.image_ref), 2, Alignment::Left),
+                ]))
+            });
+        } else {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "No actors found",
+                4,
+                Alignment::Left,
+            )]));
+        }
         table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "No labels present",
-            4,
-            Alignment::Center,
-        )]));
-    }
-
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        "",
-        4,
-        Alignment::Center,
-    )]));
-    if !inv.actors.is_empty() {
-        table.add_row(Row::new(vec![
-            TableCell::new_with_alignment("Actor ID", 1, Alignment::Left),
-            TableCell::new_with_alignment("Name", 1, Alignment::Left),
-            TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
-        ]));
-        inv.actors.iter().for_each(|a| {
-            let a = a.clone();
-            table.add_row(Row::new(vec![
-                TableCell::new_with_alignment(a.id, 1, Alignment::Left),
-                TableCell::new_with_alignment(format_optional(a.name), 1, Alignment::Left),
-                TableCell::new_with_alignment(format_optional(a.image_ref), 2, Alignment::Left),
-            ]))
-        });
-    } else {
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "No actors found",
+            "",
             4,
             Alignment::Left,
         )]));
-    }
-    table.add_row(Row::new(vec![TableCell::new_with_alignment(
-        "",
-        4,
-        Alignment::Left,
-    )]));
-    if !inv.providers.is_empty() {
-        table.add_row(Row::new(vec![
-            TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),
-            TableCell::new_with_alignment("Name", 1, Alignment::Left),
-            TableCell::new_with_alignment("Link Name", 1, Alignment::Left),
-            TableCell::new_with_alignment("Image Reference", 1, Alignment::Left),
-        ]));
-        inv.providers.iter().for_each(|p| {
-            let p = p.clone();
+        if !inv.providers.is_empty() {
             table.add_row(Row::new(vec![
-                TableCell::new_with_alignment(p.id, 1, Alignment::Left),
-                TableCell::new_with_alignment(format_optional(p.name), 1, Alignment::Left),
-                TableCell::new_with_alignment(p.link_name, 1, Alignment::Left),
-                TableCell::new_with_alignment(format_optional(p.image_ref), 1, Alignment::Left),
-            ]))
-        });
-    } else {
+                TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),
+                TableCell::new_with_alignment("Name", 1, Alignment::Left),
+                TableCell::new_with_alignment("Link Name", 1, Alignment::Left),
+                TableCell::new_with_alignment("Image Reference", 1, Alignment::Left),
+            ]));
+            inv.providers.iter().for_each(|p| {
+                let p = p.clone();
+                table.add_row(Row::new(vec![
+                    TableCell::new_with_alignment(p.id, 1, Alignment::Left),
+                    TableCell::new_with_alignment(format_optional(p.name), 1, Alignment::Left),
+                    TableCell::new_with_alignment(p.link_name, 1, Alignment::Left),
+                    TableCell::new_with_alignment(format_optional(p.image_ref), 1, Alignment::Left),
+                ]))
+            });
+        } else {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                "No providers found",
+                4,
+                Alignment::Left,
+            )]));
+        }
         table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "No providers found",
+            "",
             4,
             Alignment::Left,
         )]));
-    }
+    });
 
     table.render()
 }

--- a/tests/integration_get.rs
+++ b/tests/integration_get.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use serial_test::serial;
 use tokio::process::Command;
 use wash_lib::cli::output::{
-    GetClaimsCommandOutput, GetHostInventoryCommandOutput, GetHostsCommandOutput,
+    GetClaimsCommandOutput, GetHostInventoriesCommandOutput, GetHostsCommandOutput,
     LinkQueryCommandOutput,
 };
 
@@ -97,40 +97,39 @@ async fn integration_get_host_inventory_serial() -> Result<()> {
         );
     }
 
-    let cmd_output: GetHostInventoryCommandOutput = serde_json::from_slice(&output.stdout)?;
+    let cmd_output: GetHostInventoriesCommandOutput = serde_json::from_slice(&output.stdout)?;
     assert!(cmd_output.success, "command returned success");
 
     assert!(
-        cmd_output.inventory.actors.is_empty(),
+        cmd_output.inventories.len() == 1,
+        "one host inventory returned"
+    );
+    let inventory = &cmd_output.inventories[0];
+    assert!(
+        inventory.actors.is_empty(),
         "host inventory contains no actors "
     );
     assert_eq!(
-        cmd_output.inventory.host_id, wash_instance.host_id,
+        inventory.host_id, wash_instance.host_id,
         "host ID matches request"
     );
     assert!(
-        !cmd_output.inventory.labels.is_empty(),
+        !inventory.labels.is_empty(),
         "at least one label on the host"
     );
     assert!(
-        cmd_output.inventory.labels.contains_key("hostcore.os"),
+        inventory.labels.contains_key("hostcore.os"),
         "hostcore.os label is present"
     );
     assert!(
-        cmd_output.inventory.labels.contains_key("hostcore.arch"),
+        inventory.labels.contains_key("hostcore.arch"),
         "hostcore.arch label is present"
     );
     assert!(
-        cmd_output
-            .inventory
-            .labels
-            .contains_key("hostcore.osfamily"),
+        inventory.labels.contains_key("hostcore.osfamily"),
         "hostcore.osfmaily label is present"
     );
-    assert!(
-        cmd_output.inventory.providers.is_empty(),
-        "host has no providers"
-    );
+    assert!(inventory.providers.is_empty(), "host has no providers");
 
     Ok(())
 }


### PR DESCRIPTION
## Feature or Problem
This converts the host inventory command to a host inventories (hosts inventory? 🧐 ) command, i.e.

```
wash get inventory
```
and
```
wash get inventories
```

will both return inventories for all hosts.

This preserves existing behavior where if a host ID is specified, the inventory for only that host is returned

## Related Issues
Resolves https://github.com/wasmCloud/wash/issues/872

## Release Information
Next

## Consumer Impact
@jordan-rash is slightly happier

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e:
```
wash get inventories


  Host Inventory (NACNKE4ZQNNUXR5DVMBNIOTF5LX7M632KMMIJ5A75TWQZFAHHUL6QUW4)

  hostcore.arch                         aarch64
  hostcore.os                           macos
  hostcore.osfamily                     unix

  No actors found

  No providers found

  Host Inventory (NAZ346FBNLT3J2JUR4C6FYVGBQKHVEU5RJ67HNHVXN4OFSQG37IESEPQ)

  hostcore.os                           macos
  hostcore.osfamily                     unix
  hostcore.arch                         aarch64

  No actors found

  No providers found
```

```
wash get inventory -o json

{
  "inventories": [
    {
      "actors": [],
      "host_id": "NACNKE4ZQNNUXR5DVMBNIOTF5LX7M632KMMIJ5A75TWQZFAHHUL6QUW4",
      "labels": {
        "hostcore.arch": "aarch64",
        "hostcore.os": "macos",
        "hostcore.osfamily": "unix"
      },
      "providers": []
    },
    {
      "actors": [],
      "host_id": "NAZ346FBNLT3J2JUR4C6FYVGBQKHVEU5RJ67HNHVXN4OFSQG37IESEPQ",
      "labels": {
        "hostcore.arch": "aarch64",
        "hostcore.os": "macos",
        "hostcore.osfamily": "unix"
      },
      "providers": []
    }
  ],
  "success": true
}
```
