### PR TITLE
feat: support specifying tags in actor config for use when signing

### DIFF
--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -154,12 +154,10 @@ fn sign_actor_wasm(
 ) -> Result<PathBuf> {
     // If we're building for WASI preview1 or preview2, we're targeting components-first
     // functionality, and the signed module should be marked as experimental
-    let tags: Vec<String> =
-        if let WasmTarget::WasiPreview1 | WasmTarget::WasiPreview2 = &actor_config.wasm_target {
-            Vec::from([WASMCLOUD_WASM_TAG_EXPERIMENTAL.into()])
-        } else {
-            Vec::new()
-        };
+    let mut tags = actor_config.tags.clone().unwrap_or_default();
+    if let WasmTarget::WasiPreview1 | WasmTarget::WasiPreview2 = &actor_config.wasm_target {
+        tags.insert(WASMCLOUD_WASM_TAG_EXPERIMENTAL.into());
+    };
 
     let source = actor_wasm_path
         .as_ref()
@@ -186,7 +184,7 @@ fn sign_actor_wasm(
                 directory: signing_config.keys_directory,
                 ..Default::default()
             },
-            tags,
+            tags: tags.into_iter().collect(),
             ..Default::default()
         },
     };
@@ -472,6 +470,7 @@ fn build_interface(
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashSet,
         fs,
         path::{Path, PathBuf},
     };
@@ -547,8 +546,8 @@ world test-world {
         Ok(())
     }
 
