### PR TITLE
[BUG] wash claims sign allows empty versions and revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,15 +4699,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14a94e06a3e2ed1af4e80cac712fed883142019ebe33c3899fd1b5e8550df9d"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca90ba1b5b0a70d3d49473c5579951f3bddc78d47b59256d2f9d4922b150aca"

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -180,6 +180,8 @@ fn sign_actor_wasm(
         metadata: ActorMetadata {
             name: common_config.name.clone(),
             ver: Some(common_config.version.to_string()),
+            //NOTE(Ahmed Tadde): sign_file requires a revision, using 1 as default
+            rev: Some(1),
             custom_caps: actor_config.claims.clone(),
             call_alias: actor_config.call_alias.clone(),
             issuer: signing_config.issuer,

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -588,6 +588,18 @@ pub fn sign_file(cmd: SignCommand, output_kind: OutputKind) -> Result<CommandOut
         bail!("Capability providers cannot provide multiple capabilities at once.");
     }
 
+    if cmd.metadata.rev.is_none() && cmd.metadata.ver.is_none() {
+        bail!("revision (--rev) and version (--ver) must be specified for signing.");
+    }
+
+    if cmd.metadata.rev.is_none() {
+        bail!("revision (--rev) must be specified for signing.");
+    }
+
+    if cmd.metadata.ver.is_none() {
+        bail!("version (--ver) must be specified for signing.");
+    }
+
     let signed = sign_buffer_with_claims(
         cmd.metadata.name.clone(),
         &buf,

--- a/tests/integration_claims.rs
+++ b/tests/integration_claims.rs
@@ -40,6 +40,10 @@ fn integration_claims_sign() {
             echo.to_str().unwrap(),
             "--name",
             "EchoSigned",
+            "--ver",
+            "0.1.0",
+            "--rev",
+            "1",
             "--http_server",
             "--issuer",
             ISSUER,
@@ -59,6 +63,91 @@ fn integration_claims_sign() {
             signed_wasm_path.to_str().unwrap()
         )
     );
+
+    // signing should fail when revision or/and version are not provided
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            "--ver",
+            "0.1.0",
+            // "--rev",
+            // "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("revision (--rev) must be specified for signing"));
+
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            // "--ver",
+            // "0.1.0",
+            "--rev",
+            "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("version (--ver) must be specified for signing"));
+
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            // "--ver",
+            // "0.1.0",
+            // "--rev",
+            // "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("revision (--rev) and version (--ver) must be specified for signing"));
 
     remove_dir_all(sign_dir).unwrap();
 }

--- a/tests/integration_claims.rs
+++ b/tests/integration_claims.rs
@@ -358,6 +358,10 @@ fn integration_claims_call_alias() {
             logger.to_str().unwrap(),
             "--name",
             "Logger",
+            "-v",
+            "0.1.0",
+            "-r",
+            "1",
             "-l",
             "-q",
             "--issuer",
@@ -401,7 +405,8 @@ fn integration_claims_call_alias() {
         "capabilities": ["HTTP Server", "Logging"],
         "expires": "never",
         "tags": "None",
-        "version": "None",
+        "version": "0.1.0",
+        "revision": 1,
         "call_alias": "wasmcloud/logger_onedotzero"
     });
 


### PR DESCRIPTION
## Feature or Problem
Currently, when signing an actor with `wash`, the `version (--ver)` and `revision (--rev)` args are not required. This will lead to claims that are missing some important information.

## Related Issues
wasmCloud/wasmCloud#861 

## Release Information
v0.21.1

## Consumer Impact
stricter `wash claims sign` cmd that ultimately improves the metadata output of `wash inspect`

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


### Acceptance or Integration
updated integration tests [integration_claims_sign](https://github.com/ahmedtadde/wash/blob/0939a7d4b1c8c229386baedccbaef9f3621071c6/tests/integration_claims.rs#L12), [integration_claims_call_alias](https://github.com/ahmedtadde/wash/blob/21f9f2f4d751e29e88fd8990ef9014a310ed425a/tests/integration_claims.rs#L328)