### PR TITLE
chore: bump wash-lib and wash-cli for wit-parser fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "wasmcloud"]
 description = "wasmcloud Shell (wash) libraries"


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR bumps wash-lib and wash-cli for patch release to resolve breaking dependency resolution.

## Related Issues
#897 

## Release Information
wash-lib 0.12.1
wash-cli 0.21.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
it builds
