### PR TITLE
Add commonly mistaken aliases

### DIFF
--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -166,6 +166,7 @@ pub struct CliConnectionOpts {
     /// JS domain for wasmcloud control interface. Defaults to None
     #[clap(
         long = "js-domain",
+        alias = "domain",
         env = "WASMCLOUD_JS_DOMAIN",
         hide_env_values = true
     )]

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -29,7 +29,7 @@ pub(crate) enum CtlCliCommand {
     Get(CtlGetCommand),
 
     /// Link an actor and a provider
-    #[clap(name = "link", subcommand)]
+    #[clap(name = "link", alias = "links", subcommand)]
     Link(LinkCommand),
 
     /// Start an actor or a provider

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,13 +191,13 @@ enum CliCommand {
     #[clap(name = "inspect")]
     Inspect(InspectCliCommand),
     /// Utilities for generating and managing keys
-    #[clap(name = "keys", subcommand)]
+    #[clap(name = "keys", alias = "key", subcommand)]
     Keys(KeysCliCommand),
     /// Perform lint checks on smithy models
     #[clap(name = "lint")]
     Lint(LintCli),
     /// Link an actor and a provider
-    #[clap(name = "link", subcommand)]
+    #[clap(name = "link", alias = "links", subcommand)]
     Link(LinkCommand),
     /// Create a new project from template
     #[clap(name = "new", subcommand)]

--- a/src/up/mod.rs
+++ b/src/up/mod.rs
@@ -210,7 +210,7 @@ pub(crate) struct WasmcloudOpts {
     #[clap(long = "allowed-insecure", env = WASMCLOUD_OCI_ALLOWED_INSECURE)]
     pub(crate) allowed_insecure: Option<Vec<String>>,
 
-    /// Jetstream domain name, configures a host to properly connect to a NATS supercluster, defaults to `core`
+    /// Jetstream domain name, configures a host to properly connect to a NATS supercluster
     #[clap(long = "wasmcloud-js-domain", env = WASMCLOUD_JS_DOMAIN)]
     pub(crate) wasmcloud_js_domain: Option<String>,
 


### PR DESCRIPTION
- chore(ctl): add alias for key/keys link/links
- chore(ctl): support --domain alias

## Feature or Problem
This PR adds a couple simple aliases where users may forget to make the subcommand a plural subcommand or where existing muscle memory may kick in (e.g. going back and forth between the NATS CLI with `--domain` and wash with `--js-domain)

## Related Issues
N/A

## Release Information
next patch

## Consumer Impact
Certain Go developers will enjoy this

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