-    /// Ensure that components which get signed contain the right experimental tags
-    /// in claims when preview1 or preview2 targets are signed
+    /// Ensure that components which get signed contain any tags specified
+    /// *and* experimental tag in claims when preview1 or preview2 targets are signed
     #[test]
     fn sign_actor_component_includes_experimental() -> Result<()> {
         // Build project path, including WIT dir
@@ -571,6 +570,7 @@ world test-world {
                 &ActorConfig {
                     wasm_target: wasm_target.clone(),
                     wit_world: Some("test".into()),
+                    tags: Some(HashSet::from(["test-tag".into()])),
                     ..ActorConfig::default()
                 },
                 SignConfig::default(),
@@ -584,25 +584,23 @@ world test-world {
             .context("failed to extract claims")?;
 
             // Check wasm targets
+            let tags = claims
+                .metadata
+                .context("failed to get claim metadata")?
+                .tags
+                .context("missing tags")?;
+            assert!(
+                tags.contains(&String::from("test-tag")),
+                "test-tag should be present"
+            );
+
             match wasm_target {
                 WasmTarget::CoreModule => assert!(
-                    claims
-                        .metadata
-                        .context("failed to get claim metadata")?
-                        .tags
-                        .context("failed to get tags")?
-                        .iter()
-                        .all(|t| t != WASMCLOUD_WASM_TAG_EXPERIMENTAL),
-                    "experimental tag should not be present on core modules",
+                    !tags.contains(&String::from(WASMCLOUD_WASM_TAG_EXPERIMENTAL)),
+                    "experimental tag should not be present on core modules"
                 ),
                 WasmTarget::WasiPreview1 | WasmTarget::WasiPreview2 => assert!(
-                    claims
-                        .metadata
-                        .context("failed to get claim metadata")?
-                        .tags
-                        .context("failed to get tags")?
-                        .iter()
-                        .any(|t| t == WASMCLOUD_WASM_TAG_EXPERIMENTAL),
+                    tags.contains(&String::from(WASMCLOUD_WASM_TAG_EXPERIMENTAL)),
                     "experimental tag should be present on preview1/preview2 components"
                 ),
             }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -1,7 +1,7 @@
 //! Parse wasmcloud.toml files which specify key information for building and signing
 //! WebAssembly modules and native capability provider binaries
 
-use std::{fmt::Display, fs, path::PathBuf};
+use std::{collections::HashSet, fmt::Display, fs, path::PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_toml::{Manifest, Product};
@@ -57,6 +57,8 @@ pub struct ActorConfig {
     pub wasi_preview2_adapter_path: Option<PathBuf>,
     /// The WIT world that is implemented by the component
     pub wit_world: Option<String>,
+    /// Tags that should be applied during the actor signing process
+    pub tags: Option<HashSet<String>>,
 }
 
 impl RustConfig {
@@ -90,6 +92,8 @@ struct RawActorConfig {
     pub call_alias: Option<String>,
     /// The WIT world that is implemented by the component
     pub wit_world: Option<String>,
+    /// Tags that should be applied during the actor signing process
+    pub tags: Option<HashSet<String>>,
 }
 
 impl TryFrom<RawActorConfig> for ActorConfig {
@@ -111,9 +115,11 @@ impl TryFrom<RawActorConfig> for ActorConfig {
             wasi_preview2_adapter_path: raw_config.wasi_preview2_adapter_path,
             call_alias: raw_config.call_alias,
             wit_world: raw_config.wit_world,
+            tags: raw_config.tags,
         })
     }
 }
+
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct ProviderConfig {
     /// The capability ID of the provider.
@@ -121,6 +127,7 @@ pub struct ProviderConfig {
     /// The vendor name of the provider.
     pub vendor: String,
 }
+
 #[derive(Deserialize, Debug, PartialEq)]
 struct RawProviderConfig {
     /// The capability ID of the provider.

--- a/crates/wash-lib/tests/parser/files/tags.toml
+++ b/crates/wash-lib/tests/parser/files/tags.toml
@@ -1,0 +1,14 @@
+language = "rust"
+type = "actor"
+name = "testactor"
+version = "0.1.0"
+
+[actor]
+claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-wasi-preview2"
+wit_world = "test-world"
+tags = [
+     "test",
+     "test",
+     "wasmcloud.com/experimental",
+]

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{collections::HashSet, fs, path::PathBuf};
 
 use claims::{assert_err, assert_ok};
 use semver::Version;
@@ -36,7 +36,7 @@ fn rust_actor() {
             call_alias: Some("testactor".to_string()),
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::CoreModule,
-            wit_world: None,
+            ..ActorConfig::default()
         })
     );
 
@@ -82,7 +82,7 @@ fn tinygo_actor_module() {
             call_alias: Some("testactor".to_string()),
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::CoreModule,
-            wit_world: None,
+            ..ActorConfig::default()
         })
     );
 
@@ -121,7 +121,7 @@ fn tinygo_actor_component() {
             call_alias: Some("testactor".to_string()),
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::WasiPreview2,
-            wit_world: None,
+            ..ActorConfig::default()
         })
     );
 }
@@ -293,7 +293,7 @@ fn minimal_rust_actor() {
             call_alias: None,
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::CoreModule,
-            wit_world: None,
+            ..ActorConfig::default()
         })
     );
 
@@ -340,7 +340,7 @@ fn cargo_toml_actor() {
             call_alias: None,
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::CoreModule,
-            wit_world: None,
+            ..ActorConfig::default()
         })
     );
 
@@ -420,5 +420,21 @@ fn minimal_rust_actor_core_module() {
             wasm_target: WasmTarget::CoreModule,
             ..
         })
+    ));
+}
+
+/// Tags are properly handled (duplicates, pre-existing experimental tag)
+/// see: https://github.com/wasmCloud/wash/pull/951
+#[test]
+fn tags() {
+    let result = get_config(Some(PathBuf::from("./tests/parser/files/tags.toml")), None);
+
+    let config = assert_ok!(result);
+    assert!(matches!(
+        config.project_type,
+        TypeConfig::Actor(ActorConfig {
+            tags,
+            ..
+        }) if tags == Some(HashSet::from(["test".into(), "wasmcloud.com/experimental".into()])),
     ));
 }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

The signing process enabled by the wasmCloud ecosystem can confer tags on to generated artifacts. This helps in adding metadata to actors and other artifacts produced by wash.

This commit adds the ability to specify tags in `wasmcloud.toml` to `wash`, so users can more easily tag generated & signed actors

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
