### PR TITLE
feat: mark components built with wash as experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "wasmbus-rpc 0.15.0",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 0.30.0",
+ "wasmparser 0.115.0",
  "wat",
  "weld-codegen",
  "wit-component",
@@ -4968,6 +4969,16 @@ name = "wasmparser"
 version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef211410dcb08b037eb6d197b2398f8ef9d635c5dc5598d0dfda32094315ea3"
+dependencies = [
+ "indexmap 2.0.2",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
  "indexmap 2.0.2",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,12 +152,13 @@ url = { version = "2.4.1", features = ["serde"] }
 wadm = "0.7.1"
 walkdir = "2.4"
 wascap = "0.11.2"
-wasm-encoder = "0.33.2"
-wasmcloud-component-adapters = { version = "0.2.4", default-features = false }
 wash-lib = { version = "0.12", path = "./crates/wash-lib" }
+wasm-encoder = "0.33.2"
 wasmbus-rpc = "0.15.0"
+wasmcloud-component-adapters = { version = "0.2.4", default-features = false }
 wasmcloud-control-interface = "0.30"
 wasmcloud-test-util = "0.10.0"
+wasmparser = "0.115.0"
 wat = "1.0.76"
 weld-codegen = "0.7.0"
 which = "4.4.0"

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -97,3 +97,4 @@ dirs = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+wasmparser = { workspace = true }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

As the component model and WASI are still maturing, the components-first codebases built with `wash` should reflect the experimental nature of support to related tooling.

This commit marks both components as experimental at two levels -- a custom section in the Wasm metadata (as a custom section) and as a tag on the signed wasmCloud actor that is produced.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
