### PR TITLE
fix: `wash build` key directory setting behavior

### DIFF
--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -15,7 +15,7 @@ use wit_component::{ComponentEncoder, StringEncoding};
 
 use crate::{
     cli::{
-        claims::{sign_file, ActorMetadata, SignCommand},
+        claims::{sign_file, ActorMetadata, GenerateCommon, SignCommand},
         OutputKind,
     },
     parser::{
@@ -181,6 +181,11 @@ fn sign_actor_wasm(
             call_alias: actor_config.call_alias.clone(),
             issuer: signing_config.issuer,
             subject: signing_config.subject,
+            common: GenerateCommon {
+                disable_keygen: signing_config.disable_keygen,
+                directory: signing_config.keys_directory,
+                ..Default::default()
+            },
             tags,
             ..Default::default()
         },

--- a/src/build.rs
+++ b/src/build.rs
@@ -53,12 +53,15 @@ pub(crate) async fn handle_command(command: BuildCommand) -> Result<CommandOutpu
     let config = get_config(command.config_path, Some(true))?;
 
     match config.project_type {
-        TypeConfig::Actor(ref _actor_config) => {
+        TypeConfig::Actor(ref actor_config) => {
             let sign_config = if command.build_only {
                 None
             } else {
                 Some(SignConfig {
-                    keys_directory: command.keys_directory,
+                    keys_directory: command
+                        .keys_directory
+                        .clone()
+                        .or(Some(actor_config.key_directory.to_path_buf())),
                     issuer: command.issuer,
                     subject: command.subject,
                     disable_keygen: command.disable_keygen,
@@ -69,7 +72,7 @@ pub(crate) async fn handle_command(command: BuildCommand) -> Result<CommandOutpu
 
             let json_output = HashMap::from([
                 ("actor_path".to_string(), json!(actor_path)),
-                ("signed".to_string(), json!(command.build_only)),
+                ("signed".to_string(), json!(!command.build_only)),
             ]);
             Ok(CommandOutput::new(
                 if command.build_only {

--- a/tests/integration_build.rs
+++ b/tests/integration_build.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::fs::File;
+use std::{env, fs::File};
 use tokio::process::Command;
 
 mod common;
@@ -51,6 +51,212 @@ async fn integration_build_rust_actor_signed() -> Result<()> {
     assert!(unsigned_file.exists(), "unsigned file not found!");
     let signed_file = project_dir.join("build/hello_s.wasm");
     assert!(signed_file.exists(), "signed file not found!");
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_build_rust_actor_signed_with_signing_keys_directory_configuration(
+) -> Result<()> {
+    let test_setup = init(
+        /* actor_name= */ "hello", /* template_name= */ "hello",
+    )
+    .await?;
+    let project_dir = test_setup.project_dir;
+    env::set_current_dir(&project_dir)?;
+    env::set_var("RUST_LOG", "debug");
+
+    // base case: no keys directory configured
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build"])
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains("hello/keys/hello_module.nk"));
+
+    // case: keys directory configured via cli arg --keys-directory
+    let key_directory = project_dir.join("batmankeys").to_string_lossy().to_string();
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build", "--keys-directory", &key_directory])
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", key_directory).as_str()));
+
+    // case: keys directory configured via cli arg --keys-directory and --disable-keygen=true
+    let key_directory = project_dir
+        .join("spidermankeys")
+        .to_string_lossy()
+        .to_string();
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "build",
+            "--keys-directory",
+            &key_directory,
+            "--disable-keygen",
+        ])
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(!output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains("No keypair found"));
+    assert!(output.contains("hello/spidermankeys"));
+
+    // case: keys directory configured via env var WASH_KEYS
+    let key_directory = project_dir.join("flashkeys").to_string_lossy().to_string();
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build"])
+        .env("WASH_KEYS", &key_directory)
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", key_directory).as_str()));
+
+    // case: keys directory configured via wasmcloud.toml. The config that is written to file does affect all the remaining test cases.
+    let key_directory = project_dir
+        .join("haljordankeys")
+        .to_string_lossy()
+        .to_string();
+
+    tokio::fs::write(
+        project_dir.join("wasmcloud.toml"),
+        r#"
+    name = "Hello World"
+    language = "rust"
+    type = "actor"
+    
+    [actor]
+    claims = ["wasmcloud:httpserver"]
+    key_directory = "./haljordankeys"
+    "#,
+    )
+    .await
+    .context("failed to update wasmcloud.toml file content for test case")?;
+
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build"])
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", key_directory).as_str()));
+
+    // case when keys directory is configured via cli arg --keys-directory and wasmcloud.toml. cli arg should take precedence
+    let key_directory = project_dir
+        .join("wonderwomankeys")
+        .to_string_lossy()
+        .to_string();
+
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build", "--keys-directory", &key_directory])
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", key_directory).as_str()));
+
+    // case when keys directory is configured via env var $WASH_KEYS, cli arg --keys-directory and wasmcloud.toml. cli arg should take precedence
+    let env_key_directory = project_dir.join("flashkeys").to_string_lossy().to_string();
+
+    let key_directory = project_dir
+        .join("aquamankeys")
+        .to_string_lossy()
+        .to_string();
+
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build", "--keys-directory", &key_directory])
+        .env("WASH_KEYS", &env_key_directory)
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", key_directory).as_str()));
+
+    // case when keys directory is configured via env var $WASH_KEYS and wasmcloud.toml. env var should take precedence
+    let env_key_directory = project_dir.join("orionkeys").to_string_lossy().to_string();
+    let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args(["build"])
+        .env("WASH_KEYS", &env_key_directory)
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Failed to build project");
+
+    let output = cmd
+        .wait_with_output()
+        .await
+        .context("test command failed to run and complete")?;
+
+    assert!(output.status.success());
+    let output =
+        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
+    assert!(output.contains(format!("{}/hello_module.nk", env_key_directory).as_str()));
+
     Ok(())
 }
 


### PR DESCRIPTION
## Feature or Problem
Despite setting `key_directory` field in the `[actor]` section of `wasmcloud.toml`, `wash build` will still either reuse or generate a new key in `~/.wash/keys`. It appears to the end user that `wash build` command is ignoring the provided configuration.


## Related Issues
#620 

## Release Information
v0.21.1

## Consumer Impact
improved correctness of the `wash` cli; behaves as expected.

## Testing
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Acceptance or Integration
added test cases to ensure key directory configuration is respected and adheres to common configuration precedence rule `config file field < env var < cli arg`

### Manual Verification
ran `wash build` on `hello` actor template repo with different key directory configuration.
