### PR TITLE
chore: remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,17 @@
 version: 2
 updates:
 - package-ecosystem: "cargo"
+  open-pull-requests-limit: 0
   directory: "/"
   schedule:
     interval: "daily"
 - package-ecosystem: "github-actions"
+  open-pull-requests-limit: 0
   directory: "/"
   schedule:
     interval: "daily"
 - package-ecosystem: npm
+  open-pull-requests-limit: 0
   directory: "/washboard"
   schedule:
     interval: "daily"


### PR DESCRIPTION
This disables dependabot updates while we're in the process of [migrating this repo to wasmCloud/wasmCloud](https://github.com/wasmCloud/wasmCloud/pull/807)