### PR TITLE
Chore/drop prov rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.21.1"
+version = "0.22.0"
 authors = ["wasmCloud Team"]
 categories = ["wasm", "command-line-utilities"]
 description = "wasmcloud Shell (wash) CLI tool"

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -435,7 +435,7 @@ mod test {
         let mut host_env = HashMap::new();
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
+        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string()); // TODO: remove these after wasmCloud v0.80.0 is released, dropping support for prov_rpc connections
         let mut host_child = start_wasmcloud_host(
             &wasmcloud_binary,
             stdout_log_file,
@@ -489,7 +489,7 @@ mod test {
         let mut host_env = HashMap::new();
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string());
+        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string()); // TODO: remove these after wasmCloud v0.80.0 is released, dropping support for prov_rpc connections
         let child_res = start_wasmcloud_host(
             &wasmcloud_binary,
             std::process::Stdio::null(),

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -301,7 +301,6 @@ mod test {
     use tokio::time::Duration;
 
     const WASMCLOUD_VERSION: &str = "v0.79.0-rc3";
-    const LOCALHOST: &str = "127.0.0.1";
 
     /// Returns an open port on the interface, searching within the range endpoints, inclusive
     async fn find_open_port() -> Result<u16> {

--- a/src/up/config.rs
+++ b/src/up/config.rs
@@ -37,14 +37,8 @@ pub(crate) const WASMCLOUD_CTL_JWT: &str = "WASMCLOUD_CTL_JWT";
 pub(crate) const WASMCLOUD_CTL_CREDSFILE: &str = "WASMCLOUD_CTL_CREDSFILE";
 pub(crate) const WASMCLOUD_CTL_TLS: &str = "WASMCLOUD_CTL_TLS";
 // NATS Provider RPC connection configuration
-pub(crate) const WASMCLOUD_PROV_RPC_HOST: &str = "WASMCLOUD_PROV_RPC_HOST";
-pub(crate) const WASMCLOUD_PROV_RPC_PORT: &str = "WASMCLOUD_PROV_RPC_PORT";
 pub(crate) const WASMCLOUD_PROV_SHUTDOWN_DELAY_MS: &str = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS";
 pub(crate) const DEFAULT_PROV_SHUTDOWN_DELAY_MS: &str = "300";
-pub(crate) const WASMCLOUD_PROV_RPC_SEED: &str = "WASMCLOUD_PROV_RPC_SEED";
-pub(crate) const WASMCLOUD_PROV_RPC_JWT: &str = "WASMCLOUD_PROV_RPC_JWT";
-pub(crate) const WASMCLOUD_PROV_RPC_CREDSFILE: &str = "WASMCLOUD_PROV_RPC_CREDSFILE";
-pub(crate) const WASMCLOUD_PROV_RPC_TLS: &str = "WASMCLOUD_PROV_RPC_TLS";
 pub(crate) const WASMCLOUD_OCI_ALLOWED_INSECURE: &str = "WASMCLOUD_OCI_ALLOWED_INSECURE";
 pub(crate) const WASMCLOUD_OCI_ALLOW_LATEST: &str = "WASMCLOUD_OCI_ALLOW_LATEST";
 // Extra configuration (logs, IPV6, config service)
@@ -164,36 +158,6 @@ pub(crate) async fn configure_host_env(
         host_config.insert(WASMCLOUD_CTL_TLS.to_string(), "1".to_string());
     }
 
-    // NATS Provider RPC connection configuration
-    if let Some(host) = wasmcloud_opts.prov_rpc_host {
-        host_config.insert(WASMCLOUD_PROV_RPC_HOST.to_string(), host);
-    } else {
-        host_config.insert(WASMCLOUD_PROV_RPC_HOST.to_string(), nats_opts.nats_host);
-    }
-    if let Some(port) = wasmcloud_opts.prov_rpc_port {
-        host_config.insert(WASMCLOUD_PROV_RPC_PORT.to_string(), port.to_string());
-    } else {
-        host_config.insert(
-            WASMCLOUD_PROV_RPC_PORT.to_string(),
-            nats_opts.nats_port.to_string(),
-        );
-    }
-    if let Some(path) = wasmcloud_opts.prov_rpc_credsfile {
-        if let Ok((jwt, seed)) = parse_credsfile(path).await {
-            host_config.insert(WASMCLOUD_PROV_RPC_JWT.to_string(), jwt);
-            host_config.insert(WASMCLOUD_PROV_RPC_SEED.to_string(), seed);
-        };
-    } else {
-        if let Some(seed) = wasmcloud_opts.prov_rpc_seed {
-            host_config.insert(WASMCLOUD_PROV_RPC_SEED.to_string(), seed);
-        }
-        if let Some(jwt) = wasmcloud_opts.prov_rpc_jwt {
-            host_config.insert(WASMCLOUD_PROV_RPC_JWT.to_string(), jwt);
-        }
-    }
-    if wasmcloud_opts.prov_rpc_tls {
-        host_config.insert(WASMCLOUD_PROV_RPC_TLS.to_string(), "1".to_string());
-    }
     host_config.insert(
         WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
         wasmcloud_opts.provider_delay.to_string(),

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -166,30 +166,6 @@ pub(crate) struct WasmcloudOpts {
     #[clap(long = "rpc-credsfile", env = WASMCLOUD_RPC_CREDSFILE)]
     pub(crate) rpc_credsfile: Option<PathBuf>,
 
-    /// An IP address or DNS name to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-host if not supplied
-    #[clap(long = "prov-rpc-host", env = WASMCLOUD_PROV_RPC_HOST)]
-    pub(crate) prov_rpc_host: Option<String>,
-
-    /// A port to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-port if not supplied
-    #[clap(long = "prov-rpc-port", env = WASMCLOUD_PROV_RPC_PORT)]
-    pub(crate) prov_rpc_port: Option<u16>,
-
-    /// A seed nkey to use to authenticate to NATS for Provider RPC messages
-    #[clap(long = "prov-rpc-seed", env = WASMCLOUD_PROV_RPC_SEED, requires = "prov_rpc_jwt")]
-    pub(crate) prov_rpc_seed: Option<String>,
-
-    /// Optional flag to enable host communication with a NATS server over TLS for Provider RPC messages
-    #[clap(long = "prov-rpc-tls", env = WASMCLOUD_PROV_RPC_TLS)]
-    pub(crate) prov_rpc_tls: bool,
-
-    /// A user JWT to use to authenticate to NATS for Provider RPC messages
-    #[clap(long = "prov-rpc-jwt", env = WASMCLOUD_PROV_RPC_JWT, requires = "prov_rpc_seed")]
-    pub(crate) prov_rpc_jwt: Option<String>,
-
-    /// Convenience flag for Provider RPC authentication, internally this parses the JWT and seed from the credsfile
-    #[clap(long = "prov-rpc-credsfile", env = WASMCLOUD_PROV_RPC_CREDSFILE)]
-    pub(crate) prov_rpc_credsfile: Option<PathBuf>,
-
     /// An IP address or DNS name to use to connect to NATS for Control Interface (CTL) messages, defaults to the value supplied to --nats-host if not supplied
     #[clap(long = "ctl-host", env = WASMCLOUD_CTL_HOST)]
     pub(crate) ctl_host: Option<String>,
@@ -354,16 +330,6 @@ pub(crate) async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result
         rpc_port: Some(
             cmd.wasmcloud_opts
                 .rpc_port
-                .unwrap_or(cmd.nats_opts.nats_port),
-        ),
-        prov_rpc_host: Some(
-            cmd.wasmcloud_opts
-                .prov_rpc_host
-                .unwrap_or_else(|| cmd.nats_opts.nats_host.to_owned()),
-        ),
-        prov_rpc_port: Some(
-            cmd.wasmcloud_opts
-                .prov_rpc_port
                 .unwrap_or(cmd.nats_opts.nats_port),
         ),
         ..cmd.wasmcloud_opts
@@ -760,17 +726,6 @@ mod tests {
             "tls://remote.global",
             "--nats-version",
             "v2.8.4",
-            "--prov-rpc-credsfile",
-            TESTDIR,
-            "--prov-rpc-host",
-            "127.0.0.2",
-            "--prov-rpc-jwt",
-            "eyyjWT",
-            "--prov-rpc-port",
-            "4232",
-            "--prov-rpc-seed",
-            "SUALIKDKMIUAKRT5536EXKC3CX73TJD3CFXZMJSHIKSP3LTYIIUQGCUVGA",
-            "--prov-rpc-tls",
             "--provider-delay",
             "500",
             "--rpc-credsfile",
@@ -842,21 +797,6 @@ mod tests {
             Some("SUALIKDKMIUAKRT5536EXKC3CX73TJD3CFXZMJSHIKSP3LTYIIUQGCUVGA".to_string())
         );
         assert!(up_all_flags.wasmcloud_opts.rpc_tls);
-        assert!(up_all_flags.wasmcloud_opts.prov_rpc_credsfile.is_some());
-        assert_eq!(
-            up_all_flags.wasmcloud_opts.prov_rpc_host,
-            Some("127.0.0.2".to_string())
-        );
-        assert_eq!(
-            up_all_flags.wasmcloud_opts.prov_rpc_jwt,
-            Some("eyyjWT".to_string())
-        );
-        assert_eq!(up_all_flags.wasmcloud_opts.prov_rpc_port, Some(4232));
-        assert_eq!(
-            up_all_flags.wasmcloud_opts.prov_rpc_seed,
-            Some("SUALIKDKMIUAKRT5536EXKC3CX73TJD3CFXZMJSHIKSP3LTYIIUQGCUVGA".to_string())
-        );
-        assert!(up_all_flags.wasmcloud_opts.prov_rpc_tls);
         assert!(up_all_flags.wasmcloud_opts.enable_ipv6);
         assert!(up_all_flags.wasmcloud_opts.enable_structured_logging);
         assert_eq!(


### PR DESCRIPTION
## Feature or Problem
The host is dropping support for a separate `prov_rpc` NATS connection. See https://github.com/wasmCloud/wasmCloud/pull/774 for motivation, but before the host can drop support, wash should remove these options

## Related Issues
https://github.com/wasmCloud/wasmCloud/pull/774

## Release Information
v0.22.0, since this is technically a breaking change

## Consumer Impact


## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
