### PR TITLE
feat: add friendly name to host table output

### DIFF
--- a/src/ctl/output.rs
+++ b/src/ctl/output.rs
@@ -84,11 +84,13 @@ pub(crate) fn hosts_table(hosts: Vec<Host>) -> String {
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Host ID", 1, Alignment::Left),
         TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Left),
+        TableCell::new_with_alignment("Friendly name", 1, Alignment::Left),
     ]));
     hosts.iter().for_each(|h| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(h.id.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(format!("{}", h.uptime_seconds), 1, Alignment::Left),
+            TableCell::new_with_alignment(h.friendly_name.clone(), 1, Alignment::Left),
         ]))
     });
 


### PR DESCRIPTION
Leaving in draft until https://github.com/wasmCloud/wash/pull/862 lands, which updates the control interface client version

## Feature or Problem
This adds hosts' friendly names to the output of `wash get hosts`:

```
wash get hosts


  Host ID                                                    Uptime (seconds)   Friendly name
  NAZ346FBNLT3J2JUR4C6FYVGBQKHVEU5RJ67HNHVXN4OFSQG37IESEPQ   812                fragrant-sun-2047
  NACNKE4ZQNNUXR5DVMBNIOTF5LX7M632KMMIJ5A75TWQZFAHHUL6QUW4   2253               red-ladybug-1700
```

## Related Issues
Resolves https://github.com/wasmCloud/wash/issues/613

## Release Information
Next

## Consumer Impact
This makes @jordan-rash a little more happy :)

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested manually (see output above)